### PR TITLE
Add support for external Ollama endpoint and improve run scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Git
+.git
+.gitignore
+
+# Poetry
+.venv
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+
+# Environment
+.env
+
+# IDEs and editors
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Logs and data
+logs/
+data/
+*.log
+
+# OS specific
+.DS_Store
+Thumbs.db 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,14 +9,14 @@ ENV PYTHONPATH=/app
 RUN pip install poetry==1.7.1
 
 # Copy only dependency files first for better caching
-COPY ../pyproject.toml ../poetry.lock* /app/
+COPY pyproject.toml poetry.lock* /app/
 
 # Configure Poetry to not use a virtual environment
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction --no-ansi
 
 # Copy rest of the source code
-COPY ../ /app/
+COPY . /app/
 
 # Default command (will be overridden by Docker Compose)
 CMD ["python", "src/main.py"] 

--- a/docker/README.md
+++ b/docker/README.md
@@ -131,6 +131,18 @@ You can also specify a `--ollama` flag to run the AI hedge fund using local LLMs
 run.bat --ticker AAPL,MSFT,NVDA --ollama main
 ```
 
+If you already have an Ollama server running (locally or on your network), point the containers at it instead of starting the bundled instance. You can either pass an explicit base URL or export `OLLAMA_BASE_URL` before running the scripts.
+
+```bash
+# Linux / macOS
+./run.sh --ticker AAPL,MSFT,NVDA --ollama --ollama-base-url http://localhost:11434 main
+
+# Windows
+run.bat --ticker AAPL,MSFT,NVDA --ollama --ollama-base-url http://localhost:11434 main
+```
+
+When `OLLAMA_BASE_URL` is provided, the Docker compose services reuse that endpoint and the Ollama container is not started. To launch the embedded Ollama service manually with Docker Compose, add the `embedded-ollama` profile (e.g. `docker compose --profile embedded-ollama up`).
+
 You can optionally specify the start and end dates to make decisions for a specific time period.
 
 ```bash

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   ollama:
+    profiles:
+      - embedded-ollama
     image: ollama/ollama:latest
     container_name: ollama
     environment:
@@ -18,15 +20,13 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     image: ai-hedge-fund
-    depends_on:
-      - ollama
     volumes:
       - ../.env:/app/.env
     command: python src/main.py --ticker AAPL,MSFT,NVDA
     environment:
-      - PYTHONUNBUFFERED=1
-      - OLLAMA_BASE_URL=http://ollama:11434
-      - PYTHONPATH=/app
+      PYTHONUNBUFFERED: "1"
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      PYTHONPATH: /app
     tty: true
     stdin_open: true
 
@@ -35,15 +35,13 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     image: ai-hedge-fund
-    depends_on:
-      - ollama
     volumes:
       - ../.env:/app/.env
     command: python src/main.py --ticker AAPL,MSFT,NVDA --show-reasoning
     environment:
-      - PYTHONUNBUFFERED=1
-      - OLLAMA_BASE_URL=http://ollama:11434
-      - PYTHONPATH=/app
+      PYTHONUNBUFFERED: "1"
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      PYTHONPATH: /app
     tty: true
     stdin_open: true
 
@@ -52,15 +50,13 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     image: ai-hedge-fund
-    depends_on:
-      - ollama
     volumes:
       - ../.env:/app/.env
     command: python src/main.py --ticker AAPL,MSFT,NVDA --ollama
     environment:
-      - PYTHONUNBUFFERED=1
-      - OLLAMA_BASE_URL=http://ollama:11434
-      - PYTHONPATH=/app
+      PYTHONUNBUFFERED: "1"
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      PYTHONPATH: /app
     tty: true
     stdin_open: true
 
@@ -69,15 +65,13 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     image: ai-hedge-fund
-    depends_on:
-      - ollama
     volumes:
       - ../.env:/app/.env
     command: python src/backtester.py --ticker AAPL,MSFT,NVDA
     environment:
-      - PYTHONUNBUFFERED=1
-      - OLLAMA_BASE_URL=http://ollama:11434
-      - PYTHONPATH=/app
+      PYTHONUNBUFFERED: "1"
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      PYTHONPATH: /app
     tty: true
     stdin_open: true
 
@@ -86,15 +80,13 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     image: ai-hedge-fund
-    depends_on:
-      - ollama
     volumes:
       - ../.env:/app/.env
     command: python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
     environment:
