### PR TITLE
Fix Windows run.bat command parsing

### DIFF
--- a/docker/run.bat
+++ b/docker/run.bat
@@ -14,6 +14,9 @@ set SHOW_REASONING=
 set COMMAND=
 set MODEL_NAME=
 
+:: Jump to argument parsing (skip function definitions)
+goto :main_start
+
 :: Help function
 :show_help
 echo AI Hedge Fund Docker Runner
@@ -48,6 +51,9 @@ echo   run.bat ollama      # Start only the Ollama container
 echo   run.bat pull llama3 # Pull the llama3 model to Ollama
 echo.
 goto :eof
+
+:: Main script entry point
+:main_start
 
 :: Parse arguments
 :parse_args
@@ -407,7 +413,3 @@ echo Running: !CMD!
 
 :: Exit
 exit /b 0
-
-:: Start script execution
-call :parse_args %* 
-


### PR DESCRIPTION
## Summary
Fixes #411 - Windows run.bat script displays help instead of executing commands.

**Root cause:** Script execution flowed directly into `:show_help` function before reaching `:parse_args` because:
1. No jump instruction after variable initialization
2. `call :parse_args %*` at end of file was unreachable (after `exit /b 0`)

**Changes:**
- Add `goto :main_start` after variable initialization to skip function definitions
- Add `:main_start` label before `:parse_args`
- Remove unreachable `call :parse_args %*` at end of file

## Test plan
- Run `run.bat build` - should execute build command instead of showing help
- Run `run.bat --ticker AAPL main` - should run main with ticker argument