### PR TITLE
Argument --llm argument to main.py too

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,35 @@ run.bat --ticker AAPL,MSFT,NVDA backtest
 **Example Output:**
 <img width="941" alt="Screenshot 2025-01-06 at 5 47 52 PM" src="https://github.com/user-attachments/assets/00e794ea-8628-44e6-9a84-8f8a31ad3b47" />
 
+To specify the LLM provider and model directly, use the `--llm` argument in the format `Provider:Model` (e.g., `Openai:gpt-4`, `Ollama:llama3`). This will override the interactive model selection.
+
+```bash
+# With Poetry:
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --llm Ollama:llama3
+
+# With Docker (on Linux/Mac):
+./run.sh --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+
+# With Docker (on Windows):
+run.bat --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+```
+
+If you do not specify `--llm`, you will be prompted to select a provider and model interactively.
+
+- Use `--ollama` for interactive local model selection (no need for --llm):
+
+```bash
+# With Poetry:
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
+
+# With Docker (on Linux/Mac):
+./run.sh --ticker AAPL,MSFT,NVDA --ollama backtest
+
+# With Docker (on Windows):
+run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
+```
+
 
 You can optionally specify the start and end dates to backtest over a specific time period.
 
@@ -218,19 +247,6 @@ poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --start-date 2024-01
 # With Docker (on Windows):
 run.bat --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01 backtest
 ```
-
-You can also specify a `--ollama` flag to run the backtester using local LLMs.
-```bash
-# With Poetry:
-poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
-
-# With Docker (on Linux/Mac):
-./run.sh --ticker AAPL,MSFT,NVDA --ollama backtest
-
-# With Docker (on Windows):
-run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
-```
-
 
 ## Project Structure 
 ```

--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ run.bat --ticker AAPL,MSFT,NVDA main
 **Example Output:**
 <img width="992" alt="Screenshot 2025-01-06 at 5 50 17 PM" src="https://github.com/user-attachments/assets/e8ca04bf-9989-4a7d-a8b4-34e04666663b" />
 
+To specify the LLM provider and model, use the `--llm` argument in the format `Provider:Model` (e.g., `Openai:gpt-4`, `Ollama:llama3`). This will override the interactive model selection.
+
+```bash
+# With Poetry:
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA --llm Ollama:llama3
+
+# With Docker (on Linux/Mac):
+./run.sh --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
+
+# With Docker (on Windows):
+run.bat --ticker AAPL,MSFT,NVDA --llm Ollama:llama3
+```
+
+If you do not specify `--llm`, you will be prompted to select a provider and model interactively.
+
 You can also specify a `--ollama` flag to run the AI hedge fund using local LLMs.
 
 ```bash
@@ -205,35 +221,7 @@ run.bat --ticker AAPL,MSFT,NVDA backtest
 **Example Output:**
 <img width="941" alt="Screenshot 2025-01-06 at 5 47 52 PM" src="https://github.com/user-attachments/assets/00e794ea-8628-44e6-9a84-8f8a31ad3b47" />
 
-To specify the LLM provider and model directly, use the `--llm` argument in the format `Provider:Model` (e.g., `Openai:gpt-4`, `Ollama:llama3`). This will override the interactive model selection.
-
-```bash
-# With Poetry:
-poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
-poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --llm Ollama:llama3
-
-# With Docker (on Linux/Mac):
-./run.sh --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
-
-# With Docker (on Windows):
-run.bat --ticker AAPL,MSFT,NVDA --llm Openai:gpt-4
-```
-
-If you do not specify `--llm`, you will be prompted to select a provider and model interactively.
-
-- Use `--ollama` for interactive local model selection (no need for --llm):
-
-```bash
-# With Poetry:
-poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
-
-# With Docker (on Linux/Mac):
-./run.sh --ticker AAPL,MSFT,NVDA --ollama backtest
-
-# With Docker (on Windows):
-run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
-```
-
+To specify the LLM provider and model, use the `--llm` argument the same way as for the Hedge Fund.
 
 You can optionally specify the start and end dates to backtest over a specific time period.
 

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -655,7 +655,7 @@ if __name__ == "__main__":
         "--llm",
         type=str,
         default=None,
-        help="Specify LLM as provider:model (e.g., openai:gpt-4, ollama:llama3) to override interactive selection",
+        help="Specify LLM as provider:model (e.g., Openai:gpt-4, Ollama:llama3) to override interactive selection",
     )
     parser.add_argument("--ollama", action="store_true", help="Use Ollama for local LLM inference")
 
@@ -703,7 +703,7 @@ if __name__ == "__main__":
             print(f"{Fore.RED}--llm argument must be in provider:model format (e.g., openai:gpt-4){Style.RESET_ALL}")
             sys.exit(1)
         model_provider, model_name = args.llm.split(':', 1)
-        if model_provider.lower() == ModelProvider.OLLAMA.value or args.ollama:
+        if model_provider.lower() == ModelProvider.OLLAMA.value:
             # For Ollama, ensure model is available
             if not ensure_ollama_and_model(model_name):
                 print(f"{Fore.RED}Cannot proceed without Ollama and the selected model.{Style.RESET_ALL}")

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -795,5 +795,3 @@ if __name__ == "__main__":
 
     performance_metrics = backtester.run_backtest()
     performance_df = backtester.analyze_performance()
-
-    print_backtest_results(performance_df, performance_metrics)


### PR DESCRIPTION
To specify the LLM provider and model, use the `--llm` argument the same way as for the Hedge Fund.

You can optionally specify the start and end dates to backtest over a specific time period.

```bash
# With Poetry:
poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01

# With Docker (on Linux/Mac):
./run.sh --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01 backtest

# With Docker (on Windows):
run.bat --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01 backtest
```

README also updated