-      - PYTHONUNBUFFERED=1
-      - OLLAMA_BASE_URL=http://ollama:11434
-      - PYTHONPATH=/app
+      PYTHONUNBUFFERED: "1"
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      PYTHONPATH: /app
     tty: true
     stdin_open: true
 

--- a/docker/run.bat
+++ b/docker/run.bat
@@ -4,6 +4,8 @@ setlocal enabledelayedexpansion
 :: Default values
 set TICKER=AAPL,MSFT,NVDA
 set USE_OLLAMA=
+set "OLLAMA_BASE_URL_VALUE=%OLLAMA_BASE_URL%"
+set USE_EXTERNAL_OLLAMA=
 set START_DATE=
 set END_DATE=
 set INITIAL_AMOUNT=100000.0
@@ -25,6 +27,7 @@ echo   --end-date DATE     End date in YYYY-MM-DD format
 echo   --initial-cash AMT  Initial cash position (default: 100000.0)
 echo   --margin-requirement RATIO  Margin requirement ratio (default: 0.0)
 echo   --ollama            Use Ollama for local LLM inference
+echo   --ollama-base-url URL  Use an existing Ollama endpoint (implies --ollama)
 echo   --show-reasoning    Show reasoning from each agent
 echo.
 echo Commands:
@@ -84,6 +87,16 @@ if "%~1"=="--ollama" (
     shift
     goto :parse_args
 )
