### PR TITLE
feat: pass many tickers, but only dislay the last ticker in progress

### DIFF
--- a/src/agents/portfolio_manager.py
+++ b/src/agents/portfolio_manager.py
@@ -28,6 +28,7 @@ def portfolio_management_agent(state: AgentState):
     portfolio = state["data"]["portfolio"]
     analyst_signals = state["data"]["analyst_signals"]
     tickers = state["data"]["tickers"]
+    progress_tickers = ",".join(tickers)
 
     progress.update_status("portfolio_management_agent", None, "Analyzing signals")
 
@@ -37,7 +38,7 @@ def portfolio_management_agent(state: AgentState):
     max_shares = {}
     signals_by_ticker = {}
     for ticker in tickers:
-        progress.update_status("portfolio_management_agent", ticker, "Processing analyst signals")
+        progress.update_status("portfolio_management_agent", progress_tickers, "Processing analyst signals")
 
         # Get position limits and current prices for the ticker
         risk_data = analyst_signals.get("risk_management_agent", {}).get(ticker, {})

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -11,13 +11,14 @@ def risk_management_agent(state: AgentState):
     portfolio = state["data"]["portfolio"]
     data = state["data"]
     tickers = data["tickers"]
+    progress_tickers = ",".join(tickers)
 
     # Initialize risk analysis for each ticker
     risk_analysis = {}
     current_prices = {}  # Store prices here to avoid redundant API calls
 
     for ticker in tickers:
-        progress.update_status("risk_management_agent", ticker, "Analyzing price data")
+        progress.update_status("risk_management_agent", progress_tickers, "Analyzing price data")
 
         prices = get_prices(
             ticker=ticker,
@@ -26,12 +27,12 @@ def risk_management_agent(state: AgentState):
         )
 
         if not prices:
-            progress.update_status("risk_management_agent", ticker, "Failed: No price data found")
+            progress.update_status("risk_management_agent", progress_tickers, "Failed: No price data found")
             continue
 
         prices_df = prices_to_df(prices)
 
-        progress.update_status("risk_management_agent", ticker, "Calculating position limits")
+        progress.update_status("risk_management_agent", progress_tickers, "Calculating position limits")
 
         # Calculate portfolio value
         current_price = prices_df["close"].iloc[-1]
@@ -64,7 +65,7 @@ def risk_management_agent(state: AgentState):
             },
         }
 
-        progress.update_status("risk_management_agent", ticker, "Done")
+        progress.update_status("risk_management_agent", progress_tickers, "Done")
 
     message = HumanMessage(
         content=json.dumps(risk_analysis),

--- a/src/agents/warren_buffett.py
+++ b/src/agents/warren_buffett.py
@@ -20,17 +20,18 @@ def warren_buffett_agent(state: AgentState):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
+    progress_tickers = ",".join(tickers)
 
     # Collect all analysis for LLM reasoning
     analysis_data = {}
     buffett_analysis = {}
 
     for ticker in tickers:
-        progress.update_status("warren_buffett_agent", ticker, "Fetching financial metrics")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Fetching financial metrics")
         # Fetch required data
         metrics = get_financial_metrics(ticker, end_date, period="ttm", limit=5)
 
-        progress.update_status("warren_buffett_agent", ticker, "Gathering financial line items")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Gathering financial line items")
         financial_line_items = search_line_items(
             ticker,
             [
@@ -46,24 +47,24 @@ def warren_buffett_agent(state: AgentState):
             end_date,
         )
 
-        progress.update_status("warren_buffett_agent", ticker, "Getting market cap")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Getting market cap")
         # Get current market cap
         market_cap = get_market_cap(ticker, end_date)
 
-        progress.update_status("warren_buffett_agent", ticker, "Analyzing fundamentals")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Analyzing fundamentals")
         # Analyze fundamentals
         fundamental_analysis = analyze_fundamentals(metrics)
 
-        progress.update_status("warren_buffett_agent", ticker, "Analyzing consistency")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Analyzing consistency")
         consistency_analysis = analyze_consistency(financial_line_items)
 
-        progress.update_status("warren_buffett_agent", ticker, "Analyzing moat")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Analyzing moat")
         moat_analysis = analyze_moat(metrics)
 
-        progress.update_status("warren_buffett_agent", ticker, "Analyzing management quality")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Analyzing management quality")
         mgmt_analysis = analyze_management_quality(financial_line_items)
 
-        progress.update_status("warren_buffett_agent", ticker, "Calculating intrinsic value")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Calculating intrinsic value")
         intrinsic_value_analysis = calculate_intrinsic_value(financial_line_items)
 
         # Calculate total score
@@ -104,7 +105,7 @@ def warren_buffett_agent(state: AgentState):
             "margin_of_safety": margin_of_safety,
         }
 
-        progress.update_status("warren_buffett_agent", ticker, "Generating Warren Buffett analysis")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Generating Warren Buffett analysis")
         buffett_output = generate_buffett_output(
             ticker=ticker,
             analysis_data=analysis_data,
@@ -119,7 +120,7 @@ def warren_buffett_agent(state: AgentState):
             "reasoning": buffett_output.reasoning,
         }
 
-        progress.update_status("warren_buffett_agent", ticker, "Done")
+        progress.update_status("warren_buffett_agent", progress_tickers, "Done")
 
     # Create the message
     message = HumanMessage(content=json.dumps(buffett_analysis), name="warren_buffett_agent")


### PR DESCRIPTION
Try to running analysis 3 tickers, and it only display the last ticker: `NVDA`
This time I just fix for the Agent `warren_buffett.py`, later if it is fine I will fix for other agents. Thanks!

`poetry run python src/main.py --ticker AAPL,MSFT,NVDA`

Before
<img width="532" alt="Screenshot 2025-03-28 at 22 14 59" src="https://github.com/user-attachments/assets/ea6863da-7444-4e79-8083-d230744bc6f5" />
<img width="467" alt="Screenshot 2025-03-28 at 22 15 23" src="https://github.com/user-attachments/assets/745a4e65-03de-4509-ba50-8c854945c439" />


After
<img width="652" alt="Screenshot 2025-03-28 at 22 07 08" src="https://github.com/user-attachments/assets/0627bdf7-e615-42c7-926b-9dea814751ab" />
<img width="758" alt="Screenshot 2025-03-28 at 22 10 36" src="https://github.com/user-attachments/assets/88c35fc8-4117-411d-bfaf-66d37adca836" />

