### PR TITLE
Fix growth rate calculations to use CAGR for accurate PEG ratios

### DIFF
--- a/src/agents/phil_fisher.py
+++ b/src/agents/phil_fisher.py
@@ -180,48 +180,52 @@ def analyze_fisher_growth_quality(financial_line_items: list) -> dict:
     details = []
     raw_score = 0  # up to 9 raw points => scale to 0–10
 
-    # 1. Revenue Growth (YoY)
+    # 1. Revenue Growth (annualized CAGR)
     revenues = [fi.revenue for fi in financial_line_items if fi.revenue is not None]
     if len(revenues) >= 2:
-        # We'll look at the earliest vs. latest to gauge multi-year growth if possible
+        # Calculate annualized growth rate (CAGR) for proper comparison
         latest_rev = revenues[0]
         oldest_rev = revenues[-1]
-        if oldest_rev > 0:
-            rev_growth = (latest_rev - oldest_rev) / abs(oldest_rev)
-            if rev_growth > 0.80:
+        num_years = len(revenues) - 1
+        if oldest_rev > 0 and latest_rev > 0:
+            # CAGR formula: (ending_value/beginning_value)^(1/years) - 1
+            rev_growth = (latest_rev / oldest_rev) ** (1 / num_years) - 1
+            if rev_growth > 0.20:  # 20% annualized
                 raw_score += 3
-                details.append(f"Very strong multi-period revenue growth: {rev_growth:.1%}")
-            elif rev_growth > 0.40:
+                details.append(f"Very strong annualized revenue growth: {rev_growth:.1%}")
+            elif rev_growth > 0.10:  # 10% annualized
                 raw_score += 2
-                details.append(f"Moderate multi-period revenue growth: {rev_growth:.1%}")
-            elif rev_growth > 0.10:
+                details.append(f"Moderate annualized revenue growth: {rev_growth:.1%}")
+            elif rev_growth > 0.03:  # 3% annualized
                 raw_score += 1
-                details.append(f"Slight multi-period revenue growth: {rev_growth:.1%}")
+                details.append(f"Slight annualized revenue growth: {rev_growth:.1%}")
             else:
-                details.append(f"Minimal or negative multi-period revenue growth: {rev_growth:.1%}")
+                details.append(f"Minimal or negative annualized revenue growth: {rev_growth:.1%}")
         else:
             details.append("Oldest revenue is zero/negative; cannot compute growth.")
     else:
         details.append("Not enough revenue data points for growth calculation.")
 
-    # 2. EPS Growth (YoY)
+    # 2. EPS Growth (annualized CAGR)
     eps_values = [fi.earnings_per_share for fi in financial_line_items if fi.earnings_per_share is not None]
     if len(eps_values) >= 2:
         latest_eps = eps_values[0]
         oldest_eps = eps_values[-1]
-        if abs(oldest_eps) > 1e-9:
-            eps_growth = (latest_eps - oldest_eps) / abs(oldest_eps)
-            if eps_growth > 0.80:
+        num_years = len(eps_values) - 1
+        if oldest_eps > 0 and latest_eps > 0:
+            # CAGR formula for EPS
+            eps_growth = (latest_eps / oldest_eps) ** (1 / num_years) - 1
+            if eps_growth > 0.20:  # 20% annualized
                 raw_score += 3
-                details.append(f"Very strong multi-period EPS growth: {eps_growth:.1%}")
-            elif eps_growth > 0.40:
+                details.append(f"Very strong annualized EPS growth: {eps_growth:.1%}")
+            elif eps_growth > 0.10:  # 10% annualized
                 raw_score += 2
-                details.append(f"Moderate multi-period EPS growth: {eps_growth:.1%}")
-            elif eps_growth > 0.10:
+                details.append(f"Moderate annualized EPS growth: {eps_growth:.1%}")
+            elif eps_growth > 0.03:  # 3% annualized
                 raw_score += 1
-                details.append(f"Slight multi-period EPS growth: {eps_growth:.1%}")
+                details.append(f"Slight annualized EPS growth: {eps_growth:.1%}")
             else:
-                details.append(f"Minimal or negative multi-period EPS growth: {eps_growth:.1%}")
+                details.append(f"Minimal or negative annualized EPS growth: {eps_growth:.1%}")
         else:
             details.append("Oldest EPS near zero; skipping EPS growth calculation.")
     else:

--- a/src/agents/stanley_druckenmiller.py
+++ b/src/agents/stanley_druckenmiller.py
@@ -177,23 +177,25 @@ def analyze_growth_and_momentum(financial_line_items: list, prices: list) -> dic
     raw_score = 0  # We'll sum up a maximum of 9 raw points, then scale to 0–10
 
     #
-    # 1. Revenue Growth
+    # 1. Revenue Growth (annualized CAGR)
     #
     revenues = [fi.revenue for fi in financial_line_items if fi.revenue is not None]
     if len(revenues) >= 2:
         latest_rev = revenues[0]
         older_rev = revenues[-1]
