### PR TITLE
Fix confidence badge display rounding

### DIFF
--- a/app/frontend/src/nodes/components/text-output-dialog.tsx
+++ b/app/frontend/src/nodes/components/text-output-dialog.tsx
@@ -72,8 +72,7 @@ export function TextOutputDialog({
     if (confidence >= 50) variant = 'success';
     else if (confidence >= 0) variant = 'warning';
     else variant = 'outline';
-    // Fix: round to 1 decimal place for display
-    const rounded = Math.round((confidence + Number.EPSILON) * 10) / 10;
+    const rounded = Number(confidence.toFixed(1));
     return (
       <Badge variant={variant as any}>
         {rounded}%

--- a/app/frontend/src/nodes/components/text-output-dialog.tsx
+++ b/app/frontend/src/nodes/components/text-output-dialog.tsx
@@ -69,14 +69,14 @@ export function TextOutputDialog({
 
   const getConfidenceBadge = (confidence: number) => {
     let variant = 'outline';
-    
     if (confidence >= 50) variant = 'success';
     else if (confidence >= 0) variant = 'warning';
     else variant = 'outline';
-    
+    // Fix: round to 1 decimal place for display
+    const rounded = Math.round((confidence + Number.EPSILON) * 10) / 10;
     return (
       <Badge variant={variant as any}>
-        {confidence}%
+        {rounded}%
       </Badge>
     );
   };
@@ -202,4 +202,4 @@ export function TextOutputDialog({
       </DialogContent>
     </Dialog>
   );
-} 
+}


### PR DESCRIPTION
Round the confidence value displayed in the badge to one decimal place for improved clarity.