### PR TITLE
fix: added condition to handle null transaction_shares from the FinancialDatasets API

### DIFF
--- a/src/agents.py
+++ b/src/agents.py
@@ -354,7 +354,9 @@ def sentiment_agent(state: AgentState):
     # Loop through the insider trades, if transaction_shares is negative, then it is a sell, which is bearish, if positive, then it is a buy, which is bullish
     signals = []
     for trade in insider_trades:
-        if trade["transaction_shares"] < 0:
+        if not trade["transaction_shares"]:
+            signals.append("neutral")
+        elif trade["transaction_shares"] < 0:
             signals.append("bearish")
         else:
             signals.append("bullish")


### PR DESCRIPTION
* [`src/agents.py`](diffhunk://#diff-f9626810656f0fce88d60f204a11125e00df081ded6cc2bff95922ea8e177b62L357-R359): Modified the `sentiment_agent` function to append "neutral" to the `signals` list when `transaction_shares` is `null`. Previously, it threw an error for the below insider trade example,
```
    {
        "ticker": "AAPL",
        "issuer": "Apple Inc",
        "name": "Arthur D Levinson",
        "title": null,
        "is_board_director": true,
        "transaction_date": null,
        "transaction_shares": null,
        "transaction_price_per_share": null,
        "transaction_value": null,
        "shares_owned_before_transaction": 56000,
        "shares_owned_after_transaction": 56000,
        "security_title": "Common Stock",
        "filing_date": "2024-11-19"
    }
```