### PR TITLE
Added command line argument to choose the llm model

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,35 @@ run.bat --ticker AAPL,MSFT,NVDA backtest
 **Example Output:**
 <img width="941" alt="Screenshot 2025-01-06 at 5 47 52 PM" src="https://github.com/user-attachments/assets/00e794ea-8628-44e6-9a84-8f8a31ad3b47" />
 
+To specify the LLM provider and model directly, use the `--llm` argument in the format `Provider:Model` (e.g., `Openai:gpt-4`, `Ollama:llama3`). This will override the interactive model selection.
+
+```bash
+# With Poetry:
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --llm Ollama:llama3
+
+# With Docker (on Linux/Mac):
+./run.sh --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+
+# With Docker (on Windows):
+run.bat --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+```
+
+If you do not specify `--llm`, you will be prompted to select a provider and model interactively.
+
+- Use `--ollama` for interactive local model selection (no need for --llm):
+
+```bash
+# With Poetry:
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
+
+# With Docker (on Linux/Mac):
+./run.sh --ticker AAPL,MSFT,NVDA --ollama backtest
+
+# With Docker (on Windows):
+run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
+```
+
 
 You can optionally specify the start and end dates to backtest over a specific time period.
 
@@ -218,19 +247,6 @@ poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --start-date 2024-01
 # With Docker (on Windows):
 run.bat --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01 backtest
 ```
-
-You can also specify a `--ollama` flag to run the backtester using local LLMs.
-```bash
-# With Poetry:
-poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
-
-# With Docker (on Linux/Mac):
-./run.sh --ticker AAPL,MSFT,NVDA --ollama backtest
-
-# With Docker (on Windows):
-run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
-```
-
 
 ## Project Structure 
 ```

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -655,7 +655,7 @@ if __name__ == "__main__":
         "--llm",
         type=str,
         default=None,
-        help="Specify LLM as provider:model (e.g., openai:gpt-4, ollama:llama3) to override interactive selection",
+        help="Specify LLM as provider:model (e.g., Openai:gpt-4, Ollama:llama3) to override interactive selection",
     )
     parser.add_argument("--ollama", action="store_true", help="Use Ollama for local LLM inference")
 
@@ -703,7 +703,7 @@ if __name__ == "__main__":
             print(f"{Fore.RED}--llm argument must be in provider:model format (e.g., openai:gpt-4){Style.RESET_ALL}")
             sys.exit(1)
         model_provider, model_name = args.llm.split(':', 1)
-        if model_provider.lower() == ModelProvider.OLLAMA.value or args.ollama:
+        if model_provider.lower() == ModelProvider.OLLAMA.value:
             # For Ollama, ensure model is available
             if not ensure_ollama_and_model(model_name):
                 print(f"{Fore.RED}Cannot proceed without Ollama and the selected model.{Style.RESET_ALL}")

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -795,5 +795,3 @@ if __name__ == "__main__":
 
     performance_metrics = backtester.run_backtest()
     performance_df = backtester.analyze_performance()
-
-    print_backtest_results(performance_df, performance_metrics)


### PR DESCRIPTION
Use command line argument --llm Provider:model to choose the llm model. Refer to src/llm/api_models.json and ollama_models.json for supported providers and models.


```
--llm Provider:model
--llm OpenAI:gpt-4o
```