### PR TITLE
Fix: Precision bug in confidence score

### DIFF
--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -70,7 +70,7 @@ def sentiment_agent(state: AgentState):
         total_weighted_signals = len(insider_signals) * insider_weight + len(news_signals) * news_weight
         confidence = 0  # Default confidence when there are no signals
         if total_weighted_signals > 0:
-            confidence = round(max(bullish_signals, bearish_signals) / total_weighted_signals, 2) * 100
+            confidence = round((max(bullish_signals, bearish_signals) / total_weighted_signals)*100,2)
         reasoning = f"Weighted Bullish signals: {bullish_signals:.1f}, Weighted Bearish signals: {bearish_signals:.1f}"
 
         sentiment_analysis[ticker] = {

--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -70,7 +70,7 @@ def sentiment_agent(state: AgentState):
         total_weighted_signals = len(insider_signals) * insider_weight + len(news_signals) * news_weight
         confidence = 0  # Default confidence when there are no signals
         if total_weighted_signals > 0:
-            confidence = round((max(bullish_signals, bearish_signals) / total_weighted_signals)*100,2)
+            confidence = round((max(bullish_signals, bearish_signals) / total_weighted_signals) * 100, 2)
         reasoning = f"Weighted Bullish signals: {bullish_signals:.1f}, Weighted Bearish signals: {bearish_signals:.1f}"
 
         sentiment_analysis[ticker] = {


### PR DESCRIPTION
## Description
Fixes floating-point precision bug in Sentiment Agent confidence score by rounding the result to 2 decimals after percentage calculation.

## Related Issue
Closes [#280](https://github.com/virattt/ai-hedge-fund/issues/280)
