### PR TITLE
fix: implement Cmd+, settings shortcut

### DIFF
--- a/app/frontend/src/components/layout/top-bar.tsx
+++ b/app/frontend/src/components/layout/top-bar.tsx
@@ -78,7 +78,7 @@ export function TopBar({
         onClick={onSettingsClick}
         className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground hover:bg-ramp-grey-700 transition-colors"
         aria-label="Open settings"
-        title="Open Settings (⇧⌘J)"
+        title="Open Settings (⌘,)"
       >
         <Settings size={16} />
       </Button>

--- a/app/frontend/src/hooks/use-keyboard-shortcuts.ts
+++ b/app/frontend/src/hooks/use-keyboard-shortcuts.ts
@@ -150,6 +150,15 @@ export function useLayoutKeyboardShortcuts(
       callback: openSettings,
       preventDefault: true,
     });
+    
+    // Add settings shortcut if provided
+    shortcuts.push({
+      key: ',',
+      ctrlKey: true, // This will match either Ctrl+, or Cmd+,
+      metaKey: true,
+      callback: openSettings,
+      preventDefault: true,
+    });
   }
 
   useKeyboardShortcuts({ shortcuts });


### PR DESCRIPTION
Fixes missing `Cmd+,` shortcut for opening settings. The UI mentioned this shortcut but it wasn't implemented. Now both `Cmd+,` and `Cmd+Shift+J` work.

- Added `Cmd+,` keyboard shortcut
- Updated tooltip to match
- Maintains backward compatibility with `Cmd+Shift+J`

Screenshot of UI shortcut mention:
<img width="2704" height="1756" alt="settings-shortcut-ui" src="https://github.com/user-attachments/assets/ae31371d-ec52-43ea-b25a-8f95511d47da" />
