### PR TITLE
fix: center plus button in component items

### DIFF
--- a/app/frontend/src/components/panels/right/component-item.tsx
+++ b/app/frontend/src/components/panels/right/component-item.tsx
@@ -54,7 +54,7 @@ export default function ComponentItem({
         <Button
           variant="ghost"
           size="icon"
-          className="h-5 w-5 p-0 hover-bg hover:text-primary text-muted-foreground"
+          className="h-5 w-5 hover-bg hover:text-primary text-muted-foreground flex items-center justify-center"
           onClick={handlePlusClick}
           aria-label="Add"
         >


### PR DESCRIPTION
Fixes the plus button alignment in component items. The button wasn't perfectly centered on hover. Now uses flexbox centering for proper alignment.

Before:
<img width="796" height="124" alt="plus-button-before" src="https://github.com/user-attachments/assets/9b27c0f6-a24b-4ed0-80d8-b57766defb66" />
After:
<img width="796" height="124" alt="plus-button-after" src="https://github.com/user-attachments/assets/af9f94ed-6d81-4179-85de-d1781de50b50" />
