### PR TITLE
Fix fallback JSON parsing for DeepSeek/non-json providers

### DIFF
--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -64,8 +64,10 @@ def call_llm(
             # For non-JSON support models, we need to extract and parse the JSON manually
             if model_info and not model_info.has_json_mode():
                 parsed_result = extract_json_from_response(result.content)
-                if parsed_result:
+                if parsed_result is not None:
                     return pydantic_model(**parsed_result)
+
+                raise ValueError("Failed to parse JSON response from model output")
             else:
                 return result
 
@@ -107,15 +109,39 @@ def create_default_response(model_class: type[BaseModel]) -> BaseModel:
 
 
 def extract_json_from_response(content: str) -> dict | None:
-    """Extracts JSON from markdown-formatted response."""
+    """Extracts JSON from model responses (raw JSON, fenced blocks, or embedded snippets)."""
     try:
-        json_start = content.find("```json")
-        if json_start != -1:
-            json_text = content[json_start + 7 :]  # Skip past ```json
-            json_end = json_text.find("```")
-            if json_end != -1:
-                json_text = json_text[:json_end].strip()
-                return json.loads(json_text)
+        text = content if isinstance(content, str) else str(content)
+        text = text.strip()
+
+        # 1) Raw JSON response (common with some providers)
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+    except Exception:
+        pass
+
+    try:
+        text = content if isinstance(content, str) else str(content)
+
+        # 2) JSON fenced code blocks
+        for marker in ("```json", "```"):
+            json_start = text.find(marker)
+            if json_start != -1:
+                json_text = text[json_start + len(marker) :]
+                json_end = json_text.find("```")
+                if json_end != -1:
+                    parsed = json.loads(json_text[:json_end].strip())
+                    if isinstance(parsed, dict):
+                        return parsed
+
+        # 3) Embedded JSON object in surrounding text
+        start = text.find("{")
+        end = text.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            parsed = json.loads(text[start : end + 1])
+            if isinstance(parsed, dict):
+                return parsed
     except Exception as e:
         print(f"Error extracting JSON from response: {e}")
     return None

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,24 @@
+from src.utils.llm import extract_json_from_response
+
+
+def test_extract_json_from_raw_json():
+    response = '{"signal":"bullish","confidence":0.82}'
+    assert extract_json_from_response(response) == {"signal": "bullish", "confidence": 0.82}
+
+
+def test_extract_json_from_fenced_json_block():
+    response = """Here is the analysis:
+```json
+{"signal":"neutral","confidence":0.4}
+```
+"""
+    assert extract_json_from_response(response) == {"signal": "neutral", "confidence": 0.4}
+
+
+def test_extract_json_from_embedded_json_object():
+    response = "Analysis complete: {\"signal\":\"bearish\",\"confidence\":0.2} end."
+    assert extract_json_from_response(response) == {"signal": "bearish", "confidence": 0.2}
+
+
+def test_extract_json_returns_none_when_not_parseable():
+    assert extract_json_from_response("no structured output") is None


### PR DESCRIPTION
## Summary
- accept raw JSON responses in `extract_json_from_response` (not just fenced markdown)
- also parse generic fenced blocks and embedded JSON objects in mixed text
- treat empty-object JSON as valid parsed output and retry when parsing fails
- add focused tests for raw/fenced/embedded JSON parsing paths

## Validation
- `python3 -m py_compile src/utils/llm.py tests/test_llm_utils.py`
- `python3 -m pytest tests/test_llm_utils.py` *(fails in this local environment due to missing project deps like `pydantic`)*

Closes #448
