### PR TITLE
Fix incorrect Google API documentation line

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ DEEPSEEK_API_KEY=your-deepseek-api-key
 # Get your Groq API key from https://groq.com/
 GROQ_API_KEY=your-groq-api-key
 
-# For getting news data to power the hedge fund
+# For running LLMs hosted by gemini (gemini-2.0-flash, gemini-2.0-pro)
 # Get your Google API key from https://console.cloud.google.com/
 GOOGLE_API_KEY=your-google-api-key
 # For getting financial data to power the hedge fund


### PR DESCRIPTION
The Google API key is used for running Gemini models, not for getting news data. This update corrects this.