### PR TITLE
feat: #67 add CLI arguments for analysts, model, and provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Hedge Fund
 
-This is a proof of concept for an AI-powered hedge fund.  The goal of this project is to explore the use of AI to make trading decisions.  This project is for **educational** purposes only and is not intended for real trading or investment.
+This is a proof of concept for an AI-powered hedge fund. The goal of this project is to explore the use of AI to make trading decisions. This project is for **educational** purposes only and is not intended for real trading or investment.
 
 This system employs several agents working together:
 
@@ -14,7 +14,6 @@ This system employs several agents working together:
 8. Portfolio Manager - Makes final trading decisions and generates orders
 
 <img width="1117" alt="Screenshot 2025-02-09 at 11 26 14 AM" src="https://github.com/user-attachments/assets/16509cc2-4b64-4c67-8de6-00d224893d58" />
-
 
 **Note**: the system simulates trading decisions, it does not actually trade.
 
@@ -33,6 +32,7 @@ This project is for **educational and research purposes only**.
 By using this software, you agree to use it solely for learning purposes.
 
 ## Table of Contents
+
 - [Setup](#setup)
 - [Usage](#usage)
   - [Running the Hedge Fund](#running-the-hedge-fund)
@@ -45,28 +45,33 @@ By using this software, you agree to use it solely for learning purposes.
 ## Setup
 
 Clone the repository:
+
 ```bash
 git clone https://github.com/virattt/ai-hedge-fund.git
 cd ai-hedge-fund
 ```
 
 1. Install Poetry (if not already installed):
+
 ```bash
 curl -sSL https://install.python-poetry.org | python3 -
 ```
 
 2. Install dependencies:
+
 ```bash
 poetry install
 ```
 
 3. Set up your environment variables:
+
 ```bash
 # Create .env file for your API keys
 cp .env.example .env
 ```
 
 4. Set your API keys:
+
 ```bash
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
@@ -81,7 +86,7 @@ GROQ_API_KEY=your-groq-api-key
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 ```
 
-**Important**: You must set `OPENAI_API_KEY`, `GROQ_API_KEY`, or `ANTHROPIC_API_KEY` for the hedge fund to work.  If you want to use LLMs from all providers, you will need to set all API keys.
+**Important**: You must set `OPENAI_API_KEY`, `GROQ_API_KEY`, or `ANTHROPIC_API_KEY` for the hedge fund to work. If you want to use LLMs from all providers, you will need to set all API keys.
 
 Financial data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key.
 
@@ -89,7 +94,62 @@ For any other ticker, you will need to set the `FINANCIAL_DATASETS_API_KEY` in t
 
 ## Usage
 
+### CLI Arguments
+
+The hedge fund supports the following command line arguments:
+
+| Argument               | Description                                                           | Default                  | Example                                                                                                |
+| ---------------------- | --------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `--tickers`            | Comma-separated list of stock ticker symbols                          | Required                 | `--tickers AAPL,MSFT,NVDA`                                                                             |
+| `--analysts`           | Comma-separated list of analysts to use (skips interactive selection) | Interactive prompt       | `--analysts all` or `--analysts technical_analyst,fundamentals_analyst`                                |
+| `--model`              | LLM model name (skips interactive selection)                          | Interactive prompt       | `--model gpt-4`                                                                                        |
+| `--model-provider`     | Model provider (skips interactive selection)                          | Interactive prompt       | `--model-provider OpenAI`                                                                              |
+| `--initial-cash`       | Initial cash position                                                 | 100000.0                 | `--initial-cash 500000`                                                                                |
+| `--initial-positions`  | JSON string of initial positions                                      | Empty positions          | `--initial-positions '{"AAPL":{"long":100,"short":0,"long_cost_basis":150.0,"short_cost_basis":0.0}}'` |
+| `--margin-requirement` | Initial margin requirement                                            | 0.0                      | `--margin-requirement 0.5`                                                                             |
+| `--start-date`         | Start date in YYYY-MM-DD format                                       | 3 months before end date | `--start-date 2024-01-01`                                                                              |
+| `--end-date`           | End date in YYYY-MM-DD format                                         | Today                    | `--end-date 2024-03-01`                                                                                |
+| `--show-reasoning`     | Show reasoning from each agent                                        | False                    | `--show-reasoning`                                                                                     |
+| `--show-agent-graph`   | Generate a visualization of the agent workflow                        | False                    | `--show-agent-graph`                                                                                   |
+
+Available analysts:
+
+- Use `--analysts all` to select all analysts, or specify individual analysts:
+  - `technical_analyst`: Technical analysis
+  - `fundamentals_analyst`: Fundamental analysis
+  - `sentiment_analyst`: Sentiment analysis
+  - `valuation_analyst`: Valuation analysis
+  - `warren_buffett`: Warren Buffett's principles
+  - `bill_ackman`: Bill Ackman's principles
+
+Available model providers:
+
+- `OpenAI`: Requires OPENAI_API_KEY
+- `Groq`: Requires GROQ_API_KEY
+- `Anthropic`: Requires ANTHROPIC_API_KEY
+
+Available models by provider:
+
+OpenAI models:
+
+- `gpt-4o`: GPT-4 Optimized
+- `gpt-4o-mini`: GPT-4 Mini Optimized
+- `o1`: OpenAI One
+- `o3-mini`: OpenAI Three Mini
+
+Groq models:
+
+- `deepseek-r1-distill-llama-70b`: DeepSeek R1 70B
+- `llama-3.3-70b-versatile`: Llama 3.3 70B
+
+Anthropic models:
+
+- `claude-3-5-haiku-latest`: Claude 3.5 Haiku
+- `claude-3-5-sonnet-latest`: Claude 3.5 Sonnet
+- `claude-3-opus-latest`: Claude 3 Opus
+
 ### Running the Hedge Fund
+
 ```bash
 poetry run python src/main.py --ticker AAPL,MSFT,NVDA
 ```
@@ -102,10 +162,11 @@ You can also specify a `--show-reasoning` flag to print the reasoning of each ag
 ```bash
 poetry run python src/main.py --ticker AAPL,MSFT,NVDA --show-reasoning
 ```
+
 You can optionally specify the start and end dates to make decisions for a specific time period.
 
 ```bash
-poetry run python src/main.py --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01 
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01
 ```
 
 ### Running the Backtester
@@ -123,7 +184,8 @@ You can optionally specify the start and end dates to backtest over a specific t
 poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01
 ```
 
-## Project Structure 
+## Project Structure
+
 ```
 ai-hedge-fund/
 ├── src/
@@ -152,7 +214,7 @@ ai-hedge-fund/
 4. Push to the branch
 5. Create a Pull Request
 
-**Important**: Please keep your pull requests small and focused.  This will make it easier to review and merge.
+**Important**: Please keep your pull requests small and focused. This will make it easier to review and merge.
 
 ## Feature Requests
 

--- a/src/main.py
+++ b/src/main.py
@@ -165,60 +165,98 @@ if __name__ == "__main__":
     parser.add_argument(
         "--show-agent-graph", action="store_true", help="Show the agent graph"
     )
+    parser.add_argument(
+        "--analysts", 
+        type=str,
+        help="Comma-separated list of analysts (e.g., 'technical_analyst,fundamentals_analyst')"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        help="LLM model name (e.g., 'gpt-4')"
+    )
+    parser.add_argument(
+        "--model-provider",
+        type=str,
+        help="Model provider (e.g., 'OpenAI')"
+    )
+    parser.add_argument(
+        "--initial-positions",
+        type=str,
+        help="JSON string of initial positions (e.g., '{\"AAPL\": {\"long\": 100, \"short\": 0, \"long_cost_basis\": 150.0, \"short_cost_basis\": 0.0}}')"
+    )
 
     args = parser.parse_args()
 
     # Parse tickers from comma-separated string
     tickers = [ticker.strip() for ticker in args.tickers.split(",")]
 
-    # Select analysts
+    # Handle analysts selection
     selected_analysts = None
-    choices = questionary.checkbox(
-        "Select your AI analysts.",
-        choices=[questionary.Choice(display, value=value) for display, value in ANALYST_ORDER],
-        instruction="\n\nInstructions: \n1. Press Space to select/unselect analysts.\n2. Press 'a' to select/unselect all.\n3. Press Enter when done to run the hedge fund.\n",
-        validate=lambda x: len(x) > 0 or "You must select at least one analyst.",
-        style=questionary.Style(
-            [
-                ("checkbox-selected", "fg:green"),
-                ("selected", "fg:green noinherit"),
-                ("highlighted", "noinherit"),
-                ("pointer", "noinherit"),
-            ]
-        ),
-    ).ask()
-
-    if not choices:
-        print("\n\nInterrupt received. Exiting...")
-        sys.exit(0)
+    if args.analysts:
+        if args.analysts.lower() == "all":
+            selected_analysts = [value for _, value in ANALYST_ORDER]
+            print(f"\nSelected all analysts: {', '.join(Fore.GREEN + analyst.title().replace('_', ' ') + Style.RESET_ALL for analyst in selected_analysts)}\n")
+        else:
+            selected_analysts = [analyst.strip() for analyst in args.analysts.split(",")]
+            # Validate analysts
+            valid_analysts = [value for _, value in ANALYST_ORDER]
+            invalid_analysts = [a for a in selected_analysts if a not in valid_analysts]
+            if invalid_analysts:
+                print(f"{Fore.RED}Invalid analysts: {', '.join(invalid_analysts)}")
+                print(f"Valid options are: 'all' or {', '.join(valid_analysts)}{Style.RESET_ALL}")
+                sys.exit(1)
+            print(f"\nSelected analysts: {', '.join(Fore.GREEN + analyst.title().replace('_', ' ') + Style.RESET_ALL for analyst in selected_analysts)}\n")
     else:
+        choices = questionary.checkbox(
+            "Select your AI analysts.",
+            choices=[questionary.Choice(display, value=value) for display, value in ANALYST_ORDER],
+            instruction="\n\nInstructions: \n1. Press Space to select/unselect analysts.\n2. Press 'a' to select/unselect all.\n3. Press Enter when done to run the hedge fund.\n",
+            validate=lambda x: len(x) > 0 or "You must select at least one analyst.",
+            style=questionary.Style(
+                [
+                    ("checkbox-selected", "fg:green"),
+                    ("selected", "fg:green noinherit"),
+                    ("highlighted", "noinherit"),
+                    ("pointer", "noinherit"),
+                ]
+            ),
+        ).ask()
+        if not choices:
+            print("\n\nInterrupt received. Exiting...")
+            sys.exit(0)
         selected_analysts = choices
         print(f"\nSelected analysts: {', '.join(Fore.GREEN + choice.title().replace('_', ' ') + Style.RESET_ALL for choice in choices)}\n")
 
-    # Select LLM model
-    model_choice = questionary.select(
-        "Select your LLM model:",
-        choices=[questionary.Choice(display, value=value) for display, value, _ in LLM_ORDER],
-        style=questionary.Style([
-            ("selected", "fg:green bold"),
-            ("pointer", "fg:green bold"),
-            ("highlighted", "fg:green"),
-            ("answer", "fg:green bold"),
-        ])
-    ).ask()
-
-    if not model_choice:
-        print("\n\nInterrupt received. Exiting...")
-        sys.exit(0)
+    # Handle model selection
+    model_choice = args.model
+    model_provider = args.model_provider
+    if model_choice and model_provider:
+        print(f"\nSelected {Fore.CYAN}{model_provider}{Style.RESET_ALL} model: {Fore.GREEN + Style.BRIGHT}{model_choice}{Style.RESET_ALL}\n")
     else:
-        # Get model info using the helper function
-        model_info = get_model_info(model_choice)
-        if model_info:
-            model_provider = model_info.provider.value
-            print(f"\nSelected {Fore.CYAN}{model_provider}{Style.RESET_ALL} model: {Fore.GREEN + Style.BRIGHT}{model_choice}{Style.RESET_ALL}\n")
+        model_choice = questionary.select(
+            "Select your LLM model:",
+            choices=[questionary.Choice(display, value=value) for display, value, _ in LLM_ORDER],
+            style=questionary.Style([
+                ("selected", "fg:green bold"),
+                ("pointer", "fg:green bold"),
+                ("highlighted", "fg:green"),
+                ("answer", "fg:green bold"),
+            ])
+        ).ask()
+
+        if not model_choice:
+            print("\n\nInterrupt received. Exiting...")
+            sys.exit(0)
         else:
-            model_provider = "Unknown"
-            print(f"\nSelected model: {Fore.GREEN + Style.BRIGHT}{model_choice}{Style.RESET_ALL}\n")
+            # Get model info using the helper function
+            model_info = get_model_info(model_choice)
+            if model_info:
+                model_provider = model_info.provider.value
+                print(f"\nSelected {Fore.CYAN}{model_provider}{Style.RESET_ALL} model: {Fore.GREEN + Style.BRIGHT}{model_choice}{Style.RESET_ALL}\n")
+            else:
+                model_provider = "Unknown"
+                print(f"\nSelected model: {Fore.GREEN + Style.BRIGHT}{model_choice}{Style.RESET_ALL}\n")
 
     # Create the workflow with selected analysts
     workflow = create_workflow(selected_analysts)
@@ -273,6 +311,19 @@ if __name__ == "__main__":
             } for ticker in tickers
         }
     }
