### PR TITLE
Fix short position cash check to use available cash

### DIFF
--- a/src/backtesting/portfolio.py
+++ b/src/backtesting/portfolio.py
@@ -133,7 +133,8 @@ class Portfolio:
         proceeds = price * quantity
         margin_ratio = self._portfolio["margin_requirement"]
         margin_required = proceeds * margin_ratio
-        if margin_required <= self._portfolio["cash"]:
+        available_cash = self._portfolio["cash"] - self._portfolio["margin_used"]
+        if margin_required <= available_cash:
             old_short_shares = position["short"]
             old_cost_basis = position["short_cost_basis"]
             total_shares = old_short_shares + quantity
@@ -147,7 +148,8 @@ class Portfolio:
             self._portfolio["cash"] += proceeds
             self._portfolio["cash"] -= margin_required
             return quantity
-        max_quantity = int(self._portfolio["cash"] / (price * margin_ratio)) if margin_ratio > 0 and price > 0 else 0
+        available_cash = self._portfolio["cash"] - self._portfolio["margin_used"]
+        max_quantity = int(available_cash / (price * margin_ratio)) if margin_ratio > 0 and price > 0 else 0
         if max_quantity > 0:
             proceeds = price * max_quantity
             margin_required = proceeds * margin_ratio


### PR DESCRIPTION
Fixes #418. The short position cash check was comparing margin_required against total cash balance without accounting for margin already used by existing short positions. Changed to use available_cash = cash - margin_used for accurate checks in both the primary check and fallback max_quantity calculation.