### PR TITLE
feat: add gemini-2.5-flash model to the list of available models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # For running LLMs hosted by anthropic (claude-3-5-sonnet, claude-3-opus, claude-3-5-haiku)
 # Get your Anthropic API key from https://anthropic.com/
 ANTHROPIC_API_KEY=your-anthropic-api-key
+
 # For running LLMs hosted by deepseek (deepseek-chat, deepseek-reasoner, etc.)
 # Get your DeepSeek API key from https://deepseek.com/
 DEEPSEEK_API_KEY=your-deepseek-api-key
@@ -9,12 +10,14 @@ DEEPSEEK_API_KEY=your-deepseek-api-key
 # Get your Groq API key from https://groq.com/
 GROQ_API_KEY=your-groq-api-key
 
-# For running LLMs hosted by gemini (gemini-2.0-flash, gemini-2.0-pro)
-# Get your Google API key from https://console.cloud.google.com/
+# For running LLMs hosted by gemini (gemini-2.5-flash, gemini-2.5-pro)
+# Get your Google API key from https://ai.dev/
 GOOGLE_API_KEY=your-google-api-key
+
 # For getting financial data to power the hedge fund
 # Get your Financial Datasets API key from https://financialdatasets.ai/
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-openai-api-key

--- a/app/frontend/src/data/models.ts
+++ b/app/frontend/src/data/models.ts
@@ -26,8 +26,8 @@ export const apiModels: ModelItem[] = [
     "provider": "DeepSeek"
   },
   {
-    "display_name": "gemini-2.0-flash",
-    "model_name": "gemini-2.0-flash",
+    "display_name": "gemini-2.5-flash",
+    "model_name": "gemini-2.5-flash-preview-05-20",
     "provider": "Gemini"
   },
   {

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -35,11 +35,6 @@
     "provider": "DeepSeek"
   },
   {
-    "display_name": "[gemini] gemini-2.0-flash",
-    "model_name": "gemini-2.0-flash",
-    "provider": "Gemini"
-  },
-  {
     "display_name": "[gemini] gemini-2.5-flash",
     "model_name": "gemini-2.5-flash-preview-05-20",
     "provider": "Gemini"

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -40,6 +40,11 @@
     "provider": "Gemini"
   },
   {
+    "display_name": "[gemini] gemini-2.5-flash",
+    "model_name": "gemini-2.5-flash-preview-05-20",
+    "provider": "Gemini"
+  },
+  {
     "display_name": "[gemini] gemini-2.5-pro",
     "model_name": "gemini-2.5-pro-exp-03-25",
     "provider": "Gemini"
@@ -89,4 +94,4 @@
     "model_name": "-",
     "provider": "OpenAI"
   }
-] 
+]


### PR DESCRIPTION
Add support for the gemini-2.5-flash model to the list of available models.
