### PR TITLE
bugs：Update api.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-import sy
+import sys
 
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-import sys
+import sy
 
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage


### PR DESCRIPTION
If all agents are selected, the program encounters an error while running the `run_hedge_fund` function. Specifically, when invoking the `michael_burry_agent` function and executing the `get_company_news` method to request news data for Apple Inc. (AAPL), an HTTP 429 error is encountered. The HTTP 429 error indicates that the requests have been rate-limited, and the server's response suggests that requests can be resumed after a 30-second wait.
The server enforces request frequency limits. When an excessive number of requests are sent in a short period, the rate-limiting mechanism is triggered, resulting in a 429 error response.
To address this issue, you can add a retry mechanism with delays to the get_company_news function. This involves pausing for a specified period before retrying failed requests, typically using exponential backoff to gradually increase wait times between attempts.