### PR TITLE
Fix handling of None values in financial metrics and improve string formatting

### DIFF
--- a/src/agents/fundamentals.py
+++ b/src/agents/fundamentals.py
@@ -20,7 +20,11 @@ def fundamentals_agent(state: AgentState):
     net_margin = metrics.get("net_margin")
     operating_margin = metrics.get("operating_margin")
 
-    thresholds = [(return_on_equity, 0.15), (net_margin, 0.20), (operating_margin, 0.15)]
+    thresholds = [
+        (return_on_equity, 0.15),  # Strong ROE above 15%
+        (net_margin, 0.20),  # Healthy profit margins
+        (operating_margin, 0.15)  # Strong operating efficiency
+    ]
     profitability_score = sum(
         metric is not None and metric > threshold
         for metric, threshold in thresholds
@@ -39,13 +43,19 @@ def fundamentals_agent(state: AgentState):
     }
     
     # 2. Growth Analysis
-    growth_score = 0
-    if metrics["revenue_growth"] and metrics["revenue_growth"] > 0.10:  # 10% revenue growth
-        growth_score += 1
-    if metrics["earnings_growth"] and metrics["earnings_growth"] > 0.10:  # 10% earnings growth
-        growth_score += 1
-    if metrics["book_value_growth"] and metrics["book_value_growth"] > 0.10:  # 10% book value growth
-        growth_score += 1
+    revenue_growth = metrics.get("revenue_growth")
+    earnings_growth = metrics.get("earnings_growth")
+    book_value_growth = metrics.get("book_value_growth")
+
+    thresholds = [
+        (revenue_growth, 0.10),  # 10% revenue growth
+        (earnings_growth, 0.10),  # 10% earnings growth
+        (book_value_growth, 0.10)  # 10% book value growth
+    ]
+    growth_score = sum(
+        metric is not None and metric > threshold
+        for metric, threshold in thresholds
+    )
         
     signals.append('bullish' if growth_score >= 2 else 'bearish' if growth_score == 0 else 'neutral')
     reasoning["growth_signal"] = {
@@ -58,13 +68,18 @@ def fundamentals_agent(state: AgentState):
     }
     
     # 3. Financial Health
+    current_ratio = metrics.get("current_ratio")
+    debt_to_equity = metrics.get("debt_to_equity")
+    free_cash_flow_per_share = metrics.get("free_cash_flow_per_share")
+    earnings_per_share = metrics.get("earnings_per_share")
+
     health_score = 0
-    if metrics["current_ratio"] and metrics["current_ratio"] > 1.5:  # Strong liquidity
+    if current_ratio and current_ratio > 1.5:  # Strong liquidity
         health_score += 1
-    if metrics["debt_to_equity"] and metrics["debt_to_equity"] < 0.5:  # Conservative debt levels
+    if debt_to_equity and debt_to_equity < 0.5:  # Conservative debt levels
         health_score += 1
-    if (metrics["free_cash_flow_per_share"] and metrics["earnings_per_share"] and
-            metrics["free_cash_flow_per_share"] > metrics["earnings_per_share"] * 0.8):  # Strong FCF conversion
+    if (free_cash_flow_per_share and earnings_per_share and
+            free_cash_flow_per_share > earnings_per_share * 0.8):  # Strong FCF conversion
         health_score += 1
         
     signals.append('bullish' if health_score >= 2 else 'bearish' if health_score == 0 else 'neutral')
@@ -78,17 +93,19 @@ def fundamentals_agent(state: AgentState):
     }
     
     # 4. Price to X ratios
