### PR TITLE
fix: use target downside deviation in Sortino ratio

### DIFF
--- a/src/backtesting/metrics.py
+++ b/src/backtesting/metrics.py
@@ -46,13 +46,11 @@ class PerformanceMetricsCalculator:
         else:
             sharpe = 0.0
 
-        negative_excess = excess[excess < 0]
-        if len(negative_excess) > 0:
-            downside_std = negative_excess.std()
-            if downside_std > 1e-12:
-                sortino = float(np.sqrt(self.annual_trading_days) * (mean_excess / downside_std))
-            else:
-                sortino = float("inf") if mean_excess > 0 else 0.0
+        # Target downside deviation: sqrt(mean(min(excess, 0)^2)) over all periods
+        downside_diff = np.minimum(excess, 0)
+        downside_dev = float(np.sqrt(np.mean(downside_diff**2)))
+        if downside_dev > 1e-12:
+            sortino = float(np.sqrt(self.annual_trading_days) * (mean_excess / downside_dev))
         else:
             sortino = float("inf") if mean_excess > 0 else 0.0
 


### PR DESCRIPTION
## Summary
- Sortino ratio used `std()` of only negative excess returns, which overstates downside risk
- Replaced with target downside deviation: `sqrt(mean(min(excess, 0)^2))` across all periods
- This matches the standard definition (Sortino & van der Meer, 1991) and is consistent with libraries like `ffn` and `empyrical`

## Why this matters
The old formula has two errors:
1. **Selection bias** — filtering to only negative returns excludes periods where the portfolio met or exceeded the target, inflating the denominator
2. **Bessel's correction** — `Series.std()` uses `ddof=1`, further distorting the result for small samples

In practice this can understate Sortino by ~20% depending on the return distribution.

## Test plan
- [x] All 3 existing metrics tests pass
- [x] Verified numerically: old vs new formula with sample data shows expected ~20% correction