-        if older_rev > 0:
-            rev_growth = (latest_rev - older_rev) / abs(older_rev)
-            if rev_growth > 0.30:
+        num_years = len(revenues) - 1
+        if older_rev > 0 and latest_rev > 0:
+            # CAGR formula: (ending_value/beginning_value)^(1/years) - 1
+            rev_growth = (latest_rev / older_rev) ** (1 / num_years) - 1
+            if rev_growth > 0.08:  # 8% annualized (adjusted for CAGR)
                 raw_score += 3
-                details.append(f"Strong revenue growth: {rev_growth:.1%}")
-            elif rev_growth > 0.15:
+                details.append(f"Strong annualized revenue growth: {rev_growth:.1%}")
+            elif rev_growth > 0.04:  # 4% annualized
                 raw_score += 2
-                details.append(f"Moderate revenue growth: {rev_growth:.1%}")
-            elif rev_growth > 0.05:
+                details.append(f"Moderate annualized revenue growth: {rev_growth:.1%}")
+            elif rev_growth > 0.01:  # 1% annualized
                 raw_score += 1
-                details.append(f"Slight revenue growth: {rev_growth:.1%}")
+                details.append(f"Slight annualized revenue growth: {rev_growth:.1%}")
             else:
                 details.append(f"Minimal/negative revenue growth: {rev_growth:.1%}")
         else:
@@ -202,26 +204,28 @@ def analyze_growth_and_momentum(financial_line_items: list, prices: list) -> dic
         details.append("Not enough revenue data points for growth calculation.")
 
     #
-    # 2. EPS Growth
+    # 2. EPS Growth (annualized CAGR)
     #
     eps_values = [fi.earnings_per_share for fi in financial_line_items if fi.earnings_per_share is not None]
     if len(eps_values) >= 2:
         latest_eps = eps_values[0]
         older_eps = eps_values[-1]
-        # Avoid division by zero
-        if abs(older_eps) > 1e-9:
-            eps_growth = (latest_eps - older_eps) / abs(older_eps)
-            if eps_growth > 0.30:
+        num_years = len(eps_values) - 1
+        # Calculate CAGR for positive EPS values
+        if older_eps > 0 and latest_eps > 0:
+            # CAGR formula for EPS
+            eps_growth = (latest_eps / older_eps) ** (1 / num_years) - 1
+            if eps_growth > 0.08:  # 8% annualized (adjusted for CAGR)
                 raw_score += 3
-                details.append(f"Strong EPS growth: {eps_growth:.1%}")
-            elif eps_growth > 0.15:
+                details.append(f"Strong annualized EPS growth: {eps_growth:.1%}")
+            elif eps_growth > 0.04:  # 4% annualized
                 raw_score += 2
-                details.append(f"Moderate EPS growth: {eps_growth:.1%}")
-            elif eps_growth > 0.05:
+                details.append(f"Moderate annualized EPS growth: {eps_growth:.1%}")
+            elif eps_growth > 0.01:  # 1% annualized
                 raw_score += 1
-                details.append(f"Slight EPS growth: {eps_growth:.1%}")
+                details.append(f"Slight annualized EPS growth: {eps_growth:.1%}")
             else:
-                details.append(f"Minimal/negative EPS growth: {eps_growth:.1%}")
+                details.append(f"Minimal/negative annualized EPS growth: {eps_growth:.1%}")
         else:
             details.append("Older EPS is near zero; skipping EPS growth calculation.")
     else:


### PR DESCRIPTION
## Summary
- Fixed incorrect growth rate calculations in Peter Lynch, Phil Fisher, and Stanley Druckenmiller agents
- All agents now use annualized growth rates (CAGR) instead of total growth over the period
- This ensures accurate PEG ratio calculations and consistent growth comparisons

## Problem
The agents were calculating total growth over multiple years instead of annualized growth rates. This caused:
1. **Incorrect PEG ratios**: The Peter Lynch agent was dividing P/E by total growth instead of annual growth, making all stocks appear extremely undervalued
2. **Inconsistent comparisons**: Companies with different measurement periods couldn't be fairly compared
3. **Misleading signals**: Growth thresholds were based on total growth, not annual rates

### Example of the issue:
- Stock with EPS growing from $2 to $4 over 5 years
- **Old calculation**: 100% total growth → PEG = 20/100 = 0.20 (appears very undervalued)
- **New calculation**: 14.9% CAGR → PEG = 20/14.9 = 1.34 (fairly valued)

## Solution
Updated all growth calculations to use the CAGR formula:
```
CAGR = (ending_value / beginning_value)^(1/years) - 1
```

### Changes made:
1. **Peter Lynch agent**:
   - Fixed EPS growth rate calculation for PEG ratio
   - Updated revenue growth calculation
   - Improved comments for clarity

2. **Phil Fisher agent**:
   - Updated revenue growth to use CAGR
   - Updated EPS growth to use CAGR
   - Adjusted thresholds for annualized rates

3. **Stanley Druckenmiller agent**:
   - Updated revenue growth to use CAGR  
   - Updated EPS growth to use CAGR
   - Adjusted thresholds for annualized rates
