### PR TITLE
feat: add stop-loss and take-profit functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,19 @@ You can also specify a `--show-reasoning` flag to print the reasoning of each ag
 ```bash
 poetry run python src/agents.py --ticker AAPL --show-reasoning
 ```
+
 You can optionally specify the start and end dates to make decisions for a specific time period.
 
 ```bash
 poetry run python src/agents.py --ticker AAPL --start-date 2024-01-01 --end-date 2024-03-01 
 ```
+
+Risk management parameters can be configured using:
+```bash
+poetry run python src/agents.py --ticker AAPL --stop-loss 0.05 --take-profit 0.15
+```
+- `--stop-loss`: Stop loss percentage (default: 5%)
+- `--take-profit`: Take profit percentage (default: 15%)
 
 ### Running the Backtester
 


### PR DESCRIPTION
Hi! Saw some of the work on Twitter/X and found it pretty fun. Figured I wanted to contribute something so i've added a simple stop-loss and take-profit functionality to help manage risk and lock in profits automatically.

Changes:
- Added stop-loss and take-profit parameters to portfolio configuration
- Implemented automatic position exit when either threshold is hit
- Added CLI arguments to customize stop-loss (default 5%) and take-profit (default 15%) levels
- Enhanced risk management agent to monitor these thresholds

Would love to hear y'alls thoughts and if anything needs adjusting. Thanks!