-    pe_ratio = metrics.get("price_to_earnings_ratio", None)
-    pb_ratio = metrics.get("price_to_book_ratio", None)
-    ps_ratio = metrics.get("price_to_sales_ratio", None)
-    
-    price_ratio_score = 0
-    if pe_ratio and pe_ratio < 25:  # Reasonable P/E ratio
-        price_ratio_score += 1
-    if pb_ratio and pb_ratio < 3:  # Reasonable P/B ratio
-        price_ratio_score += 1
-    if ps_ratio and ps_ratio < 5:  # Reasonable P/S ratio
-        price_ratio_score += 1
+    pe_ratio = metrics.get("price_to_earnings_ratio")
+    pb_ratio = metrics.get("price_to_book_ratio")
+    ps_ratio = metrics.get("price_to_sales_ratio")
+
+    thresholds = [
+        (pe_ratio, 25),  # Reasonable P/E ratio
+        (pb_ratio, 3),  # Reasonable P/B ratio
+        (ps_ratio, 5)  # Reasonable P/S ratio
+    ]
+    price_ratio_score = sum(
+        metric is not None and metric > threshold
+        for metric, threshold in thresholds
+    )
         
     signals.append('bullish' if price_ratio_score >= 2 else 'bearish' if price_ratio_score == 0 else 'neutral')
     reasoning["price_ratios_signal"] = {

--- a/src/agents/fundamentals.py
+++ b/src/agents/fundamentals.py
@@ -17,66 +17,87 @@ def fundamentals_agent(state: AgentState):
     
     # 1. Profitability Analysis
     profitability_score = 0
-    if metrics["return_on_equity"] > 0.15:  # Strong ROE above 15%
+    if metrics["return_on_equity"] and metrics["return_on_equity"] > 0.15:  # Strong ROE above 15%
         profitability_score += 1
-    if metrics["net_margin"] > 0.20:  # Healthy profit margins
+    if metrics["net_margin"] and metrics["net_margin"] > 0.20:  # Healthy profit margins
         profitability_score += 1
-    if metrics["operating_margin"] > 0.15:  # Strong operating efficiency
+    if metrics["operating_margin"] and metrics["operating_margin"] > 0.15:  # Strong operating efficiency
         profitability_score += 1
         
     signals.append('bullish' if profitability_score >= 2 else 'bearish' if profitability_score == 0 else 'neutral')
     reasoning["profitability_signal"] = {
         "signal": signals[0],
-        "details": f"ROE: {metrics['return_on_equity']:.2%}, Net Margin: {metrics['net_margin']:.2%}, Op Margin: {metrics['operating_margin']:.2%}"
+        "details": (
+            f"ROE: {metrics['return_on_equity']:.2%}" if metrics["return_on_equity"] else "ROE: N/A"
+        ) + ", " + (
+            f"Net Margin: {metrics['net_margin']:.2%}" if metrics["net_margin"] else "Net Margin: N/A"
+        ) + ", " + (
+            f"Op Margin: {metrics['operating_margin']:.2%}" if metrics["operating_margin"] else "Op Margin: N/A"
+        )
     }
     
     # 2. Growth Analysis
     growth_score = 0
-    if metrics["revenue_growth"] > 0.10:  # 10% revenue growth
+    if metrics["revenue_growth"] and metrics["revenue_growth"] > 0.10:  # 10% revenue growth
         growth_score += 1
-    if metrics["earnings_growth"] > 0.10:  # 10% earnings growth
+    if metrics["earnings_growth"] and metrics["earnings_growth"] > 0.10:  # 10% earnings growth
         growth_score += 1
-    if metrics["book_value_growth"] > 0.10:  # 10% book value growth
+    if metrics["book_value_growth"] and metrics["book_value_growth"] > 0.10:  # 10% book value growth
         growth_score += 1
         
     signals.append('bullish' if growth_score >= 2 else 'bearish' if growth_score == 0 else 'neutral')
     reasoning["growth_signal"] = {
         "signal": signals[1],
-        "details": f"Revenue Growth: {metrics['revenue_growth']:.2%}, Earnings Growth: {metrics['earnings_growth']:.2%}"
+        "details": (
+            f"Revenue Growth: {metrics['revenue_growth']:.2%}" if metrics["revenue_growth"] else "Revenue Growth: N/A"
+        ) + ", " + (
+            f"Earnings Growth: {metrics['earnings_growth']:.2%}" if metrics["earnings_growth"] else "Earnings Growth: N/A"
+        )
     }
     
     # 3. Financial Health
     health_score = 0
-    if metrics["current_ratio"] > 1.5:  # Strong liquidity
+    if metrics["current_ratio"] and metrics["current_ratio"] > 1.5:  # Strong liquidity
         health_score += 1
-    if metrics["debt_to_equity"] < 0.5:  # Conservative debt levels
+    if metrics["debt_to_equity"] and metrics["debt_to_equity"] < 0.5:  # Conservative debt levels
         health_score += 1
-    if metrics["free_cash_flow_per_share"] > metrics["earnings_per_share"] * 0.8:  # Strong FCF conversion
+    if (metrics["free_cash_flow_per_share"] and metrics["earnings_per_share"] and
+            metrics["free_cash_flow_per_share"] > metrics["earnings_per_share"] * 0.8):  # Strong FCF conversion
         health_score += 1
         
     signals.append('bullish' if health_score >= 2 else 'bearish' if health_score == 0 else 'neutral')
     reasoning["financial_health_signal"] = {
         "signal": signals[2],
-        "details": f"Current Ratio: {metrics['current_ratio']:.2f}, D/E: {metrics['debt_to_equity']:.2f}"
+        "details": (
+            f"Current Ratio: {metrics['current_ratio']:.2f}" if metrics["current_ratio"] else "Current Ratio: N/A"
+        ) + ", " + (
+            f"D/E: {metrics['debt_to_equity']:.2f}" if metrics["debt_to_equity"] else "D/E: N/A"
+        )
     }
     
     # 4. Price to X ratios
-    pe_ratio = metrics["price_to_earnings_ratio"]
-    pb_ratio = metrics["price_to_book_ratio"]
-    ps_ratio = metrics["price_to_sales_ratio"]
+    pe_ratio = metrics.get("price_to_earnings_ratio", None)
+    pb_ratio = metrics.get("price_to_book_ratio", None)
+    ps_ratio = metrics.get("price_to_sales_ratio", None)
     
     price_ratio_score = 0
-    if pe_ratio < 25:  # Reasonable P/E ratio
+    if pe_ratio and pe_ratio < 25:  # Reasonable P/E ratio
         price_ratio_score += 1
-    if pb_ratio < 3:  # Reasonable P/B ratio
+    if pb_ratio and pb_ratio < 3:  # Reasonable P/B ratio
         price_ratio_score += 1
-    if ps_ratio < 5:  # Reasonable P/S ratio
+    if ps_ratio and ps_ratio < 5:  # Reasonable P/S ratio
         price_ratio_score += 1
         
     signals.append('bullish' if price_ratio_score >= 2 else 'bearish' if price_ratio_score == 0 else 'neutral')
     reasoning["price_ratios_signal"] = {
         "signal": signals[3],
-        "details": f"P/E: {pe_ratio:.2f}, P/B: {pb_ratio:.2f}, P/S: {ps_ratio:.2f}"
+        "details": (
+            f"P/E: {pe_ratio:.2f}" if pe_ratio else "P/E: N/A"
+        ) + ", " + (
+            f"P/B: {pb_ratio:.2f}" if pb_ratio else "P/B: N/A"
+        ) + ", " + (
+            f"P/S: {ps_ratio:.2f}" if ps_ratio else "P/S: N/A"
+        )
     }
     
     # Determine overall signal

--- a/src/agents/fundamentals.py
+++ b/src/agents/fundamentals.py
@@ -16,17 +16,15 @@ def fundamentals_agent(state: AgentState):
     reasoning = {}
     
     # 1. Profitability Analysis
-    return_on_equity = metrics.get("return_on_equity", None)
-    net_margin = metrics.get("net_margin", None)
-    operating_margin = metrics.get("operating_margin", None)
+    return_on_equity = metrics.get("return_on_equity")
+    net_margin = metrics.get("net_margin")
+    operating_margin = metrics.get("operating_margin")
 
-    profitability_score = 0
-    if return_on_equity and return_on_equity > 0.15:  # Strong ROE above 15%
-        profitability_score += 1
-    if net_margin and net_margin > 0.20:  # Healthy profit margins
-        profitability_score += 1
-    if operating_margin and operating_margin > 0.15:  # Strong operating efficiency
-        profitability_score += 1
+    thresholds = [(return_on_equity, 0.15), (net_margin, 0.20), (operating_margin, 0.15)]
+    profitability_score = sum(
+        metric is not None and metric > threshold
+        for metric, threshold in thresholds
+    )
         
     signals.append('bullish' if profitability_score >= 2 else 'bearish' if profitability_score == 0 else 'neutral')
     reasoning["profitability_signal"] = {

--- a/src/agents/fundamentals.py
+++ b/src/agents/fundamentals.py
@@ -16,12 +16,16 @@ def fundamentals_agent(state: AgentState):
     reasoning = {}
     
     # 1. Profitability Analysis
+    return_on_equity = metrics.get("return_on_equity", None)
+    net_margin = metrics.get("net_margin", None)
+    operating_margin = metrics.get("operating_margin", None)
+
     profitability_score = 0
-    if metrics["return_on_equity"] and metrics["return_on_equity"] > 0.15:  # Strong ROE above 15%
+    if return_on_equity and return_on_equity > 0.15:  # Strong ROE above 15%
         profitability_score += 1
-    if metrics["net_margin"] and metrics["net_margin"] > 0.20:  # Healthy profit margins
+    if net_margin and net_margin > 0.20:  # Healthy profit margins
         profitability_score += 1
-    if metrics["operating_margin"] and metrics["operating_margin"] > 0.15:  # Strong operating efficiency
+    if operating_margin and operating_margin > 0.15:  # Strong operating efficiency
         profitability_score += 1
         
     signals.append('bullish' if profitability_score >= 2 else 'bearish' if profitability_score == 0 else 'neutral')

--- a/src/agents/valuation.py
+++ b/src/agents/valuation.py
@@ -14,7 +14,7 @@ def valuation_agent(state: AgentState):
     reasoning = {}
 
     # Calculate working capital change
-    working_capital_change = current_financial_line_item.get('working_capital', 0) - previous_financial_line_item.get('working_capital', 0)
+    working_capital_change = (current_financial_line_item.get('working_capital') or 0) - (previous_financial_line_item.get('working_capital') or 0)
     
     # Owner Earnings Valuation (Buffett Method)
     owner_earnings_value = calculate_owner_earnings_value(


### PR DESCRIPTION
Some stocks have a None value for financial metrics and cause runtime errors.

Resolved issues with None values causing runtime errors in calculations and string formatting:
- Ensured default values (e.g., 0 or "N/A") are used when metrics are missing or None.
- Refactored conditional logic in f-strings to avoid unsupported format specifiers.

Updated profitability, growth, financial health, and price ratio signals to handle missing data gracefully.

Improved readability and reliability of the details strings in the reasoning dictionary.

Ensured all calculations and outputs are robust against incomplete or invalid financial data.