+if "%~1"=="--ollama-base-url" (
+    set "OLLAMA_BASE_URL_VALUE=%~2"
+    set USE_EXTERNAL_OLLAMA=1
+    if "!USE_OLLAMA!"=="" (
+        set USE_OLLAMA=--ollama
+    )
+    shift
+    shift
+    goto :parse_args
+)
 if "%~1"=="--show-reasoning" (
     set SHOW_REASONING=--show-reasoning
     shift
@@ -134,6 +147,23 @@ call :show_help
 exit /b 1
 
 :check_command
+if defined USE_OLLAMA (
+    if not defined USE_EXTERNAL_OLLAMA if not "!OLLAMA_BASE_URL_VALUE!"=="" (
+        set "__OLLAMA_CHECK=!OLLAMA_BASE_URL_VALUE!"
+        if /I not "!__OLLAMA_CHECK!"=="http://ollama:11434" if /I not "!__OLLAMA_CHECK!"=="http://ollama:11434/" (
+            set USE_EXTERNAL_OLLAMA=1
+        )
+        set "__OLLAMA_CHECK="
+    )
+)
+
+if defined USE_EXTERNAL_OLLAMA (
+    if "!OLLAMA_BASE_URL_VALUE!"=="" (
+        echo Error: --ollama-base-url requires a value.
+        exit /b 1
+    )
+)
+
 if "!COMMAND!"=="" (
     echo Error: No command specified.
     call :show_help
@@ -169,7 +199,7 @@ if "!COMMAND!"=="build" (
 :: Start Ollama container if 'ollama' command is provided
 if "!COMMAND!"=="ollama" (
     echo Starting Ollama container...
-    !COMPOSE_CMD! up -d ollama
+    !COMPOSE_CMD! --profile embedded-ollama up -d ollama
     
     :: Check if Ollama is running
     echo Waiting for Ollama to start...
@@ -205,7 +235,7 @@ if "!COMMAND!"=="pull" (
     )
     
     :: Start Ollama if it's not already running
-    !COMPOSE_CMD! up -d ollama
+    !COMPOSE_CMD! --profile embedded-ollama up -d ollama
     
     :: Wait for Ollama to start
     echo Ensuring Ollama is running...
@@ -242,7 +272,7 @@ if "!COMMAND!"=="pull" (
 :: Run with Docker Compose if 'compose' command is provided
 if "!COMMAND!"=="compose" (
     echo Running with Docker Compose (includes Ollama)...
-    !COMPOSE_CMD! up --build
+    !COMPOSE_CMD! --profile embedded-ollama up --build
     exit /b 0
 )
 
@@ -271,59 +301,86 @@ if "!COMMAND!"=="main" (
     )
 )
 
-:: If using Ollama, make sure the service is started
+:: If using Ollama, prepare embedded service or external connection
 if not "!USE_OLLAMA!"=="" (
-    echo Setting up Ollama container for local LLM inference...
-    
-    :: Start Ollama container if not already running
-    !COMPOSE_CMD! up -d ollama
-    
-    :: Wait for Ollama to start
-    echo Waiting for Ollama to start...
-    for /l %%i in (1, 1, 30) do (
-        !COMPOSE_CMD! exec ollama curl -s http://localhost:11434/api/version >nul 2>&1
-        if !ERRORLEVEL! EQU 0 (
-            echo Ollama is running.
-            :: Show available models
-            echo Available models:
-            !COMPOSE_CMD! exec ollama ollama list
-            goto :continue_ollama
-        )
-        timeout /t 1 /nobreak >nul
-        echo.
+    if not "!OLLAMA_BASE_URL_VALUE!"=="" (
+        set "OLLAMA_BASE_URL=!OLLAMA_BASE_URL_VALUE!"
     )
-    
-    :continue_ollama
-    :: Build the AI Hedge Fund image if needed
+
+    set COMMAND_OVERRIDE=
+
+    if not "!START_DATE!"=="" (
+        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! !START_DATE!
+    )
+
+    if not "!END_DATE!"=="" (
+        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! !END_DATE!
+    )
+
+    if not "!INITIAL_PARAM!"=="" (
+        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! !INITIAL_PARAM!
+    )
+
+    if not "!MARGIN_REQUIREMENT!"=="" (
+        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! --margin-requirement !MARGIN_REQUIREMENT!
+    )
+
+    if defined USE_EXTERNAL_OLLAMA (
+        set "TRIMMED_BASE=!OLLAMA_BASE_URL_VALUE!"
+        if "!TRIMMED_BASE!"=="" set "TRIMMED_BASE=!OLLAMA_BASE_URL!"
+        if "!TRIMMED_BASE!"=="" (
+            echo Error: No external Ollama base URL provided.
+            exit /b 1
+        )
+        if "!TRIMMED_BASE:~-1!"=="/" set "TRIMMED_BASE=!TRIMMED_BASE:~0,-1!"
+        set "HEALTHCHECK_URL=!TRIMMED_BASE!/api/version"
+        echo Using external Ollama endpoint at !TRIMMED_BASE!
+        echo Checking connectivity to Ollama...
+        set REACHABLE=
+        for /l %%i in (1, 1, 30) do (
+            powershell -NoLogo -Command "try {Invoke-WebRequest -Uri '!HEALTHCHECK_URL!' -UseBasicParsing -TimeoutSec 2 ^| Out-Null; exit 0} catch { exit 1 }" >nul 2>&1
+            if !ERRORLEVEL! EQU 0 (
+                set REACHABLE=1
+                goto :external_check_done
+            )
+            timeout /t 1 /nobreak >nul
+            echo.
+        )
+:external_check_done
+        if defined REACHABLE (
+            echo External Ollama endpoint is reachable.
+        ) else (
+            echo Warning: Unable to reach Ollama at !HEALTHCHECK_URL! within 30 seconds.
+            echo Continuing anyway; ensure the endpoint is reachable from within the containers.
+        )
+    ) else (
+        echo Setting up embedded Ollama container for local LLM inference...
+        !COMPOSE_CMD! --profile embedded-ollama up -d ollama
+
+        echo Waiting for Ollama to start...
+        for /l %%i in (1, 1, 30) do (
+            !COMPOSE_CMD! exec ollama curl -s http://localhost:11434/api/version >nul 2>&1
+            if !ERRORLEVEL! EQU 0 (
+                echo Ollama is running.
+                echo Available models:
+                !COMPOSE_CMD! exec ollama ollama list
+                goto :continue_ollama
+            )
+            timeout /t 1 /nobreak >nul
+            echo.
+        )
+        echo Warning: Unable to confirm Ollama startup within 30 seconds.
+:continue_ollama
+    )
+
     docker images -q ai-hedge-fund 2>nul | findstr /r /c:"^..*$" >nul
     if !ERRORLEVEL! NEQ 0 (
         echo Building AI Hedge Fund image...
         docker build -t ai-hedge-fund .
     )
-    
-    :: Create command override for Docker Compose
-    set COMMAND_OVERRIDE=
-    
-    if not "!START_DATE!"=="" (
-        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! !START_DATE!
-    )
-    
-    if not "!END_DATE!"=="" (
-        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! !END_DATE!
-    )
-    
-    if not "!INITIAL_PARAM!"=="" (
-        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! !INITIAL_PARAM!
-    )
-    
-    if not "!MARGIN_REQUIREMENT!"=="" (
-        set COMMAND_OVERRIDE=!COMMAND_OVERRIDE! --margin-requirement !MARGIN_REQUIREMENT!
-    )
-    
-    :: Run the command with Docker Compose
+
     echo Running AI Hedge Fund with Ollama using Docker Compose...
-    
-    :: Use the appropriate service based on command and reasoning flag
+
     if "!COMMAND!"=="main" (
         if not "!SHOW_REASONING!"=="" (
             !COMPOSE_CMD! run --rm hedge-fund-reasoning python src/main.py --ticker !TICKER! !COMMAND_OVERRIDE! !SHOW_REASONING! --ollama
@@ -333,7 +390,7 @@ if not "!USE_OLLAMA!"=="" (
     ) else if "!COMMAND!"=="backtest" (
         !COMPOSE_CMD! run --rm backtester-ollama python src/backtester.py --ticker !TICKER! !COMMAND_OVERRIDE! !SHOW_REASONING! --ollama
     )
-    
+
     exit /b 0
 )
 
@@ -353,3 +410,4 @@ exit /b 0
 
 :: Start script execution
 call :parse_args %* 
+

--- a/docker/run.bat
+++ b/docker/run.bat
@@ -376,7 +376,7 @@ if not "!USE_OLLAMA!"=="" (
     docker images -q ai-hedge-fund 2>nul | findstr /r /c:"^..*$" >nul
     if !ERRORLEVEL! NEQ 0 (
         echo Building AI Hedge Fund image...
-        docker build -t ai-hedge-fund .
+        docker build -t ai-hedge-fund -f Dockerfile ..
     )
 
     echo Running AI Hedge Fund with Ollama using Docker Compose...

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -13,6 +13,7 @@ show_help() {
   echo "  --initial-cash AMT  Initial cash position (default: 100000.0)"
   echo "  --margin-requirement RATIO  Margin requirement ratio (default: 0.0)"
   echo "  --ollama            Use Ollama for local LLM inference"
+  echo "  --ollama-base-url URL  Use an existing Ollama endpoint (implies --ollama)"
   echo "  --show-reasoning    Show reasoning from each agent"
   echo ""
   echo "Commands:"
@@ -37,6 +38,8 @@ show_help() {
 # Default values
 TICKER="AAPL,MSFT,NVDA"
 USE_OLLAMA=""
+OLLAMA_BASE_URL_VALUE="${OLLAMA_BASE_URL:-}"
+USE_EXTERNAL_OLLAMA=""
 START_DATE=""
 END_DATE=""
 INITIAL_AMOUNT="100000.0"
@@ -72,6 +75,14 @@ while [[ $# -gt 0 ]]; do
       USE_OLLAMA="--ollama"
       shift
       ;;
+    --ollama-base-url)
+      OLLAMA_BASE_URL_VALUE="$2"
+      USE_EXTERNAL_OLLAMA="1"
+      if [ -z "$USE_OLLAMA" ]; then
+        USE_OLLAMA="--ollama"
+      fi
+      shift 2
+      ;;
     --show-reasoning)
       SHOW_REASONING="--show-reasoning"
       shift
@@ -96,6 +107,18 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# Determine if we should use an external Ollama instance
+if [ -n "$USE_OLLAMA" ] && [ -z "$USE_EXTERNAL_OLLAMA" ] && [ -n "$OLLAMA_BASE_URL_VALUE" ]; then
+  if [ "$OLLAMA_BASE_URL_VALUE" != "http://ollama:11434" ] && [ "$OLLAMA_BASE_URL_VALUE" != "http://ollama:11434/" ]; then
+    USE_EXTERNAL_OLLAMA="1"
+  fi
+fi
+
+if [ "$USE_EXTERNAL_OLLAMA" = "1" ] && [ -z "$OLLAMA_BASE_URL_VALUE" ]; then
+  echo "Error: --ollama-base-url requires a value."
+  exit 1
+fi
 
 # Check if command is provided
 if [ -z "$COMMAND" ]; then
@@ -146,7 +169,7 @@ fi
 # Start Ollama container if 'ollama' command is provided
 if [ "$COMMAND" = "ollama" ]; then
   echo "Starting Ollama container..."
-  $COMPOSE_CMD $GPU_CONFIG up -d ollama
+  $COMPOSE_CMD $GPU_CONFIG --profile embedded-ollama up -d ollama
   
   # Check if Ollama is running
   echo "Waiting for Ollama to start..."
@@ -180,7 +203,7 @@ if [ "$COMMAND" = "pull" ]; then
   fi
   
   # Start Ollama if it's not already running
-  $COMPOSE_CMD $GPU_CONFIG up -d ollama
+  $COMPOSE_CMD $GPU_CONFIG --profile embedded-ollama up -d ollama
   
   # Wait for Ollama to start
   echo "Ensuring Ollama is running..."
@@ -214,7 +237,7 @@ fi
 # Run with Docker Compose
 if [ "$COMMAND" = "compose" ]; then
   echo "Running with Docker Compose (includes Ollama)..."
-  $COMPOSE_CMD $GPU_CONFIG up --build
+  $COMPOSE_CMD $GPU_CONFIG --profile embedded-ollama up --build
   exit 0
 fi
 
@@ -243,56 +266,88 @@ elif [ "$COMMAND" = "backtest" ]; then
   fi
 fi
 
-# If using Ollama, make sure the service is started
+# If using Ollama, prepare embedded service or external connection
 if [ -n "$USE_OLLAMA" ]; then
-  echo "Setting up Ollama container for local LLM inference..."
-  
-  # Start Ollama container if not already running
-  $COMPOSE_CMD $GPU_CONFIG up -d ollama
-  
-  # Wait for Ollama to start
-  echo "Waiting for Ollama to start..."
-  for i in {1..30}; do
-    if docker run --rm --network=host curlimages/curl:latest curl -s http://localhost:11434/api/version &> /dev/null; then
-      echo "Ollama is running."
-      # Show available models
-      echo "Available models:"
-      docker exec -t ollama ollama list
-      break
+  if [ -n "$OLLAMA_BASE_URL_VALUE" ]; then
+    export OLLAMA_BASE_URL="$OLLAMA_BASE_URL_VALUE"
+  fi
+
+  COMMAND_OVERRIDE=""
+
+  if [ -n "$START_DATE" ]; then
+    COMMAND_OVERRIDE="$COMMAND_OVERRIDE $START_DATE"
+  fi
+
+  if [ -n "$END_DATE" ]; then
+    COMMAND_OVERRIDE="$COMMAND_OVERRIDE $END_DATE"
+  fi
+
+  if [ -n "$INITIAL_PARAM" ]; then
+    COMMAND_OVERRIDE="$COMMAND_OVERRIDE $INITIAL_PARAM"
+  fi
+
+  if [ -n "$MARGIN_REQUIREMENT" ]; then
+    COMMAND_OVERRIDE="$COMMAND_OVERRIDE --margin-requirement $MARGIN_REQUIREMENT"
+  fi
+
+  if [ "$USE_EXTERNAL_OLLAMA" = "1" ]; then
+    TRIMMED_BASE="${OLLAMA_BASE_URL_VALUE%/}"
+    if [ -z "$TRIMMED_BASE" ]; then
+      TRIMMED_BASE="${OLLAMA_BASE_URL%/}"
     fi
-    echo -n "."
-    sleep 1
-  done
-  
-  # Build the AI Hedge Fund image if needed
+    if [ -z "$TRIMMED_BASE" ]; then
+      echo "Error: No external Ollama base URL provided."
+      exit 1
+    fi
+    HEALTHCHECK_URL="$TRIMMED_BASE/api/version"
+    echo "Using external Ollama endpoint at $TRIMMED_BASE"
+    echo "Checking connectivity to Ollama..."
+    REACHABLE=false
+    for i in {1..30}; do
+      if docker run --rm --network=host curlimages/curl:latest curl -s "$HEALTHCHECK_URL" &> /dev/null; then
+        REACHABLE=true
+        break
+      fi
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    if [ "$REACHABLE" = false ]; then
+      echo "Warning: Unable to reach Ollama at $HEALTHCHECK_URL within 30 seconds."
+      echo "Continuing anyway; ensure the endpoint is reachable from within the containers."
+    else
+      echo "External Ollama endpoint is reachable."
+    fi
+  else
+    echo "Setting up embedded Ollama container for local LLM inference..."
+    $COMPOSE_CMD $GPU_CONFIG --profile embedded-ollama up -d ollama
+
+    echo "Waiting for Ollama to start..."
+    EMBEDDED_REACHABLE=false
+    for i in {1..30}; do
+      if docker run --rm --network=host curlimages/curl:latest curl -s http://localhost:11434/api/version &> /dev/null; then
+        EMBEDDED_REACHABLE=true
+        echo "Ollama is running."
+        echo "Available models:"
+        docker exec -t ollama ollama list
+        break
+      fi
+      echo -n "."
+      sleep 1
+    done
+    echo ""
+    if [ "$EMBEDDED_REACHABLE" = false ]; then
+      echo "Warning: Unable to confirm embedded Ollama startup within 30 seconds."
+    fi
+  fi
+
   if [[ "$(docker images -q ai-hedge-fund 2> /dev/null)" == "" ]]; then
     echo "Building AI Hedge Fund image..."
     docker build -t ai-hedge-fund .
   fi
-  
-  # Create command override for Docker Compose
-  COMMAND_OVERRIDE=""
-  
-  if [ -n "$START_DATE" ]; then
-    COMMAND_OVERRIDE="$COMMAND_OVERRIDE $START_DATE"
-  fi
-  
-  if [ -n "$END_DATE" ]; then
-    COMMAND_OVERRIDE="$COMMAND_OVERRIDE $END_DATE"
-  fi
-  
-  if [ -n "$INITIAL_PARAM" ]; then
-    COMMAND_OVERRIDE="$COMMAND_OVERRIDE $INITIAL_PARAM"
-  fi
-  
-  if [ -n "$MARGIN_REQUIREMENT" ]; then
-    COMMAND_OVERRIDE="$COMMAND_OVERRIDE --margin-requirement $MARGIN_REQUIREMENT"
-  fi
-  
-  # Run the command with Docker Compose
+
   echo "Running AI Hedge Fund with Ollama using Docker Compose..."
-  
-  # Use the appropriate service based on command and reasoning flag
+
   if [ "$COMMAND" = "main" ]; then
     if [ -n "$SHOW_REASONING" ]; then
       $COMPOSE_CMD $GPU_CONFIG run --rm hedge-fund-reasoning python src/main.py --ticker $TICKER $COMMAND_OVERRIDE $SHOW_REASONING --ollama
@@ -302,10 +357,9 @@ if [ -n "$USE_OLLAMA" ]; then
   elif [ "$COMMAND" = "backtest" ]; then
     $COMPOSE_CMD $GPU_CONFIG run --rm backtester-ollama python src/backtester.py --ticker $TICKER $COMMAND_OVERRIDE $SHOW_REASONING --ollama
   fi
-  
+
   exit 0
 fi
-
 # Standard Docker run (without Ollama)
 # Build the command
 CMD="docker run -it --rm -v $(pwd)/.env:/app/.env"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -343,7 +343,7 @@ if [ -n "$USE_OLLAMA" ]; then
 
   if [[ "$(docker images -q ai-hedge-fund 2> /dev/null)" == "" ]]; then
     echo "Building AI Hedge Fund image..."
-    docker build -t ai-hedge-fund .
+    docker build -t ai-hedge-fund -f Dockerfile ..
   fi
 
   echo "Running AI Hedge Fund with Ollama using Docker Compose..."

--- a/src/utils/docker.py
+++ b/src/utils/docker.py
@@ -6,8 +6,8 @@ from colorama import Fore, Style
 import questionary
 
 def ensure_ollama_and_model(model_name: str, ollama_url: str) -> bool:
-    """Ensure the Ollama model is available in a Docker environment."""
-    print(f"{Fore.CYAN}Docker environment detected.{Style.RESET_ALL}")
+    """Ensure the Ollama model is available at the target Ollama endpoint."""
+    print(f"{Fore.CYAN}Using Ollama endpoint at {ollama_url}{Style.RESET_ALL}")
     
     # Step 1: Check if Ollama service is available
     if not is_ollama_available(ollama_url):


### PR DESCRIPTION
The current docker installation does not support using an existing Ollama instance. This PR introduces support for an external Ollama endpoint, enhancing the configuration for dynamic endpoint management. 

Update Dockerfile and scripts to ensure correct paths for build context. Improve utilities for checking model availability.