### PR TITLE
fix: change arguments in backtester to be kebab case

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ poetry run python src/main.py --ticker AAPL --show-reasoning
 You can optionally specify the start and end dates to make decisions for a specific time period.
 
 ```bash
-poetry run python src/main.py --ticker AAPL --start_date 2024-01-01 --end_date 2024-03-01 
+poetry run python src/main.py --ticker AAPL --start-date 2024-01-01 --end-date 2024-03-01 
 ```
 
 ### Running the Backtester

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ poetry run python src/main.py --ticker AAPL --show-reasoning
 You can optionally specify the start and end dates to make decisions for a specific time period.
 
 ```bash
-poetry run python src/main.py --ticker AAPL --start-date 2024-01-01 --end-date 2024-03-01 
+poetry run python src/main.py --ticker AAPL --start_date 2024-01-01 --end_date 2024-03-01 
 ```
 
 ### Running the Backtester

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -133,9 +133,9 @@ if __name__ == "__main__":
     # Set up argument parser
     parser = argparse.ArgumentParser(description='Run backtesting simulation')
     parser.add_argument('--ticker', type=str, help='Stock ticker symbol (e.g., AAPL)')
-    parser.add_argument('--end_date', type=str, default=datetime.now().strftime('%Y-%m-%d'), help='End date in YYYY-MM-DD format')
-    parser.add_argument('--start_date', type=str, default=(datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d'), help='Start date in YYYY-MM-DD format')
-    parser.add_argument('--initial_capital', type=float, default=100000, help='Initial capital amount (default: 100000)')
+    parser.add_argument('--end-date', type=str, default=datetime.now().strftime('%Y-%m-%d'), help='End date in YYYY-MM-DD format')
+    parser.add_argument('--start-date', type=str, default=(datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d'), help='Start date in YYYY-MM-DD format')
+    parser.add_argument('--initial-capital', type=float, default=100000, help='Initial capital amount (default: 100000)')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
```
  --end_date END_DATE   End date in YYYY-MM-DD format
  --start_date START_DATE
                        Start date in YYYY-MM-DD format
  --initial_capital INITIAL_CAPITAL
                        Initial capital amount (default: 100000)
```
cli has underscore instead of hyphens.


EDIT:

moved backtester to kebab case instead.