### PR TITLE
Fix NoneType error in valuation agent working capital calculation

### DIFF
--- a/src/agents/valuation.py
+++ b/src/agents/valuation.py
@@ -74,7 +74,11 @@ def valuation_analyst_agent(state: AgentState, agent_id: str = "valuation_analys
         # ------------------------------------------------------------------
         # Valuation models
         # ------------------------------------------------------------------
-        wc_change = li_curr.working_capital - li_prev.working_capital
+        # Handle potential None values for working capital
+        if li_curr.working_capital is not None and li_prev.working_capital is not None:
+            wc_change = li_curr.working_capital - li_prev.working_capital
+        else:
+            wc_change = 0  # Default to 0 if working capital data is unavailable
 
         # Owner Earnings
         owner_val = calculate_owner_earnings_value(


### PR DESCRIPTION
## Summary
- Fixed TypeError when working_capital values are None in the valuation agent
- Added proper None checks before performing subtraction operations
- Defaults to 0 for working capital change when data is unavailable

## Problem
The valuation agent was crashing with:
```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'
```

This occurred when trying to calculate working capital change but one or both of the working_capital values were None.

## Solution
Added a conditional check to handle None values:
- If both working_capital values are present, calculate the difference normally
- If either value is None, default the working capital change to 0

## Test plan
- [x] Verify the agent no longer crashes when working_capital data is missing
- [x] Confirm valuation calculations continue with default value when data unavailable
- [ ] Test with various tickers including those with incomplete financial data