### PR TITLE
Fix short margin sizing to use free cash

### DIFF
--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -122,7 +122,9 @@ class BacktestService:
         elif action == "short":
             proceeds = current_price * quantity
             margin_required = proceeds * self.portfolio["margin_requirement"]
-            if margin_required <= self.portfolio["cash"]:
+            available_margin_cash = max(0.0, self.portfolio["cash"] - self.portfolio["margin_used"])
+
+            if margin_required <= available_margin_cash:
                 # Weighted average short cost basis
                 old_short_shares = position["short"]
                 old_cost_basis = position["short_cost_basis"]
@@ -144,7 +146,7 @@ class BacktestService:
             else:
                 margin_ratio = self.portfolio["margin_requirement"]
                 if margin_ratio > 0:
-                    max_quantity = int(self.portfolio["cash"] / (current_price * margin_ratio))
+                    max_quantity = int(available_margin_cash / (current_price * margin_ratio))
                 else:
                     max_quantity = 0
 

--- a/src/backtesting/portfolio.py
+++ b/src/backtesting/portfolio.py
@@ -133,7 +133,9 @@ class Portfolio:
         proceeds = price * quantity
         margin_ratio = self._portfolio["margin_requirement"]
         margin_required = proceeds * margin_ratio
-        if margin_required <= self._portfolio["cash"]:
+        available_margin_cash = max(0.0, self._portfolio["cash"] - self._portfolio["margin_used"])
+
+        if margin_required <= available_margin_cash:
             old_short_shares = position["short"]
             old_cost_basis = position["short_cost_basis"]
             total_shares = old_short_shares + quantity
@@ -147,7 +149,7 @@ class Portfolio:
             self._portfolio["cash"] += proceeds
             self._portfolio["cash"] -= margin_required
             return quantity
-        max_quantity = int(self._portfolio["cash"] / (price * margin_ratio)) if margin_ratio > 0 and price > 0 else 0
+        max_quantity = int(available_margin_cash / (price * margin_ratio)) if margin_ratio > 0 and price > 0 else 0
         if max_quantity > 0:
             proceeds = price * max_quantity
             margin_required = proceeds * margin_ratio

--- a/tests/backtesting/test_portfolio.py
+++ b/tests/backtesting/test_portfolio.py
@@ -74,6 +74,22 @@ def test_apply_short_open_partial_when_insufficient_margin_cash() -> None:
     assert snap["cash"] == pytest.approx(400.0)
 
 
+def test_apply_short_open_uses_free_cash_not_total_cash() -> None:
+    p = Portfolio(tickers=["AAPL"], initial_cash=200.0, margin_requirement=0.5)
+
+    first_fill = p.apply_short_open("AAPL", 10, 100.0)
+    assert first_fill == 4
+
+    # After first short, total cash has grown from short proceeds,
+    # but free cash for new margin is still only 200 (cash - margin_used).
+    second_fill = p.apply_short_open("AAPL", 10, 100.0)
+    assert second_fill == 4
+
+    snap = p.get_snapshot()
+    assert snap["positions"]["AAPL"]["short"] == 8
+    assert snap["margin_used"] == pytest.approx(400.0)
+
+
 def test_apply_short_cover_realized_gain_and_margin_release(portfolio: Portfolio) -> None:
     # Open short 100 @ 50, then cover 40 @ 40 → gain = (50-40)*40 = 400
     portfolio.apply_short_open("AAPL", 100, 50.0)


### PR DESCRIPTION
## Summary
- compute available margin cash as `cash - margin_used` before opening new short positions
- use available margin cash for both direct fills and partial-fill sizing
- add a regression test to ensure repeated short opens do not over-size from inflated total cash

## Verification
- `python3 -m py_compile src/backtesting/portfolio.py app/backend/services/backtest_service.py tests/backtesting/test_portfolio.py`
- custom regression check script for `Portfolio.apply_short_open` (asserts two consecutive opens fill 4 + 4 shares with 200 initial cash and 50% margin)

Closes #418
