### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # AI Hedge Fund
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=de) | 
+[Español](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=es) | 
+[français](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=fr) | 
+[日本語](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=ja) | 
+[한국어](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=ko) | 
+[Português](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=pt) | 
+[Русский](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=ru) | 
+[中文](https://www.readme-i18n.com/virattt/ai-hedge-fund?lang=zh)
+
 This is a proof of concept for an AI-powered hedge fund.  The goal of this project is to explore the use of AI to make trading decisions.  This project is for **educational** purposes only and is not intended for real trading or investment.
 
 This system employs several agents working together:


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.