### PR TITLE
Added reasoning open-sourced model capability with Groq for better results.

### DIFF
--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -101,6 +101,16 @@ AVAILABLE_MODELS = [
         provider=ModelProvider.GROQ
     ),
     LLMModel(
+        display_name="[groq] deepseek-r1-distill-llama-70b",
+        model_name="deepseek-r1-distill-llama-70b",
+        provider=ModelProvider.GROQ
+    ),
+    LLMModel(
+        display_name="[groq] deepseek-r1-distill-qwen-32b",
+        model_name="deepseek-r1-distill-qwen-32b",
+        provider=ModelProvider.GROQ
+    ),
+    LLMModel(
         display_name="[openai] gpt-4.5",
         model_name="gpt-4.5-preview",
         provider=ModelProvider.OPENAI


### PR DESCRIPTION

Added models : deepseek-r1-distill-llama-70b and deepseek-r1-distill-qwen-32b

Those models impose good reasoning capabilities as they are trained on R1's SFT datasets. 

Attached screenshot of the working-workflow

![image](https://github.com/user-attachments/assets/946bff34-b3a2-41c2-abcb-bfbb0d0d871e)