+
+    # Update portfolio with initial positions if provided
+    if args.initial_positions:
+        try:
+            initial_positions = json.loads(args.initial_positions)
+            for ticker, position in initial_positions.items():
+                if ticker in portfolio["positions"]:
+                    portfolio["positions"][ticker].update(position)
+                else:
+                    print(f"{Fore.YELLOW}Warning: Position provided for unknown ticker {ticker}{Style.RESET_ALL}")
+        except json.JSONDecodeError:
+            print(f"{Fore.RED}Error: Invalid JSON format for initial positions{Style.RESET_ALL}")
+            sys.exit(1)
 
     # Run the hedge fund
     result = run_hedge_fund(

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import sys
+import json
 
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage


### PR DESCRIPTION
### CLI Arguments Enhancement

#### Overview
This PR introduces new command-line interface arguments to provide more flexibility in configuring the hedge fund simulation.

#### Changes
Added new CLI arguments to main.py:
--analysts: Allows specifying a comma-separated list of analysts (e.g., 'technical_analyst,fundamentals_analyst')
--model: Enables selection of specific LLM model (e.g., 'gpt-4')
--model-provider: Allows choosing the model provider (e.g., 'OpenAI')

#### Updated README.md with:
- Improved formatting and readability
- Added documentation for new CLI arguments
- Enhanced setup instructions

#### Impact:
These changes make the system more configurable, allowing users to:
- Customize which analysts are active in their simulation
- Choose specific LLM models for their use case
- Select different model providers based on their preferences 

Closes #67 