### PR TITLE
Removed unused llm instance

### DIFF
--- a/src/agents/market_data.py
+++ b/src/agents/market_data.py
@@ -1,12 +1,7 @@
-
-from langchain_openai.chat_models import ChatOpenAI
-
 from agents.state import AgentState
 from tools.api import search_line_items, get_financial_metrics, get_insider_trades, get_market_cap, get_prices
 
 from datetime import datetime
-
-llm = ChatOpenAI(model="gpt-4o")
 
 def market_data_agent(state: AgentState):
     """Responsible for gathering and preprocessing market data"""


### PR DESCRIPTION
ChatOpenAI instance remains in-memory even if we don't use it, it's a good idea to remove to conserve memory, especially in memory-constrained environments.