### PR TITLE
added simple docker & docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \ 
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://install.python-poetry.org | python3 -
+
+ENV PATH="${PATH}:/root/.local/bin"
+
+RUN git clone https://github.com/virattt/ai-hedge-fund.git
+
+WORKDIR /ai-hedge-fund
+
+RUN poetry install

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ ai-hedge-fund/
 ├── ...
 ```
 
+## Docker & docker-compose
+
+If you have docker installed on your system, you can easily run the project by running docker-compose:
+
+`docker-compose up -d`
+
+Then:
+
+`docker exec -it ai-hedge-fund poetry run python src/main.py --ticker AAPL`
+
 ## Contributing
 
 1. Fork the repository

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+
+services:
+  ai-hedge-fund:
+    container_name: ai-hedge-fund
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    stdin_open: true
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    volumes:
+      - ./:/ai-hedge-fund
     env_file:
       - .env
     stdin_open: true


### PR DESCRIPTION
Added a simple docker-compose environment so docker users can run the project with just 1 or 2 commands. Not sure if this helps, but this implementation is based on the `docker-compose` & `docker exec` setup I contributed to this very similar repo:

https://github.com/dzhng/deep-research

However, users could use `docker run` as well if they wish