### PR TITLE
Switch default model from GPT-4o to GPT-4.1

### DIFF
--- a/app/backend/models/schemas.py
+++ b/app/backend/models/schemas.py
@@ -26,7 +26,7 @@ class HedgeFundRequest(BaseModel):
     agent_models: Optional[List[AgentModelConfig]] = None
     end_date: Optional[str] = Field(default_factory=lambda: datetime.now().strftime("%Y-%m-%d"))
     start_date: Optional[str] = None
-    model_name: str = "gpt-4o"
+    model_name: str = "gpt-4.1"
     model_provider: ModelProvider = ModelProvider.OPENAI
     initial_cash: float = 100000.0
     margin_requirement: float = 0.0

--- a/app/frontend/src/data/models.ts
+++ b/app/frontend/src/data/models.ts
@@ -28,12 +28,12 @@ export const getModels = async (): Promise<LanguageModel[]> => {
 };
 
 /**
- * Get the default model (GPT-4o) from the models list
+ * Get the default model (GPT-4.1) from the models list
  */
 export const getDefaultModel = async (): Promise<LanguageModel | null> => {
   try {
     const models = await getModels();
-    return models.find(model => model.model_name === "gpt-4o") || models[0] || null;
+    return models.find(model => model.model_name === "gpt-4.1") || models[0] || null;
   } catch (error) {
     console.error('Failed to get default model:', error);
     return null;

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -35,7 +35,7 @@ class Backtester:
         start_date: str,
         end_date: str,
         initial_capital: float,
-        model_name: str = "gpt-4o",
+        model_name: str = "gpt-4.1",
         model_provider: str = "OpenAI",
         selected_analysts: list[str] = [],
         initial_margin_requirement: float = 0.0,

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -51,7 +51,7 @@
   },
   {
     "display_name": "GPT 4.1",
-    "model_name": "gpt-4.1-2025-04-14",
+    "model_name": "gpt-4.1",
     "provider": "OpenAI"
   },
   {

--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,7 @@ def run_hedge_fund(
     portfolio: dict,
     show_reasoning: bool = False,
     selected_analysts: list[str] = [],
-    model_name: str = "gpt-4o",
+    model_name: str = "gpt-4.1",
     model_provider: str = "OpenAI",
 ):
     # Start progress tracking

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -36,7 +36,7 @@ def call_llm(
     
     # Fallback to defaults if still not provided
     if not model_name:
-        model_name = "gpt-4o"
+        model_name = "gpt-4.1"
     if not model_provider:
         model_provider = "OPENAI"
 
@@ -125,7 +125,7 @@ def get_agent_model_config(state, agent_name):
 
     if agent_name == 'portfolio_manager':
         # Get the model and provider from state metadata
-        model_name = state.get("metadata", {}).get("model_name", "gpt-4o")
+        model_name = state.get("metadata", {}).get("model_name", "gpt-4.1")
         model_provider = state.get("metadata", {}).get("model_provider", "OPENAI")
         return model_name, model_provider
     
@@ -135,7 +135,7 @@ def get_agent_model_config(state, agent_name):
         return model_name, model_provider.value if hasattr(model_provider, 'value') else str(model_provider)
     
     # Fall back to global configuration
-    model_name = state.get("metadata", {}).get("model_name", "gpt-4o")
+    model_name = state.get("metadata", {}).get("model_name", "gpt-4.1")
     model_provider = state.get("metadata", {}).get("model_provider", "OPENAI")
     
     # Convert enum to string if necessary


### PR DESCRIPTION
## Summary
Updates the default language model across the application from GPT-4o to GPT-4.1.

## Reason for change
GPT-4.1 performs better than GPT-4o, is optimized for API usage, and is cheaper to operate.