### PR TITLE
Fix short position cash check to use available cash (margin-aware)

### DIFF
--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -122,7 +122,10 @@ class BacktestService:
         elif action == "short":
             proceeds = current_price * quantity
             margin_required = proceeds * self.portfolio["margin_requirement"]
-            if margin_required <= self.portfolio["cash"]:
+            available_cash = max(
+                0.0, self.portfolio["cash"] - self.portfolio["margin_used"]
+            )
+            if margin_required <= available_cash:
                 # Weighted average short cost basis
                 old_short_shares = position["short"]
                 old_cost_basis = position["short_cost_basis"]
@@ -144,7 +147,7 @@ class BacktestService:
             else:
                 margin_ratio = self.portfolio["margin_requirement"]
                 if margin_ratio > 0:
-                    max_quantity = int(self.portfolio["cash"] / (current_price * margin_ratio))
+                    max_quantity = int(available_cash / (current_price * margin_ratio))
                 else:
                     max_quantity = 0
 

--- a/src/backtesting/portfolio.py
+++ b/src/backtesting/portfolio.py
@@ -133,7 +133,10 @@ class Portfolio:
         proceeds = price * quantity
         margin_ratio = self._portfolio["margin_requirement"]
         margin_required = proceeds * margin_ratio
-        if margin_required <= self._portfolio["cash"]:
+        available_cash = max(
+            0.0, self._portfolio["cash"] - self._portfolio["margin_used"]
+        )
+        if margin_required <= available_cash:
             old_short_shares = position["short"]
             old_cost_basis = position["short_cost_basis"]
             total_shares = old_short_shares + quantity
@@ -147,7 +150,7 @@ class Portfolio:
             self._portfolio["cash"] += proceeds
             self._portfolio["cash"] -= margin_required
             return quantity
-        max_quantity = int(self._portfolio["cash"] / (price * margin_ratio)) if margin_ratio > 0 and price > 0 else 0
+        max_quantity = int(available_cash / (price * margin_ratio)) if margin_ratio > 0 and price > 0 else 0
         if max_quantity > 0:
             proceeds = price * max_quantity
             margin_required = proceeds * margin_ratio

--- a/tests/backtesting/test_portfolio.py
+++ b/tests/backtesting/test_portfolio.py
@@ -74,6 +74,24 @@ def test_apply_short_open_partial_when_insufficient_margin_cash() -> None:
     assert snap["cash"] == pytest.approx(400.0)
 
 
+def test_apply_short_open_uses_available_cash_not_total_cash() -> None:
+    p = Portfolio(tickers=["AAPL"], initial_cash=1_000.0, margin_requirement=0.5)
+
+    # First short consumes all free margin but increases total cash with proceeds.
+    first = p.apply_short_open("AAPL", 10, 100.0)
+    assert first == 10
+
+    # Available cash should still be 1,000 (cash 1,500 - margin_used 500),
+    # so max additional quantity at $100 with 50% margin is 20 shares.
+    second = p.apply_short_open("AAPL", 30, 100.0)
+    assert second == 20
+
+    snap = p.get_snapshot()
+    pos = snap["positions"]["AAPL"]
+    assert pos["short"] == 30
+    assert snap["margin_used"] == pytest.approx(1_500.0)
+
+
 def test_apply_short_cover_realized_gain_and_margin_release(portfolio: Portfolio) -> None:
     # Open short 100 @ 50, then cover 40 @ 40 → gain = (50-40)*40 = 400
     portfolio.apply_short_open("AAPL", 100, 50.0)


### PR DESCRIPTION
## Summary

- Fixed the short position cash availability check in both `Portfolio.apply_short_open` and `BacktestService.execute_trade` to correctly compute available cash as `cash - margin_used` rather than using total cash.
- Added a regression test that verifies the available cash semantics when opening additional shorts after an initial short has already tied up margin.

## Problem

Previously, the short open path compared `margin_required <= self._portfolio["cash"]`, which uses the **total cash balance**. This can include amounts already tied up in margin for existing positions, allowing the backtester to over-leverage and allocate more margin than actual free cash would permit.

## Fix

Replace the check with:

```python
available_cash = max(0.0, self._portfolio["cash"] - self._portfolio["margin_used"])
if margin_required <= available_cash:
    # proceed with short
```

The partial fill fallback also now uses `available_cash` instead of total cash.

## Test Plan

- Added `test_apply_short_open_uses_available_cash_not_total_cash` to verify:
  - First short consumes all free margin while increasing total cash via proceeds.
  - Second short correctly limits to the remaining **available** cash, not the inflated total cash.
- Verified syntax with `py_compile` on all touched files.
- Ran focused portfolio checks with a minimal script (pandas-only environment) confirming behavior matches expectations.

Closes #418