### PR TITLE
fix(windows): docker run.bat argument parsing entry point

### DIFF
--- a/docker/run.bat
+++ b/docker/run.bat
@@ -14,6 +14,8 @@ set SHOW_REASONING=
 set COMMAND=
 set MODEL_NAME=
 
+goto :start
+
 :: Help function
 :show_help
 echo AI Hedge Fund Docker Runner
@@ -409,5 +411,6 @@ echo Running: !CMD!
 exit /b 0
 
 :: Start script execution
-call :parse_args %* 
+:start
+call :parse_args %*
 


### PR DESCRIPTION
## Summary
Fixes #411

**Problem:** `run.bat build` and other commands were not being parsed, causing the script to immediately display help text instead of executing the requested command.

**Root cause:** The `:parse_args` label was defined but never called from the main execution flow. The script would execute top-to-bottom, hitting `:show_help` first.

**Fix:** Added explicit entry point jump (`goto :start`) before label definitions, ensuring argument parsing runs before any label code.

## Changes
- Added `goto :start` after variable initialization to skip label definitions
- Added `:start` label before `call :parse_args %*` at script end

## Testing
Verified static structure:
- `goto :start` appears before `:show_help` label  
- `:start` label exists and calls `:parse_args %*`
- No whitespace errors in diff

## Impact
Minimal, reversible change. Only affects Windows Docker runner script execution flow.

Closes #411