### PR TITLE
feat: migrate from financialdatasets.ai to Financial Modeling Prep (F…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # For getting financial data to power the hedge fund
-# Get your Financial Datasets API key from https://financialdatasets.ai/
-FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+# Get your Financial Modeling Prep API key from https://financialmodelingprep.com/
+FMP_API_KEY=your-fmp-api-key
 
 # For running LLMs hosted by openai (GPT 5, etc.)
 # Get your OpenAI API key from https://platform.openai.com/

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Open and edit the `.env` file to add your API keys:
 OPENAI_API_KEY=your-openai-api-key
 
 # For getting financial data to power the hedge fund
-FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+FMP_API_KEY=your-fmp-api-key
 ```
 
 **Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work. 
 
-**Financial Data**: Data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key. For any other ticker, you will need to set the `FINANCIAL_DATASETS_API_KEY` in the .env file.
+**Financial Data**: Data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key. For any other ticker, you will need to set the `FMP_API_KEY` in the .env file.
 
 ## How to Run
 

--- a/app/README.md
+++ b/app/README.md
@@ -105,7 +105,7 @@ OPENAI_API_KEY=your-openai-api-key
 GROQ_API_KEY=your-groq-api-key
 
 # For getting financial data to power the hedge fund
-FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+FMP_API_KEY=your-fmp-api-key
 ```
 
 4. Install Poetry (if not already installed):

--- a/app/backend/README.md
+++ b/app/backend/README.md
@@ -45,7 +45,7 @@ OPENAI_API_KEY=your-openai-api-key
 GROQ_API_KEY=your-groq-api-key
 
 # For getting financial data to power the hedge fund
-FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+FMP_API_KEY=your-fmp-api-key
 ```
 
 ## Running the Server

--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -224,7 +224,7 @@ class BacktestService:
         end_date_dt = datetime.strptime(self.end_date, "%Y-%m-%d")
         start_date_dt = end_date_dt - relativedelta(years=1)
         start_date_str = start_date_dt.strftime("%Y-%m-%d")
-        api_key = self.request.api_keys.get("FINANCIAL_DATASETS_API_KEY")
+        api_key = self.request.api_keys.get("FMP_API_KEY")
 
         for ticker in self.tickers:
             get_prices(ticker, start_date_str, self.end_date, api_key=api_key)

--- a/docker/README.md
+++ b/docker/README.md
@@ -75,12 +75,12 @@ Open and edit the `.env` file to add your API keys:
 OPENAI_API_KEY=your-openai-api-key
 
 # For getting financial data to power the hedge fund
-FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+FMP_API_KEY=your-fmp-api-key
 ```
 
 **Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work. 
 
-**Financial Data**: Data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key. For any other ticker, you will need to set the `FINANCIAL_DATASETS_API_KEY` in the .env file.
+**Financial Data**: Data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key. For any other ticker, you will need to set the `FMP_API_KEY` in the .env file.
 
 ## How to Run
 

--- a/src/agents/aswath_damodaran.py
+++ b/src/agents/aswath_damodaran.py
@@ -36,7 +36,7 @@ def aswath_damodaran_agent(state: AgentState, agent_id: str = "aswath_damodaran_
     data      = state["data"]
     end_date  = data["end_date"]
     tickers   = data["tickers"]
-    api_key  = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key  = get_api_key_from_state(state, "FMP_API_KEY")
 
     analysis_data: dict[str, dict] = {}
     damodaran_signals: dict[str, dict] = {}

--- a/src/agents/ben_graham.py
+++ b/src/agents/ben_graham.py
@@ -28,7 +28,7 @@ def ben_graham_agent(state: AgentState, agent_id: str = "ben_graham_agent"):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     
     analysis_data = {}
     graham_analysis = {}

--- a/src/agents/bill_ackman.py
+++ b/src/agents/bill_ackman.py
@@ -25,7 +25,7 @@ def bill_ackman_agent(state: AgentState, agent_id: str = "bill_ackman_agent"):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     analysis_data = {}
     ackman_analysis = {}
     

--- a/src/agents/cathie_wood.py
+++ b/src/agents/cathie_wood.py
@@ -27,7 +27,7 @@ def cathie_wood_agent(state: AgentState, agent_id: str = "cathie_wood_agent"):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     analysis_data = {}
     cw_analysis = {}
 

--- a/src/agents/charlie_munger.py
+++ b/src/agents/charlie_munger.py
@@ -1,5 +1,6 @@
 from src.graph.state import AgentState, show_agent_reasoning
 from src.tools.api import get_financial_metrics, get_market_cap, search_line_items, get_insider_trades, get_company_news
+from src.tools.sentiment_analyzer import enrich_news_sentiment
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
@@ -23,7 +24,7 @@ def charlie_munger_agent(state: AgentState, agent_id: str = "charlie_munger_agen
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     analysis_data = {}
     munger_analysis = {}
     
@@ -77,6 +78,9 @@ def charlie_munger_agent(state: AgentState, agent_id: str = "charlie_munger_agen
             api_key=api_key,
         )
         
+        # Enrich news with LLM-based sentiment (FMP does not provide sentiment)
+        enrich_news_sentiment(company_news, ticker=ticker, max_articles=5)
+
         progress.update_status(agent_id, ticker, "Analyzing moat strength")
         moat_analysis = analyze_moat_strength(metrics, financial_line_items)
         

--- a/src/agents/fundamentals.py
+++ b/src/agents/fundamentals.py
@@ -13,7 +13,7 @@ def fundamentals_analyst_agent(state: AgentState, agent_id: str = "fundamentals_
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     # Initialize fundamental analysis for each ticker
     fundamental_analysis = {}
 

--- a/src/agents/growth_agent.py
+++ b/src/agents/growth_agent.py
@@ -22,7 +22,7 @@ def growth_analyst_agent(state: AgentState, agent_id: str = "growth_analyst_agen
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     growth_analysis: dict[str, dict] = {}
 
     for ticker in tickers:

--- a/src/agents/michael_burry.py
+++ b/src/agents/michael_burry.py
@@ -16,6 +16,7 @@ from src.tools.api import (
     get_market_cap,
     search_line_items,
 )
+from src.tools.sentiment_analyzer import enrich_news_sentiment
 from src.utils.llm import call_llm
 from src.utils.progress import progress
 from src.utils.api_key import get_api_key_from_state
@@ -31,7 +32,7 @@ class MichaelBurrySignal(BaseModel):
 
 def michael_burry_agent(state: AgentState, agent_id: str = "michael_burry_agent"):
     """Analyse stocks using Michael Burry's deep‑value, contrarian framework."""
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     data = state["data"]
     end_date: str = data["end_date"]  # YYYY‑MM‑DD
     tickers: list[str] = data["tickers"]
@@ -86,6 +87,10 @@ def michael_burry_agent(state: AgentState, agent_id: str = "michael_burry_agent"
 
         progress.update_status(agent_id, ticker, "Analyzing insider activity")
         insider_analysis = _analyze_insider_activity(insider_trades)
+
+        # Enrich news with LLM-based sentiment (FMP does not provide sentiment)
+        progress.update_status(agent_id, ticker, "Enriching news sentiment via LLM")
+        enrich_news_sentiment(news, ticker=ticker, max_articles=10)
 
         progress.update_status(agent_id, ticker, "Analyzing contrarian sentiment")
         contrarian_analysis = _analyze_contrarian_sentiment(news)

--- a/src/agents/mohnish_pabrai.py
+++ b/src/agents/mohnish_pabrai.py
@@ -21,7 +21,7 @@ def mohnish_pabrai_agent(state: AgentState, agent_id: str = "mohnish_pabrai_agen
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
 
     analysis_data: dict[str, any] = {}
     pabrai_analysis: dict[str, any] = {}

--- a/src/agents/news_sentiment.py
+++ b/src/agents/news_sentiment.py
@@ -9,6 +9,7 @@ import json
 
 from src.graph.state import AgentState, show_agent_reasoning
 from src.tools.api import get_company_news
+from src.tools.sentiment_analyzer import analyze_sentiment as openrouter_analyze_sentiment
 from src.utils.api_key import get_api_key_from_state
 from src.utils.llm import call_llm
 from src.utils.progress import progress
@@ -30,6 +31,10 @@ def news_sentiment_agent(state: AgentState, agent_id: str = "news_sentiment_agen
     with missing sentiment data, and then aggregates the sentiments to produce an
     overall signal (bullish, bearish, or neutral) and a confidence score for each ticker.
 
+    Since FMP does not provide sentiment scores, this agent uses:
+      1. The project's configured LLM (via call_llm) as the primary classifier.
+      2. OpenRouter-based SentimentAnalyzer as a fallback.
+
     Args:
         state: The current state of the agent graph.
         agent_id: The ID of the agent.
@@ -40,7 +45,7 @@ def news_sentiment_agent(state: AgentState, agent_id: str = "news_sentiment_agen
     data = state.get("data", {})
     end_date = data.get("end_date")
     tickers = data.get("tickers")
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     sentiment_analysis = {}
 
     for ticker in tickers:
@@ -69,10 +74,9 @@ def news_sentiment_agent(state: AgentState, agent_id: str = "news_sentiment_agen
               progress.update_status(agent_id, ticker, f"Analyzing sentiment for {len(articles_to_analyze)} articles")
               
               for idx, news in enumerate(articles_to_analyze):
-                # We analyze based on title, but can also pass in the entire article text,
-                # but this is more expensive and requires extracting the text from the article.
-                # Note: this is an opportunity for improvement!
                 progress.update_status(agent_id, ticker, f"Analyzing sentiment for article {idx + 1} of {len(articles_to_analyze)}")
+                
+                # Primary: use the project's configured LLM
                 prompt = (
                     f"Please analyze the sentiment of the following news headline "
                     f"with the following context: "
@@ -83,12 +87,16 @@ def news_sentiment_agent(state: AgentState, agent_id: str = "news_sentiment_agen
                     f"Headline: {news.title}"
                 )
                 response = call_llm(prompt, Sentiment, agent_name=agent_id, state=state)
-                if response:
+                
+                if response and hasattr(response, "sentiment"):
                     news.sentiment = response.sentiment.lower()
                     sentiment_confidences[id(news)] = response.confidence
                 else:
-                    news.sentiment = "neutral"
-                    sentiment_confidences[id(news)] = 0
+                    # Fallback: use OpenRouter SentimentAnalyzer
+                    fallback = openrouter_analyze_sentiment(news.title, ticker)
+                    news.sentiment = fallback["sentiment"]
+                    sentiment_confidences[id(news)] = fallback["confidence"]
+                
                 sentiments_classified_by_llm += 1
 
             # Aggregate sentiment across all articles
@@ -176,17 +184,6 @@ def _calculate_confidence_score(
     
     Uses a weighted approach combining LLM confidence scores (70%) with 
     signal proportion (30%) when LLM classifications are available.
-    
-    Args:
-        sentiment_confidences: Dictionary mapping news article IDs to confidence scores.
-        company_news: List of CompanyNews objects.
-        overall_signal: The overall sentiment signal ("bullish", "bearish", or "neutral").
-        bullish_signals: Count of bullish signals.
-        bearish_signals: Count of bearish signals.
-        total_signals: Total number of signals.
-        
-    Returns:
-        Confidence score as a float between 0 and 100.
     """
     if total_signals == 0:
         return 0.0

--- a/src/agents/peter_lynch.py
+++ b/src/agents/peter_lynch.py
@@ -42,7 +42,7 @@ def peter_lynch_agent(state: AgentState, agent_id: str = "peter_lynch_agent"):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     analysis_data = {}
     lynch_analysis = {}
 

--- a/src/agents/phil_fisher.py
+++ b/src/agents/phil_fisher.py
@@ -36,7 +36,7 @@ def phil_fisher_agent(state: AgentState, agent_id: str = "phil_fisher_agent"):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     analysis_data = {}
     fisher_analysis = {}
 

--- a/src/agents/rakesh_jhunjhunwala.py
+++ b/src/agents/rakesh_jhunjhunwala.py
@@ -19,7 +19,7 @@ def rakesh_jhunjhunwala_agent(state: AgentState, agent_id: str = "rakesh_jhunjhu
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     # Collect all analysis for LLM reasoning
     analysis_data = {}
     jhunjhunwala_analysis = {}

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -13,7 +13,7 @@ def risk_management_agent(state: AgentState, agent_id: str = "risk_management_ag
     portfolio = state["data"]["portfolio"]
     data = state["data"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     
     # Initialize risk analysis for each ticker
     risk_analysis = {}

--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -6,6 +6,7 @@ import numpy as np
 import json
 from src.utils.api_key import get_api_key_from_state
 from src.tools.api import get_insider_trades, get_company_news
+from src.tools.sentiment_analyzer import enrich_news_sentiment
 
 
 ##### Sentiment Agent #####
@@ -14,7 +15,7 @@ def sentiment_analyst_agent(state: AgentState, agent_id: str = "sentiment_analys
     data = state.get("data", {})
     end_date = data.get("end_date")
     tickers = data.get("tickers")
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     # Initialize sentiment analysis for each ticker
     sentiment_analysis = {}
 
@@ -39,6 +40,10 @@ def sentiment_analyst_agent(state: AgentState, agent_id: str = "sentiment_analys
 
         # Get the company news
         company_news = get_company_news(ticker, end_date, limit=100, api_key=api_key)
+
+        # Enrich news with LLM-based sentiment (FMP does not provide sentiment)
+        progress.update_status(agent_id, ticker, "Analyzing news sentiment via LLM")
+        enrich_news_sentiment(company_news, ticker=ticker, max_articles=10)
 
         # Get the sentiment from the company news
         sentiment = pd.Series([n.sentiment for n in company_news]).dropna()

--- a/src/agents/stanley_druckenmiller.py
+++ b/src/agents/stanley_druckenmiller.py
@@ -37,7 +37,7 @@ def stanley_druckenmiller_agent(state: AgentState, agent_id: str = "stanley_druc
     start_date = data["start_date"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     analysis_data = {}
     druck_analysis = {}
 

--- a/src/agents/technicals.py
+++ b/src/agents/technicals.py
@@ -45,7 +45,7 @@ def technical_analyst_agent(state: AgentState, agent_id: str = "technical_analys
     start_date = data["start_date"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     # Initialize analysis for each ticker
     technical_analysis = {}
 

--- a/src/agents/valuation.py
+++ b/src/agents/valuation.py
@@ -24,7 +24,7 @@ def valuation_analyst_agent(state: AgentState, agent_id: str = "valuation_analys
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     valuation_analysis: dict[str, dict] = {}
 
     for ticker in tickers:

--- a/src/agents/warren_buffett.py
+++ b/src/agents/warren_buffett.py
@@ -21,7 +21,7 @@ def warren_buffett_agent(state: AgentState, agent_id: str = "warren_buffett_agen
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    api_key = get_api_key_from_state(state, "FMP_API_KEY")
     # Collect all analysis for LLM reasoning
     analysis_data = {}
     buffett_analysis = {}

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -11,6 +11,7 @@ class Price(BaseModel):
 
 
 class PriceResponse(BaseModel):
+    """Kept for backward compatibility; no longer used by FMP adapter."""
     ticker: str
     prices: list[Price]
 
@@ -20,48 +21,49 @@ class FinancialMetrics(BaseModel):
     report_period: str
     period: str
     currency: str
-    market_cap: float | None
-    enterprise_value: float | None
-    price_to_earnings_ratio: float | None
-    price_to_book_ratio: float | None
-    price_to_sales_ratio: float | None
-    enterprise_value_to_ebitda_ratio: float | None
-    enterprise_value_to_revenue_ratio: float | None
-    free_cash_flow_yield: float | None
-    peg_ratio: float | None
-    gross_margin: float | None
-    operating_margin: float | None
-    net_margin: float | None
-    return_on_equity: float | None
-    return_on_assets: float | None
-    return_on_invested_capital: float | None
-    asset_turnover: float | None
-    inventory_turnover: float | None
-    receivables_turnover: float | None
-    days_sales_outstanding: float | None
-    operating_cycle: float | None
-    working_capital_turnover: float | None
-    current_ratio: float | None
-    quick_ratio: float | None
-    cash_ratio: float | None
-    operating_cash_flow_ratio: float | None
-    debt_to_equity: float | None
-    debt_to_assets: float | None
-    interest_coverage: float | None
-    revenue_growth: float | None
-    earnings_growth: float | None
-    book_value_growth: float | None
-    earnings_per_share_growth: float | None
-    free_cash_flow_growth: float | None
-    operating_income_growth: float | None
-    ebitda_growth: float | None
-    payout_ratio: float | None
-    earnings_per_share: float | None
-    book_value_per_share: float | None
-    free_cash_flow_per_share: float | None
+    market_cap: float | None = None
+    enterprise_value: float | None = None
+    price_to_earnings_ratio: float | None = None
+    price_to_book_ratio: float | None = None
+    price_to_sales_ratio: float | None = None
+    enterprise_value_to_ebitda_ratio: float | None = None
+    enterprise_value_to_revenue_ratio: float | None = None
+    free_cash_flow_yield: float | None = None
+    peg_ratio: float | None = None
+    gross_margin: float | None = None
+    operating_margin: float | None = None
+    net_margin: float | None = None
+    return_on_equity: float | None = None
+    return_on_assets: float | None = None
+    return_on_invested_capital: float | None = None
+    asset_turnover: float | None = None
+    inventory_turnover: float | None = None
+    receivables_turnover: float | None = None
+    days_sales_outstanding: float | None = None
+    operating_cycle: float | None = None
+    working_capital_turnover: float | None = None
+    current_ratio: float | None = None
+    quick_ratio: float | None = None
+    cash_ratio: float | None = None
+    operating_cash_flow_ratio: float | None = None
+    debt_to_equity: float | None = None
+    debt_to_assets: float | None = None
+    interest_coverage: float | None = None
+    revenue_growth: float | None = None
+    earnings_growth: float | None = None
+    book_value_growth: float | None = None
+    earnings_per_share_growth: float | None = None
+    free_cash_flow_growth: float | None = None
+    operating_income_growth: float | None = None
+    ebitda_growth: float | None = None
+    payout_ratio: float | None = None
+    earnings_per_share: float | None = None
+    book_value_per_share: float | None = None
+    free_cash_flow_per_share: float | None = None
 
 
 class FinancialMetricsResponse(BaseModel):
+    """Kept for backward compatibility; no longer used by FMP adapter."""
     financial_metrics: list[FinancialMetrics]
 
 
@@ -76,26 +78,28 @@ class LineItem(BaseModel):
 
 
 class LineItemResponse(BaseModel):
+    """Kept for backward compatibility; no longer used by FMP adapter."""
     search_results: list[LineItem]
 
 
 class InsiderTrade(BaseModel):
     ticker: str
-    issuer: str | None
-    name: str | None
-    title: str | None
-    is_board_director: bool | None
-    transaction_date: str | None
-    transaction_shares: float | None
-    transaction_price_per_share: float | None
-    transaction_value: float | None
-    shares_owned_before_transaction: float | None
-    shares_owned_after_transaction: float | None
-    security_title: str | None
-    filing_date: str
+    issuer: str | None = None
+    name: str | None = None
+    title: str | None = None
+    is_board_director: bool | None = None
+    transaction_date: str | None = None
+    transaction_shares: float | None = None
+    transaction_price_per_share: float | None = None
+    transaction_value: float | None = None
+    shares_owned_before_transaction: float | None = None
+    shares_owned_after_transaction: float | None = None
+    security_title: str | None = None
+    filing_date: str = ""
 
 
 class InsiderTradeResponse(BaseModel):
+    """Kept for backward compatibility; no longer used by FMP adapter."""
     insider_trades: list[InsiderTrade]
 
 
@@ -110,10 +114,12 @@ class CompanyNews(BaseModel):
 
 
 class CompanyNewsResponse(BaseModel):
+    """Kept for backward compatibility; no longer used by FMP adapter."""
     news: list[CompanyNews]
 
 
 class CompanyFacts(BaseModel):
+    """Kept for backward compatibility; no longer used by FMP adapter."""
     ticker: str
     name: str
     cik: str | None = None
@@ -135,6 +141,7 @@ class CompanyFacts(BaseModel):
 
 
 class CompanyFactsResponse(BaseModel):
+    """Kept for backward compatibility; no longer used by FMP adapter."""
     company_facts: CompanyFacts
 
 

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -4,93 +4,106 @@ import pandas as pd
 import requests
 import time
 
-from src.data.cache import get_cache
 from src.data.models import (
     CompanyNews,
-    CompanyNewsResponse,
     FinancialMetrics,
-    FinancialMetricsResponse,
     Price,
-    PriceResponse,
     LineItem,
-    LineItemResponse,
     InsiderTrade,
-    InsiderTradeResponse,
-    CompanyFactsResponse,
 )
+
+from src.data.cache import get_cache
 
 # Global cache instance
 _cache = get_cache()
 
+# ---------------------------------------------------------------------------
+# FMP base URL & auth helper
+# ---------------------------------------------------------------------------
+FMP_BASE_URL = "https://financialmodelingprep.com/stable"
 
-def _make_api_request(url: str, headers: dict, method: str = "GET", json_data: dict = None, max_retries: int = 3) -> requests.Response:
+
+def _fmp_params(extra: dict | None = None, api_key: str | None = None) -> dict:
+    """Return query-params dict that always includes the FMP apikey."""
+    key = api_key or os.environ.get("FMP_API_KEY", "")
+    params = {"apikey": key}
+    if extra:
+        params.update(extra)
+    return params
+
+
+# ---------------------------------------------------------------------------
+# Generic request helper with retry / rate-limit handling
+# ---------------------------------------------------------------------------
+
+def _make_api_request(url: str, params: dict = None, max_retries: int = 3) -> requests.Response:
     """
     Make an API request with rate limiting handling and moderate backoff.
-    
-    Args:
-        url: The URL to request
-        headers: Headers to include in the request
-        method: HTTP method (GET or POST)
-        json_data: JSON data for POST requests
-        max_retries: Maximum number of retries (default: 3)
-    
-    Returns:
-        requests.Response: The response object
-    
-    Raises:
-        Exception: If the request fails with a non-429 error
+    FMP uses query-param based auth, so no custom headers needed.
     """
-    for attempt in range(max_retries + 1):  # +1 for initial attempt
-        if method.upper() == "POST":
-            response = requests.post(url, headers=headers, json=json_data)
-        else:
-            response = requests.get(url, headers=headers)
-        
+    for attempt in range(max_retries + 1):
+        response = requests.get(url, params=params)
+
         if response.status_code == 429 and attempt < max_retries:
-            # Linear backoff: 60s, 90s, 120s, 150s...
             delay = 60 + (30 * attempt)
             print(f"Rate limited (429). Attempt {attempt + 1}/{max_retries + 1}. Waiting {delay}s before retrying...")
             time.sleep(delay)
             continue
-        
-        # Return the response (whether success, other errors, or final 429)
+
         return response
 
 
+# ---------------------------------------------------------------------------
+# Prices
+# ---------------------------------------------------------------------------
+
 def get_prices(ticker: str, start_date: str, end_date: str, api_key: str = None) -> list[Price]:
-    """Fetch price data from cache or API."""
-    # Create a cache key that includes all parameters to ensure exact matches
+    """Fetch daily OHLCV price data from FMP."""
     cache_key = f"{ticker}_{start_date}_{end_date}"
-    
-    # Check cache first - simple exact match
+
     if cached_data := _cache.get_prices(cache_key):
         return [Price(**price) for price in cached_data]
 
-    # If not in cache, fetch from API
-    headers = {}
-    financial_api_key = api_key or os.environ.get("FINANCIAL_DATASETS_API_KEY")
-    if financial_api_key:
-        headers["X-API-KEY"] = financial_api_key
+    url = f"{FMP_BASE_URL}/historical-price-eod/full"
+    params = _fmp_params({
+        "symbol": ticker,
+        "from": start_date,
+        "to": end_date,
+    }, api_key)
 
-    url = f"https://api.financialdatasets.ai/prices/?ticker={ticker}&interval=day&interval_multiplier=1&start_date={start_date}&end_date={end_date}"
-    response = _make_api_request(url, headers)
+    response = _make_api_request(url, params)
     if response.status_code != 200:
         return []
 
-    # Parse response with Pydantic model
     try:
-        price_response = PriceResponse(**response.json())
-        prices = price_response.prices
-    except:
+        data = response.json()
+        # FMP returns a list of objects directly
+        if not isinstance(data, list):
+            return []
+        prices = [
+            Price(
+                open=item["open"],
+                close=item["close"],
+                high=item["high"],
+                low=item["low"],
+                volume=int(item["volume"]),
+                time=item["date"],
+            )
+            for item in data
+        ]
+    except Exception:
         return []
 
     if not prices:
         return []
 
-    # Cache the results using the comprehensive cache key
     _cache.set_prices(cache_key, [p.model_dump() for p in prices])
     return prices
 
+
+# ---------------------------------------------------------------------------
+# Financial Metrics  (combines FMP /ratios, /key-metrics, /financial-growth)
+# ---------------------------------------------------------------------------
 
 def get_financial_metrics(
     ticker: str,
@@ -99,38 +112,155 @@ def get_financial_metrics(
     limit: int = 10,
     api_key: str = None,
 ) -> list[FinancialMetrics]:
-    """Fetch financial metrics from cache or API."""
-    # Create a cache key that includes all parameters to ensure exact matches
+    """Fetch financial metrics by merging FMP ratios, key-metrics, and growth data."""
     cache_key = f"{ticker}_{period}_{end_date}_{limit}"
-    
-    # Check cache first - simple exact match
+
     if cached_data := _cache.get_financial_metrics(cache_key):
         return [FinancialMetrics(**metric) for metric in cached_data]
 
-    # If not in cache, fetch from API
-    headers = {}
-    financial_api_key = api_key or os.environ.get("FINANCIAL_DATASETS_API_KEY")
-    if financial_api_key:
-        headers["X-API-KEY"] = financial_api_key
+    # Map period names: the old API used "ttm"/"annual"/"quarterly"
+    # FMP uses "annual"/"quarter" for statements; for ratios/key-metrics it
+    # also supports "quarter" and "annual" (no "ttm" param – annual is closest).
+    fmp_period = "quarter" if period == "quarterly" else "annual"
 
-    url = f"https://api.financialdatasets.ai/financial-metrics/?ticker={ticker}&report_period_lte={end_date}&limit={limit}&period={period}"
-    response = _make_api_request(url, headers)
-    if response.status_code != 200:
+    # --- Ratios ---
+    ratios_url = f"{FMP_BASE_URL}/ratios"
+    ratios_params = _fmp_params({"symbol": ticker, "period": fmp_period, "limit": limit}, api_key)
+    ratios_resp = _make_api_request(ratios_url, ratios_params)
+    ratios_list = ratios_resp.json() if ratios_resp.status_code == 200 else []
+    if not isinstance(ratios_list, list):
+        ratios_list = []
+
+    # --- Key Metrics ---
+    km_url = f"{FMP_BASE_URL}/key-metrics"
+    km_params = _fmp_params({"symbol": ticker, "period": fmp_period, "limit": limit}, api_key)
+    km_resp = _make_api_request(km_url, km_params)
+    km_list = km_resp.json() if km_resp.status_code == 200 else []
+    if not isinstance(km_list, list):
+        km_list = []
+
+    # --- Financial Growth ---
+    growth_url = f"{FMP_BASE_URL}/financial-growth"
+    growth_params = _fmp_params({"symbol": ticker, "period": fmp_period, "limit": limit}, api_key)
+    growth_resp = _make_api_request(growth_url, growth_params)
+    growth_list = growth_resp.json() if growth_resp.status_code == 200 else []
+    if not isinstance(growth_list, list):
+        growth_list = []
+
+    # Index by date for merging
+    ratios_by_date = {r.get("date"): r for r in ratios_list}
+    km_by_date = {k.get("date"): k for k in km_list}
+    growth_by_date = {g.get("date"): g for g in growth_list}
+
+    all_dates = sorted(
+        set(list(ratios_by_date.keys()) + list(km_by_date.keys()) + list(growth_by_date.keys())),
+        reverse=True,
+    )
+
+    # Filter dates <= end_date
+    all_dates = [d for d in all_dates if d and d <= end_date][:limit]
+
+    metrics = []
+    for date in all_dates:
+        r = ratios_by_date.get(date, {})
+        k = km_by_date.get(date, {})
+        g = growth_by_date.get(date, {})
+
+        metrics.append(FinancialMetrics(
+            ticker=ticker,
+            report_period=date,
+            period=period,
+            currency=r.get("reportedCurrency") or k.get("reportedCurrency") or "USD",
+            market_cap=k.get("marketCap"),
+            enterprise_value=k.get("enterpriseValue"),
+            price_to_earnings_ratio=r.get("priceToEarningsRatio"),
+            price_to_book_ratio=r.get("priceToBookRatio"),
+            price_to_sales_ratio=r.get("priceToSalesRatio"),
+            enterprise_value_to_ebitda_ratio=r.get("enterpriseValueMultiple"),
+            enterprise_value_to_revenue_ratio=k.get("evToSales"),
+            free_cash_flow_yield=k.get("freeCashFlowYield"),
+            peg_ratio=r.get("priceToEarningsGrowthRatio"),
+            gross_margin=r.get("grossProfitMargin"),
+            operating_margin=r.get("operatingProfitMargin"),
+            net_margin=r.get("netProfitMargin"),
+            return_on_equity=k.get("returnOnEquity"),
+            return_on_assets=k.get("returnOnAssets"),
+            return_on_invested_capital=k.get("returnOnInvestedCapital"),
+            asset_turnover=r.get("assetTurnover"),
+            inventory_turnover=r.get("inventoryTurnover"),
+            receivables_turnover=r.get("receivablesTurnover"),
+            days_sales_outstanding=k.get("daysOfSalesOutstanding"),
+            operating_cycle=k.get("operatingCycle"),
+            working_capital_turnover=r.get("workingCapitalTurnoverRatio"),
+            current_ratio=k.get("currentRatio") or r.get("currentRatio"),
+            quick_ratio=r.get("quickRatio"),
+            cash_ratio=r.get("cashRatio"),
+            operating_cash_flow_ratio=r.get("operatingCashFlowRatio"),
+            debt_to_equity=r.get("debtToEquityRatio"),
+            debt_to_assets=r.get("debtToAssetsRatio"),
+            interest_coverage=r.get("interestCoverageRatio"),
+            revenue_growth=g.get("revenueGrowth"),
+            earnings_growth=g.get("netIncomeGrowth"),
+            book_value_growth=g.get("bookValueperShareGrowth"),
+            earnings_per_share_growth=g.get("epsgrowth"),
+            free_cash_flow_growth=g.get("freeCashFlowGrowth"),
+            operating_income_growth=g.get("operatingIncomeGrowth"),
+            ebitda_growth=g.get("ebitdaGrowth"),
+            payout_ratio=r.get("dividendPayoutRatio"),
+            earnings_per_share=r.get("netIncomePerShare"),
+            book_value_per_share=r.get("bookValuePerShare"),
+            free_cash_flow_per_share=r.get("freeCashFlowPerShare"),
+        ))
+
+    if not metrics:
         return []
 
-    # Parse response with Pydantic model
-    try:
-        metrics_response = FinancialMetricsResponse(**response.json())
-        financial_metrics = metrics_response.financial_metrics
-    except:
-        return []
+    _cache.set_financial_metrics(cache_key, [m.model_dump() for m in metrics])
+    return metrics
 
-    if not financial_metrics:
-        return []
 
-    # Cache the results as dicts using the comprehensive cache key
-    _cache.set_financial_metrics(cache_key, [m.model_dump() for m in financial_metrics])
-    return financial_metrics
+# ---------------------------------------------------------------------------
+# Line Items  (replaces POST /financials/search/line-items)
+# ---------------------------------------------------------------------------
+
+# Mapping from snake_case line-item names used by agents → (FMP endpoint suffix, FMP camelCase key)
+_LINE_ITEM_MAP: dict[str, tuple[str, str]] = {
+    # Income Statement
+    "revenue":                              ("income-statement", "revenue"),
+    "net_income":                           ("income-statement", "netIncome"),
+    "operating_income":                     ("income-statement", "operatingIncome"),
+    "ebit":                                 ("income-statement", "ebit"),
+    "ebitda":                               ("income-statement", "ebitda"),
+    "interest_expense":                     ("income-statement", "interestExpense"),
+    "gross_profit":                         ("income-statement", "grossProfit"),
+    "operating_expense":                    ("income-statement", "operatingExpenses"),
+    "research_and_development":             ("income-statement", "researchAndDevelopmentExpenses"),
+    "earnings_per_share":                   ("income-statement", "eps"),
+    "outstanding_shares":                   ("income-statement", "weightedAverageShsOut"),
+    # Balance Sheet
+    "total_assets":                         ("balance-sheet-statement", "totalAssets"),
+    "total_liabilities":                    ("balance-sheet-statement", "totalLiabilities"),
+    "current_assets":                       ("balance-sheet-statement", "totalCurrentAssets"),
+    "current_liabilities":                  ("balance-sheet-statement", "totalCurrentLiabilities"),
+    "shareholders_equity":                  ("balance-sheet-statement", "totalStockholdersEquity"),
+    "total_debt":                           ("balance-sheet-statement", "totalDebt"),
+    "cash_and_equivalents":                 ("balance-sheet-statement", "cashAndCashEquivalents"),
+    "goodwill_and_intangible_assets":       ("balance-sheet-statement", "goodwillAndIntangibleAssets"),
+    "intangible_assets":                    ("balance-sheet-statement", "intangibleAssets"),
+    # Cash Flow Statement
+    "free_cash_flow":                       ("cash-flow-statement", "freeCashFlow"),
+    "capital_expenditure":                  ("cash-flow-statement", "capitalExpenditure"),
+    "depreciation_and_amortization":        ("cash-flow-statement", "depreciationAndAmortization"),
+    "dividends_and_other_cash_distributions": ("cash-flow-statement", "netDividendsPaid"),
+    "issuance_or_purchase_of_equity_shares": ("cash-flow-statement", "netStockIssuance"),
+    # Derived / Key Metrics
+    "working_capital":                      ("key-metrics", "workingCapital"),
+    "gross_margin":                         ("ratios", "grossProfitMargin"),
+    "operating_margin":                     ("ratios", "operatingProfitMargin"),
+    "book_value_per_share":                 ("ratios", "bookValuePerShare"),
+    "debt_to_equity":                       ("ratios", "debtToEquityRatio"),
+    "return_on_invested_capital":           ("key-metrics", "returnOnInvestedCapital"),
+}
 
 
 def search_line_items(
@@ -141,38 +271,104 @@ def search_line_items(
     limit: int = 10,
     api_key: str = None,
 ) -> list[LineItem]:
-    """Fetch line items from API."""
-    # If not in cache or insufficient data, fetch from API
-    headers = {}
-    financial_api_key = api_key or os.environ.get("FINANCIAL_DATASETS_API_KEY")
-    if financial_api_key:
-        headers["X-API-KEY"] = financial_api_key
+    """
+    Replaces the old POST /financials/search/line-items by fetching the
+    required FMP statement endpoints and extracting the requested fields.
+    """
+    fmp_period = "quarter" if period == "quarterly" else "annual"
 
-    url = "https://api.financialdatasets.ai/financials/search/line-items"
+    # Determine which FMP endpoints we need
+    needed_endpoints: set[str] = set()
+    for item in line_items:
+        if item in _LINE_ITEM_MAP:
+            needed_endpoints.add(_LINE_ITEM_MAP[item][0])
+        # If not in map, we still try income-statement as fallback
+        else:
+            needed_endpoints.add("income-statement")
 
-    body = {
-        "tickers": [ticker],
-        "line_items": line_items,
-        "end_date": end_date,
-        "period": period,
-        "limit": limit,
-    }
-    response = _make_api_request(url, headers, method="POST", json_data=body)
-    if response.status_code != 200:
-        return []
-    
-    try:
-        data = response.json()
-        response_model = LineItemResponse(**data)
-        search_results = response_model.search_results
-    except:
-        return []
-    if not search_results:
-        return []
+    # Fetch each endpoint once
+    endpoint_data: dict[str, list[dict]] = {}
+    for ep in needed_endpoints:
+        url = f"{FMP_BASE_URL}/{ep}"
+        params = _fmp_params({"symbol": ticker, "period": fmp_period, "limit": limit}, api_key)
+        resp = _make_api_request(url, params)
+        if resp.status_code == 200:
+            data = resp.json()
+            if isinstance(data, list):
+                endpoint_data[ep] = data
+            else:
+                endpoint_data[ep] = []
+        else:
+            endpoint_data[ep] = []
 
-    # Cache the results
-    return search_results[:limit]
+    # Determine the set of report dates available (use the first endpoint that has data)
+    all_dates: list[str] = []
+    for ep_records in endpoint_data.values():
+        for rec in ep_records:
+            d = rec.get("date")
+            if d and d not in all_dates:
+                all_dates.append(d)
+    all_dates = sorted(set(all_dates), reverse=True)
+    all_dates = [d for d in all_dates if d <= end_date][:limit]
 
+    # Index endpoint data by date
+    indexed: dict[str, dict[str, dict]] = {}  # date -> endpoint -> record
+    for ep, records in endpoint_data.items():
+        for rec in records:
+            d = rec.get("date")
+            if d:
+                indexed.setdefault(d, {})[ep] = rec
+
+    results: list[LineItem] = []
+    for date in all_dates:
+        ep_records = indexed.get(date, {})
+        extra_fields: dict[str, any] = {}
+
+        for item_name in line_items:
+            if item_name in _LINE_ITEM_MAP:
+                ep, fmp_key = _LINE_ITEM_MAP[item_name]
+                rec = ep_records.get(ep, {})
+                extra_fields[item_name] = rec.get(fmp_key)
+            else:
+                # Try to find the camelCase version in any available endpoint
+                camel = _snake_to_camel(item_name)
+                found = False
+                for rec in ep_records.values():
+                    if camel in rec:
+                        extra_fields[item_name] = rec[camel]
+                        found = True
+                        break
+                if not found:
+                    extra_fields[item_name] = None
+
+        # Determine currency from any available record
+        currency = "USD"
+        for rec in ep_records.values():
+            if "reportedCurrency" in rec:
+                currency = rec["reportedCurrency"]
+                break
+
+        li = LineItem(
+            ticker=ticker,
+            report_period=date,
+            period=period,
+            currency=currency,
+            **extra_fields,
+        )
+        results.append(li)
+
+    return results[:limit]
+
+
+def _snake_to_camel(name: str) -> str:
+    """Convert snake_case to camelCase."""
+    parts = name.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+# ---------------------------------------------------------------------------
+# Insider Trades
+# ---------------------------------------------------------------------------
 
 def get_insider_trades(
     ticker: str,
@@ -181,63 +377,89 @@ def get_insider_trades(
     limit: int = 1000,
     api_key: str = None,
 ) -> list[InsiderTrade]:
-    """Fetch insider trades from cache or API."""
-    # Create a cache key that includes all parameters to ensure exact matches
+    """Fetch insider trades from FMP."""
     cache_key = f"{ticker}_{start_date or 'none'}_{end_date}_{limit}"
-    
-    # Check cache first - simple exact match
+
     if cached_data := _cache.get_insider_trades(cache_key):
         return [InsiderTrade(**trade) for trade in cached_data]
 
-    # If not in cache, fetch from API
-    headers = {}
-    financial_api_key = api_key or os.environ.get("FINANCIAL_DATASETS_API_KEY")
-    if financial_api_key:
-        headers["X-API-KEY"] = financial_api_key
+    url = f"{FMP_BASE_URL}/insider-trading/search"
+    params = _fmp_params({"symbol": ticker, "limit": min(limit, 500)}, api_key)
 
-    all_trades = []
-    current_end_date = end_date
+    all_trades: list[InsiderTrade] = []
+    page = 0
 
     while True:
-        url = f"https://api.financialdatasets.ai/insider-trades/?ticker={ticker}&filing_date_lte={current_end_date}"
-        if start_date:
-            url += f"&filing_date_gte={start_date}"
-        url += f"&limit={limit}"
-
-        response = _make_api_request(url, headers)
+        params["page"] = page
+        response = _make_api_request(url, params)
         if response.status_code != 200:
             break
 
         try:
             data = response.json()
-            response_model = InsiderTradeResponse(**data)
-            insider_trades = response_model.insider_trades
-        except:
-            break  # Parsing error, exit loop
-
-        if not insider_trades:
+            if not isinstance(data, list) or not data:
+                break
+        except Exception:
             break
 
-        all_trades.extend(insider_trades)
+        for item in data:
+            filing_date = (item.get("filingDate") or "").split(" ")[0]
+            transaction_date = (item.get("transactionDate") or "").split(" ")[0]
 
-        # Only continue pagination if we have a start_date and got a full page
-        if not start_date or len(insider_trades) < limit:
+            # Filter by date range
+            if filing_date and filing_date > end_date:
+                continue
+            if start_date and filing_date and filing_date < start_date:
+                continue
+
+            # Determine transaction value
+            shares = item.get("securitiesTransacted")
+            price = item.get("price")
+            tx_value = None
+            if shares is not None and price is not None:
+                try:
+                    tx_value = float(shares) * float(price)
+                except (ValueError, TypeError):
+                    pass
+
+            # Determine if board director from typeOfOwner
+            type_of_owner = (item.get("typeOfOwner") or "").lower()
+            is_board = "director" in type_of_owner
+
+            trade = InsiderTrade(
+                ticker=ticker,
+                issuer=None,
+                name=item.get("reportingName"),
+                title=item.get("typeOfOwner"),
+                is_board_director=is_board,
+                transaction_date=transaction_date or None,
+                transaction_shares=float(shares) if shares is not None else None,
+                transaction_price_per_share=float(price) if price is not None else None,
+                transaction_value=tx_value,
+                shares_owned_before_transaction=None,
+                shares_owned_after_transaction=float(item["securitiesOwned"]) if item.get("securitiesOwned") is not None else None,
+                security_title=item.get("securityName"),
+                filing_date=filing_date,
+            )
+            all_trades.append(trade)
+
+        # Stop if we have enough or the page was not full
+        if len(all_trades) >= limit or len(data) < 500:
             break
+        page += 1
 
-        # Update end_date to the oldest filing date from current batch for next iteration
-        current_end_date = min(trade.filing_date for trade in insider_trades).split("T")[0]
-
-        # If we've reached or passed the start_date, we can stop
-        if current_end_date <= start_date:
-            break
+    all_trades = all_trades[:limit]
 
     if not all_trades:
         return []
 
-    # Cache the results using the comprehensive cache key
     _cache.set_insider_trades(cache_key, [trade.model_dump() for trade in all_trades])
     return all_trades
 
+
+# ---------------------------------------------------------------------------
+# Company News
+# ---------------------------------------------------------------------------
 
 def get_company_news(
     ticker: str,
@@ -246,99 +468,104 @@ def get_company_news(
     limit: int = 1000,
     api_key: str = None,
 ) -> list[CompanyNews]:
-    """Fetch company news from cache or API."""
-    # Create a cache key that includes all parameters to ensure exact matches
+    """Fetch company news from FMP."""
     cache_key = f"{ticker}_{start_date or 'none'}_{end_date}_{limit}"
-    
-    # Check cache first - simple exact match
+
     if cached_data := _cache.get_company_news(cache_key):
         return [CompanyNews(**news) for news in cached_data]
 
-    # If not in cache, fetch from API
-    headers = {}
-    financial_api_key = api_key or os.environ.get("FINANCIAL_DATASETS_API_KEY")
-    if financial_api_key:
-        headers["X-API-KEY"] = financial_api_key
+    url = f"{FMP_BASE_URL}/news/stock"
+    params = _fmp_params({
+        "symbols": ticker,
+        "limit": min(limit, 100),
+        "page": 0,
+    }, api_key)
 
-    all_news = []
-    current_end_date = end_date
+    all_news: list[CompanyNews] = []
+    page = 0
 
     while True:
-        url = f"https://api.financialdatasets.ai/news/?ticker={ticker}&end_date={current_end_date}"
-        if start_date:
-            url += f"&start_date={start_date}"
-        url += f"&limit={limit}"
-
-        response = _make_api_request(url, headers)
+        params["page"] = page
+        response = _make_api_request(url, params)
         if response.status_code != 200:
             break
 
         try:
             data = response.json()
-            response_model = CompanyNewsResponse(**data)
-            company_news = response_model.news
-        except:
-            break  # Parsing error, exit loop
-
-        if not company_news:
+            if not isinstance(data, list) or not data:
+                break
+        except Exception:
             break
 
-        all_news.extend(company_news)
+        for item in data:
+            pub_date = (item.get("publishedDate") or "").split(" ")[0]
 
-        # Only continue pagination if we have a start_date and got a full page
-        if not start_date or len(company_news) < limit:
+            # Filter by date range
+            if pub_date and pub_date > end_date:
+                continue
+            if start_date and pub_date and pub_date < start_date:
+                continue
+
+            news = CompanyNews(
+                ticker=ticker,
+                title=item.get("title", ""),
+                author=item.get("publisher", ""),
+                source=item.get("site", ""),
+                date=pub_date,
+                url=item.get("url", ""),
+                sentiment=None,  # FMP does not provide sentiment; filled by SentimentAnalyzer
+            )
+            all_news.append(news)
+
+        if len(all_news) >= limit or len(data) < 100:
             break
+        page += 1
 
-        # Update end_date to the oldest date from current batch for next iteration
-        current_end_date = min(news.date for news in company_news).split("T")[0]
-
-        # If we've reached or passed the start_date, we can stop
-        if current_end_date <= start_date:
-            break
+    all_news = all_news[:limit]
 
     if not all_news:
         return []
 
-    # Cache the results using the comprehensive cache key
     _cache.set_company_news(cache_key, [news.model_dump() for news in all_news])
     return all_news
 
+
+# ---------------------------------------------------------------------------
+# Market Cap
+# ---------------------------------------------------------------------------
 
 def get_market_cap(
     ticker: str,
     end_date: str,
     api_key: str = None,
 ) -> float | None:
-    """Fetch market cap from the API."""
-    # Check if end_date is today
+    """Fetch market cap from FMP."""
     if end_date == datetime.datetime.now().strftime("%Y-%m-%d"):
-        # Get the market cap from company facts API
-        headers = {}
-        financial_api_key = api_key or os.environ.get("FINANCIAL_DATASETS_API_KEY")
-        if financial_api_key:
-            headers["X-API-KEY"] = financial_api_key
-
-        url = f"https://api.financialdatasets.ai/company/facts/?ticker={ticker}"
-        response = _make_api_request(url, headers)
+        # Use company profile for real-time market cap
+        url = f"{FMP_BASE_URL}/profile"
+        params = _fmp_params({"symbol": ticker}, api_key)
+        response = _make_api_request(url, params)
         if response.status_code != 200:
-            print(f"Error fetching company facts: {ticker} - {response.status_code}")
             return None
-
-        data = response.json()
-        response_model = CompanyFactsResponse(**data)
-        return response_model.company_facts.market_cap
+        try:
+            data = response.json()
+            if isinstance(data, list) and data:
+                return data[0].get("marketCap")
+            return None
+        except Exception:
+            return None
 
     financial_metrics = get_financial_metrics(ticker, end_date, api_key=api_key)
     if not financial_metrics:
         return None
 
     market_cap = financial_metrics[0].market_cap
+    return market_cap if market_cap else None
 
-    if not market_cap:
-        return None
 
-    return market_cap
-
+# ---------------------------------------------------------------------------
+# DataFrame helpers
+# ---------------------------------------------------------------------------
 
 def prices_to_df(prices: list[Price]) -> pd.DataFrame:
     """Convert prices to a DataFrame."""
@@ -352,7 +579,6 @@ def prices_to_df(prices: list[Price]) -> pd.DataFrame:
     return df
 
 
-# Update the get_price_data function to use the new functions
 def get_price_data(ticker: str, start_date: str, end_date: str, api_key: str = None) -> pd.DataFrame:
     prices = get_prices(ticker, start_date, end_date, api_key=api_key)
     return prices_to_df(prices)

--- a/src/tools/sentiment_analyzer.py
+++ b/src/tools/sentiment_analyzer.py
@@ -1,0 +1,234 @@
+"""
+SentimentAnalyzer – LLM-powered news sentiment scoring via OpenRouter.
+
+This module bridges the gap left by FMP's news endpoint, which does not
+provide sentiment scores.  It takes CompanyNews objects (title + metadata)
+and returns a normalised sentiment label ("positive" / "negative" / "neutral")
+together with a confidence score (0-100).
+
+The module is designed to be called from:
+  • news_sentiment_agent  – classifies articles without pre-existing sentiment
+  • sentiment_analyst_agent – enriches news before aggregation
+  • michael_burry agent   – contrarian sentiment analysis
+  • charlie_munger agent  – qualitative news review
+
+Usage
+-----
+    from src.tools.sentiment_analyzer import enrich_news_sentiment
+
+    # Mutates each CompanyNews.sentiment in-place and returns confidence map
+    confidences = enrich_news_sentiment(news_list, ticker="AAPL", max_articles=5)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import TYPE_CHECKING
+
+import requests
+
+if TYPE_CHECKING:
+    from src.data.models import CompanyNews
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Preferred models in order of priority
+_OPENROUTER_MODELS = [
+    "google/gemini-2.0-flash-001",
+    "anthropic/claude-3.5-sonnet",
+]
+
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def _get_openrouter_key() -> str:
+    """Resolve the OpenRouter API key from the environment."""
+    key = os.environ.get("OPENROUTER_API_KEY", "")
+    if not key:
+        print("[SentimentAnalyzer] WARNING: OPENROUTER_API_KEY not set.")
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Core LLM call
+# ---------------------------------------------------------------------------
+
+def _call_openrouter(
+    prompt: str,
+    model: str | None = None,
+    max_retries: int = 2,
+) -> dict | None:
+    """
+    Call OpenRouter chat-completions and return parsed JSON.
+
+    Returns a dict like {"sentiment": "positive", "confidence": 82}
+    or None on failure.
+    """
+    api_key = _get_openrouter_key()
+    if not api_key:
+        return None
+
+    model = model or _OPENROUTER_MODELS[0]
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://github.com/ShutongSun/ai-hedge-fund",
+        "X-Title": "AI Hedge Fund – Sentiment Analyzer",
+    }
+
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a financial sentiment classifier. "
+                    "Given a news headline about a stock, determine the sentiment "
+                    "as 'positive', 'negative', or 'neutral' for the stock only. "
+                    "Also provide a confidence score from 0 to 100. "
+                    "Respond ONLY with valid JSON: "
+                    '{"sentiment": "<positive|negative|neutral>", "confidence": <0-100>}'
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 80,
+    }
+
+    for attempt in range(max_retries + 1):
+        try:
+            resp = requests.post(
+                _OPENROUTER_BASE_URL,
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+
+            if resp.status_code == 429 and attempt < max_retries:
+                time.sleep(2 + attempt * 2)
+                continue
+
+            if resp.status_code != 200:
+                print(f"[SentimentAnalyzer] OpenRouter error {resp.status_code}: {resp.text[:200]}")
+                # Try fallback model on first failure
+                if attempt == 0 and model == _OPENROUTER_MODELS[0] and len(_OPENROUTER_MODELS) > 1:
+                    model = _OPENROUTER_MODELS[1]
+                    payload["model"] = model
+                    continue
+                return None
+
+            data = resp.json()
+            content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+
+            # Parse JSON from response – handle markdown-wrapped JSON
+            content = content.strip()
+            if content.startswith("```"):
+                # Strip markdown code fences
+                lines = content.split("\n")
+                content = "\n".join(
+                    l for l in lines if not l.strip().startswith("```")
+                ).strip()
+
+            result = json.loads(content)
+
+            # Validate
+            sentiment = result.get("sentiment", "neutral").lower()
+            if sentiment not in ("positive", "negative", "neutral"):
+                sentiment = "neutral"
+            confidence = int(result.get("confidence", 50))
+            confidence = max(0, min(100, confidence))
+
+            return {"sentiment": sentiment, "confidence": confidence}
+
+        except json.JSONDecodeError:
+            # Try to extract sentiment from free-text response
+            if content:
+                lower = content.lower()
+                if "positive" in lower:
+                    return {"sentiment": "positive", "confidence": 50}
+                elif "negative" in lower:
+                    return {"sentiment": "negative", "confidence": 50}
+            return {"sentiment": "neutral", "confidence": 30}
+        except Exception as e:
+            print(f"[SentimentAnalyzer] Error: {e}")
+            if attempt < max_retries:
+                time.sleep(1)
+                continue
+            return None
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def analyze_sentiment(title: str, ticker: str) -> dict:
+    """
+    Analyze the sentiment of a single news headline.
+
+    Parameters
+    ----------
+    title : str
+        The news headline text.
+    ticker : str
+        The stock ticker symbol for context.
+
+    Returns
+    -------
+    dict
+        {"sentiment": "positive"|"negative"|"neutral", "confidence": 0-100}
+    """
+    prompt = (
+        f"The stock is {ticker}. "
+        f"Analyze the sentiment of this headline for {ticker}:\n\n"
+        f'"{title}"'
+    )
+    result = _call_openrouter(prompt)
+    if result is None:
+        return {"sentiment": "neutral", "confidence": 0}
+    return result
+
+
+def enrich_news_sentiment(
+    news_items: list["CompanyNews"],
+    ticker: str,
+    max_articles: int = 5,
+) -> dict[int, int]:
+    """
+    Enrich a list of CompanyNews objects with sentiment labels in-place.
+
+    Only articles whose ``sentiment`` field is ``None`` are analyzed.
+    At most ``max_articles`` will be sent to the LLM to control costs.
+
+    Parameters
+    ----------
+    news_items : list[CompanyNews]
+        Mutable list – each item's ``.sentiment`` will be set.
+    ticker : str
+        Stock ticker for context.
+    max_articles : int
+        Maximum number of articles to classify via LLM.
+
+    Returns
+    -------
+    dict[int, int]
+        Mapping of ``id(news_item)`` → confidence score (0-100) for each
+        article that was classified by the LLM.
+    """
+    confidences: dict[int, int] = {}
+    articles_to_analyze = [n for n in news_items if n.sentiment is None][:max_articles]
+
+    for news in articles_to_analyze:
+        result = analyze_sentiment(news.title, ticker)
+        news.sentiment = result["sentiment"]
+        confidences[id(news)] = result["confidence"]
+
+    return confidences

--- a/tests/test_api_rate_limiting.py
+++ b/tests/test_api_rate_limiting.py
@@ -5,13 +5,12 @@ from unittest.mock import Mock, patch, call
 from src.tools.api import _make_api_request, get_prices
 
 class TestRateLimiting:
-    """Test suite for API rate limiting functionality."""
+    """Test suite for API rate limiting functionality (FMP adapter)."""
 
     @patch('src.tools.api.time.sleep')
     @patch('src.tools.api.requests.get')
     def test_handles_single_rate_limit(self, mock_get, mock_sleep):
         """Test that API retries once after a 429 and succeeds."""
-        # Setup mock responses: first 429, then 200
         mock_429_response = Mock()
         mock_429_response.status_code = 429
         
@@ -21,31 +20,20 @@ class TestRateLimiting:
         
         mock_get.side_effect = [mock_429_response, mock_200_response]
         
-        # Call the function
-        headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://financialmodelingprep.com/stable/test"
+        params = {"apikey": "test-key"}
         
-        result = _make_api_request(url, headers)
+        result = _make_api_request(url, params)
         
-        # Verify behavior
         assert result.status_code == 200
         assert result.text == "Success"
-        
-        # Verify requests.get was called twice
         assert mock_get.call_count == 2
-        mock_get.assert_has_calls([
-            call(url, headers=headers),
-            call(url, headers=headers)
-        ])
-        
-        # Verify sleep was called once with 60 seconds (first retry)
         mock_sleep.assert_called_once_with(60)
 
     @patch('src.tools.api.time.sleep')
     @patch('src.tools.api.requests.get')
     def test_handles_multiple_rate_limits(self, mock_get, mock_sleep):
         """Test that API retries multiple times after 429s."""
-        # Setup mock responses: three 429s, then 200
         mock_429_response = Mock()
         mock_429_response.status_code = 429
         
@@ -60,111 +48,56 @@ class TestRateLimiting:
             mock_200_response
         ]
         
-        # Call the function
-        headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://financialmodelingprep.com/stable/test"
+        params = {"apikey": "test-key"}
         
-        result = _make_api_request(url, headers)
+        result = _make_api_request(url, params)
         
-        # Verify behavior
         assert result.status_code == 200
         assert result.text == "Success"
-        
-        # Verify requests.get was called 4 times
         assert mock_get.call_count == 4
-        
-        # Verify sleep was called 3 times with linear backoff: 60s, 90s, 120s
         assert mock_sleep.call_count == 3
         expected_calls = [call(60), call(90), call(120)]
         mock_sleep.assert_has_calls(expected_calls)
 
     @patch('src.tools.api.time.sleep')
-    @patch('src.tools.api.requests.post')
-    def test_handles_post_rate_limiting(self, mock_post, mock_sleep):
-        """Test that POST requests handle rate limiting."""
-        # Setup mock responses: first 429, then 200
-        mock_429_response = Mock()
-        mock_429_response.status_code = 429
-        
-        mock_200_response = Mock()
-        mock_200_response.status_code = 200
-        mock_200_response.text = "Success"
-        
-        mock_post.side_effect = [mock_429_response, mock_200_response]
-        
-        # Call the function with POST method
-        headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
-        json_data = {"test": "data"}
-        
-        result = _make_api_request(url, headers, method="POST", json_data=json_data)
-        
-        # Verify behavior
-        assert result.status_code == 200
-        assert result.text == "Success"
-        
-        # Verify requests.post was called twice
-        assert mock_post.call_count == 2
-        mock_post.assert_has_calls([
-            call(url, headers=headers, json=json_data),
-            call(url, headers=headers, json=json_data)
-        ])
-        
-        # Verify sleep was called once with 60 seconds (first retry)
-        mock_sleep.assert_called_once_with(60)
-
-    @patch('src.tools.api.time.sleep')
     @patch('src.tools.api.requests.get')
     def test_ignores_other_errors(self, mock_get, mock_sleep):
         """Test that non-429 errors are returned without retrying."""
-        # Setup mock response: 500 error
         mock_500_response = Mock()
         mock_500_response.status_code = 500
         mock_500_response.text = "Internal Server Error"
         
         mock_get.return_value = mock_500_response
         
-        # Call the function
-        headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://financialmodelingprep.com/stable/test"
+        params = {"apikey": "test-key"}
         
-        result = _make_api_request(url, headers)
+        result = _make_api_request(url, params)
         
-        # Verify behavior
         assert result.status_code == 500
         assert result.text == "Internal Server Error"
-        
-        # Verify requests.get was called only once
         assert mock_get.call_count == 1
-        
-        # Verify sleep was never called
         mock_sleep.assert_not_called()
 
     @patch('src.tools.api.time.sleep')
     @patch('src.tools.api.requests.get')
     def test_normal_success_requests(self, mock_get, mock_sleep):
         """Test that successful requests return immediately without retry."""
-        # Setup mock response: 200 success
         mock_200_response = Mock()
         mock_200_response.status_code = 200
         mock_200_response.text = "Success"
         
         mock_get.return_value = mock_200_response
         
-        # Call the function
-        headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://financialmodelingprep.com/stable/test"
+        params = {"apikey": "test-key"}
         
-        result = _make_api_request(url, headers)
+        result = _make_api_request(url, params)
         
-        # Verify behavior
         assert result.status_code == 200
         assert result.text == "Success"
-        
-        # Verify requests.get was called only once
         assert mock_get.call_count == 1
-        
-        # Verify sleep was never called
         mock_sleep.assert_not_called()
 
     @patch('src.tools.api._cache')
@@ -172,46 +105,36 @@ class TestRateLimiting:
     @patch('src.tools.api.requests.get')
     def test_full_integration(self, mock_get, mock_sleep, mock_cache):
         """Test that get_prices function properly handles rate limiting."""
-        # Mock cache to return None (cache miss)
         mock_cache.get_prices.return_value = None
         
-        # Setup mock responses: first 429, then 200 with valid data
         mock_429_response = Mock()
         mock_429_response.status_code = 429
         
         mock_200_response = Mock()
         mock_200_response.status_code = 200
-        mock_200_response.json.return_value = {
-            "ticker": "AAPL",
-            "prices": [
-                {
-                    "time": "2024-01-01T00:00:00Z",
-                    "open": 100.0,
-                    "close": 101.0,
-                    "high": 102.0,
-                    "low": 99.0,
-                    "volume": 1000
-                }
-            ]
-        }
+        mock_200_response.json.return_value = [
+            {
+                "date": "2024-01-01",
+                "open": 100.0,
+                "close": 101.0,
+                "high": 102.0,
+                "low": 99.0,
+                "volume": 1000
+            }
+        ]
         
         mock_get.side_effect = [mock_429_response, mock_200_response]
         
-        # Set environment variable for API key
-        with patch.dict(os.environ, {"FINANCIAL_DATASETS_API_KEY": "test-key"}):
-            # Call get_prices
+        with patch.dict(os.environ, {"FMP_API_KEY": "test-key"}):
             result = get_prices("AAPL", "2024-01-01", "2024-01-02")
         
-        # Verify the function succeeded and returned data
         assert len(result) == 1
         assert result[0].open == 100.0
         assert result[0].close == 101.0
         
-        # Verify rate limiting behavior
         assert mock_get.call_count == 2
         mock_sleep.assert_called_once_with(60)
         
-        # Verify cache operations
         mock_cache.get_prices.assert_called_once()
         mock_cache.set_prices.assert_called_once()
 
@@ -219,31 +142,24 @@ class TestRateLimiting:
     @patch('src.tools.api.requests.get')
     def test_max_retries_exceeded(self, mock_get, mock_sleep):
         """Test that function stops retrying after max_retries and returns final 429."""
-        # Setup mock responses: all 429s (exceeds max retries)
         mock_429_response = Mock()
         mock_429_response.status_code = 429
         mock_429_response.text = "Too Many Requests"
         
         mock_get.return_value = mock_429_response
         
-        # Call the function with max_retries=2
-        headers = {"X-API-KEY": "test-key"}
-        url = "https://api.financialdatasets.ai/test"
+        url = "https://financialmodelingprep.com/stable/test"
+        params = {"apikey": "test-key"}
         
-        result = _make_api_request(url, headers, max_retries=2)
+        result = _make_api_request(url, params, max_retries=2)
         
-        # Verify final 429 is returned
         assert result.status_code == 429
         assert result.text == "Too Many Requests"
-        
-        # Verify requests.get was called 3 times (1 initial + 2 retries)
         assert mock_get.call_count == 3
-        
-        # Verify sleep was called 2 times with linear backoff: 60s, 90s
         assert mock_sleep.call_count == 2
         expected_calls = [call(60), call(90)]
         mock_sleep.assert_has_calls(expected_calls)
 
 
 if __name__ == "__main__":
-    pytest.main([__file__]) 
+    pytest.main([__file__])


### PR DESCRIPTION
…MP) API

- Replace all financialdatasets.ai REST endpoints with FMP /stable/* equivalents
- Update data models to handle FMP's camelCase JSON and flat array responses
- Add SentimentAnalyzer module (OpenRouter LLM) to fill FMP's missing sentiment gap
- Integrate sentiment enrichment into news_sentiment, sentiment, michael_burry, and charlie_munger agents
- Update all 15+ agent files to use FMP_API_KEY instead of FINANCIAL_DATASETS_API_KEY
- Update .env.example, README.md, and docker docs
- Update test suite for new API signature
- Implement client-side field mapping: search_line_items -> combined statement queries
- Add rate limiting with linear backoff for FMP endpoints