### PR TITLE
feat: support remote Ollama deployment with environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-openai-api-key
+# For running LLMs hosted by ollama
+OLLAMA_BASE_URL=your-ollama-base-url

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -9,6 +9,9 @@ from enum import Enum
 from pydantic import BaseModel
 from typing import Tuple, List, Dict, Any, Optional
 
+import dotenv
+
+dotenv.load_dotenv()
 
 class ModelProvider(str, Enum):
     """Enum for supported LLM providers"""

--- a/src/utils/ollama.py
+++ b/src/utils/ollama.py
@@ -7,9 +7,13 @@ import time
 from typing import List
 import questionary
 from colorama import Fore, Style
+import os
+import dotenv
+
+dotenv.load_dotenv()
 
 # Constants
-OLLAMA_SERVER_URL = "http://localhost:11434"
+OLLAMA_SERVER_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
 OLLAMA_API_MODELS_ENDPOINT = f"{OLLAMA_SERVER_URL}/api/tags"
 OLLAMA_DOWNLOAD_URL = {
     "darwin": "https://ollama.com/download/darwin",     # macOS
@@ -29,7 +33,7 @@ def is_ollama_installed() -> bool:
     
     if system == "darwin" or system == "linux":  # macOS or Linux
         try:
-            result = subprocess.run(["which", "ollama"], 
+            result = subprocess.run(["curl", OLLAMA_API_MODELS_ENDPOINT], 
                                    stdout=subprocess.PIPE, 
                                    stderr=subprocess.PIPE, 
                                    text=True)
@@ -38,7 +42,7 @@ def is_ollama_installed() -> bool:
             return False
     elif system == "windows":  # Windows
         try:
-            result = subprocess.run(["where", "ollama"], 
+            result = subprocess.run(["curl", OLLAMA_API_MODELS_ENDPOINT], 
                                    stdout=subprocess.PIPE, 
                                    stderr=subprocess.PIPE, 
                                    text=True,


### PR DESCRIPTION
- Add OLLAMA_BASE_URL environment variable for remote server support
- Refactor Ollama installation check to accommodate remote servers
- Update model and script references (models/, ollama/) to use new config
- Remove hardcoded localhost references where applicable
- Maintain existing localhost default for backward compatibility

Key changes enable:
- Deployment flexibility (local/remote Ollama instances)
- Centralized configuration via environment variables
- Cleaner separation between infrastructure and application code