### PR TITLE
feat: dynamic model discovery for OpenAI-compatible endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,11 @@ FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 
 # For running LLMs hosted by openai (GPT 5, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
+# Set OPENAI_API_BASE to use any OpenAI-compatible endpoint (e.g. vLLM, LM Studio, a proxy)
+# If the endpoint does not support GET /models, list model IDs manually in OPENAI_MODELS
 OPENAI_API_KEY=your-openai-api-key
+# OPENAI_API_BASE=https://your-custom-endpoint/v1
+# OPENAI_MODELS=qwen-max,qwen-plus,qwen-turbo
 
 # For running LLMs hosted by anthropic (claude-4-sonnet, claude-4.1-opus, etc.)
 # Get your Anthropic API key from https://anthropic.com/

--- a/app/backend/routes/language_models.py
+++ b/app/backend/routes/language_models.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any
 
 from app.backend.models.schemas import ErrorResponse
 from app.backend.services.ollama_service import OllamaService
+from app.backend.services.openai_compatible_service import get_dynamic_models
 from src.llm.models import get_models_list
 
 router = APIRouter(prefix="/language-models")
@@ -20,9 +21,19 @@ ollama_service = OllamaService()
 async def get_language_models():
     """Get the list of available cloud-based and Ollama language models."""
     try:
-        # Start with cloud models
+        # Start with statically configured cloud models
         models = get_models_list()
-        
+
+        # Dynamically discover models from OpenAI-compatible endpoints
+        # (e.g. Alibaba DashScope, custom OPENAI_API_BASE, etc.)
+        dynamic_models = await get_dynamic_models()
+
+        # Avoid duplicates — skip any dynamic model already present in the static list
+        static_keys = {(m["model_name"], m["provider"]) for m in models}
+        for m in dynamic_models:
+            if (m["model_name"], m["provider"]) not in static_keys:
+                models.append(m)
+
         # Add available Ollama models (handles all checking internally)
         ollama_models = await ollama_service.get_available_models()
         models.extend(ollama_models)

--- a/app/backend/services/openai_compatible_service.py
+++ b/app/backend/services/openai_compatible_service.py
@@ -1,0 +1,59 @@
+import os
+import logging
+from typing import List, Dict, Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+async def get_dynamic_models() -> List[Dict[str, Any]]:
+    """
+    If OPENAI_API_BASE is set to a custom (non-OpenAI) endpoint, fetch its
+    model list via the standard GET /v1/models endpoint and return them as
+    OpenAI-provider models so they route through get_model() correctly.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    base_url = os.getenv("OPENAI_API_BASE", "").rstrip("/")
+
+    # Only activate when a custom base URL is explicitly configured
+    if not api_key or not base_url or "api.openai.com" in base_url:
+        return []
+
+    if not base_url.startswith("http://") and not base_url.startswith("https://"):
+        logger.warning(
+            f"OPENAI_API_BASE looks malformed (got: {base_url!r}). "
+            "Make sure it starts with 'https://' in your .env file."
+        )
+        return []
+
+    url = base_url + "/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+        models = [
+            {"display_name": item["id"], "model_name": item["id"], "provider": "OpenAI"}
+            for item in data.get("data", [])
+            if item.get("id")
+        ]
+        logger.info(f"[OpenAI custom base] Discovered {len(models)} models from {url}")
+        return models
+    except Exception as e:
+        logger.warning(f"[OpenAI custom base] Failed to fetch models from {url}: {e}")
+
+    # Fallback: use OPENAI_MODELS if the /models endpoint is not supported
+    models_env = os.getenv("OPENAI_MODELS", "")
+    if models_env:
+        models = [
+            {"display_name": m.strip(), "model_name": m.strip(), "provider": "OpenAI"}
+            for m in models_env.split(",")
+            if m.strip()
+        ]
+        logger.info(f"[OpenAI custom base] Using {len(models)} models from OPENAI_MODELS env var")
+        return models
+
+    return []

--- a/src/backtesting/cli.py
+++ b/src/backtesting/cli.py
@@ -9,7 +9,7 @@ from colorama import Fore, Style, init
 import questionary
 
 from .engine import BacktestEngine
-from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider
+from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, get_dynamic_llm_order
 from src.utils.analysts import ANALYST_ORDER
 from src.main import run_hedge_fund
 from src.utils.ollama import ensure_ollama_and_model
@@ -102,9 +102,14 @@ def main() -> int:
             f"\nSelected {Fore.CYAN}Ollama{Style.RESET_ALL} model: {Fore.GREEN + Style.BRIGHT}{model_name}{Style.RESET_ALL}\n"
         )
     else:
+        dynamic = get_dynamic_llm_order()
+        static_names = {name for _, name, _ in LLM_ORDER}
+        extra = [(display, name, provider) for display, name, provider in dynamic if name not in static_names]
+        combined_order = LLM_ORDER + extra
+
         model_choice = questionary.select(
             "Select your LLM model:",
-            choices=[questionary.Choice(display, value=(name, provider)) for display, name, provider in LLM_ORDER],
+            choices=[questionary.Choice(display, value=(name, provider)) for display, name, provider in combined_order],
             style=questionary.Style(
                 [
                     ("selected", "fg:green bold"),

--- a/src/cli/input.py
+++ b/src/cli/input.py
@@ -6,7 +6,7 @@ import questionary
 from colorama import Fore, Style
 
 from src.utils.analysts import ANALYST_ORDER
-from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, find_model_by_name
+from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, find_model_by_name, get_dynamic_llm_order
 from src.utils.ollama import ensure_ollama_and_model
 
 from dataclasses import dataclass
@@ -150,9 +150,14 @@ def select_model(use_ollama: bool, model_flag: str | None = None) -> tuple[str, 
             f"\nSelected {Fore.CYAN}Ollama{Style.RESET_ALL} model: {Fore.GREEN + Style.BRIGHT}{model_name}{Style.RESET_ALL}\n"
         )
     else:
+        dynamic = get_dynamic_llm_order()
+        static_names = {name for _, name, _ in LLM_ORDER}
+        extra = [(display, name, provider) for display, name, provider in dynamic if name not in static_names]
+        combined_order = LLM_ORDER + extra
+
         model_choice = questionary.select(
             "Select your LLM model:",
-            choices=[questionary.Choice(display, value=(name, provider)) for display, name, provider in LLM_ORDER],
+            choices=[questionary.Choice(display, value=(name, provider)) for display, name, provider in combined_order],
             style=questionary.Style(
                 [
                     ("selected", "fg:green bold"),
@@ -176,13 +181,9 @@ def select_model(use_ollama: bool, model_flag: str | None = None) -> tuple[str, 
                 print("\n\nInterrupt received. Exiting...")
                 sys.exit(0)
 
-        if model_info:
-            print(
-                f"\nSelected {Fore.CYAN}{model_provider}{Style.RESET_ALL} model: {Fore.GREEN + Style.BRIGHT}{model_name}{Style.RESET_ALL}\n"
-            )
-        else:
-            model_provider = "Unknown"
-            print(f"\nSelected model: {Fore.GREEN + Style.BRIGHT}{model_name}{Style.RESET_ALL}\n")
+        print(
+            f"\nSelected {Fore.CYAN}{model_provider}{Style.RESET_ALL} model: {Fore.GREEN + Style.BRIGHT}{model_name}{Style.RESET_ALL}\n"
+        )
 
     return model_name, model_provider or ""
 

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 from langchain_anthropic import ChatAnthropic
 from langchain_deepseek import ChatDeepSeek
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -135,7 +136,74 @@ def get_models_list():
     ]
 
 
+def get_dynamic_llm_order() -> List[Tuple[str, str, str]]:
+    """
+    If OPENAI_API_BASE points to a custom endpoint, fetch its model list via
+    GET /v1/models and return choices in (display_name, model_name, provider) format.
+    Falls back to an empty list on any error so the CLI still works offline.
+    """
+    api_key = os.getenv("OPENAI_API_KEY", "")
+    base_url = os.getenv("OPENAI_API_BASE", "").rstrip("/")
+
+    if not api_key or not base_url or "api.openai.com" in base_url:
+        return []
+
+    if not base_url.startswith("http://") and not base_url.startswith("https://"):
+        logging.getLogger(__name__).warning(
+            f"OPENAI_API_BASE looks malformed (got: {base_url!r}). "
+            "Make sure it starts with 'https://' in your .env file."
+        )
+        return []
+
+    try:
+        import httpx
+        response = httpx.get(
+            base_url + "/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+        order = []
+        for item in data.get("data", []):
+            model_id = item.get("id", "")
+            if model_id:
+                order.append((model_id, model_id, ModelProvider.OPENAI.value))
+        return order
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"Could not fetch models from {base_url}: {e}")
+
+    # Fallback: use OPENAI_MODELS if the /models endpoint is not supported
+    models_env = os.getenv("OPENAI_MODELS", "")
+    if models_env:
+        return [
+            (model_id.strip(), model_id.strip(), ModelProvider.OPENAI.value)
+            for model_id in models_env.split(",")
+            if model_id.strip()
+        ]
+
+    return []
+
+
 def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = None) -> ChatOpenAI | ChatGroq | ChatOllama | GigaChat | None:
+    # Normalize string providers (e.g. "OPENAI" → ModelProvider.OPENAI)
+    if isinstance(model_provider, str) and not isinstance(model_provider, ModelProvider):
+        # Try exact match first, then case-insensitive
+        try:
+            model_provider = ModelProvider(model_provider)
+        except ValueError:
+            match = next(
+                (p for p in ModelProvider if p.value.lower() == model_provider.lower()),
+                None,
+            )
+            if match:
+                model_provider = match
+            else:
+                raise ValueError(
+                    f"Unknown model provider: {model_provider!r}. "
+                    f"Valid providers: {[p.value for p in ModelProvider]}"
+                )
+
     if model_provider == ModelProvider.GROQ:
         api_key = (api_keys or {}).get("GROQ_API_KEY") or os.getenv("GROQ_API_KEY")
         if not api_key:

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -36,7 +36,7 @@ def call_llm(
     else:
         # Use system defaults when no state or agent_name is provided
         model_name = "gpt-4.1"
-        model_provider = "OPENAI"
+        model_provider = "OpenAI"
 
     # Extract API keys from state if available
     api_keys = None
@@ -138,7 +138,7 @@ def get_agent_model_config(state, agent_name):
     
     # Fall back to global configuration (system defaults)
     model_name = state.get("metadata", {}).get("model_name") or "gpt-4.1"
-    model_provider = state.get("metadata", {}).get("model_provider") or "OPENAI"
+    model_provider = state.get("metadata", {}).get("model_provider") or "OpenAI"
     
     # Convert enum to string if necessary
     if hasattr(model_provider, 'value'):


### PR DESCRIPTION
## Summary

- When `OPENAI_API_BASE` is set to a custom endpoint, the app now automatically fetches available models via the standard `GET /v1/models` endpoint and surfaces them in both the **web UI model picker** and the **CLI model selector** — no manual editing of `api_models.json` needed
- For providers that don't implement `/models` (e.g. Alibaba DashScope), a fallback env var `OPENAI_MODELS` accepts a comma-separated list of model IDs
- Fixed two hardcoded `"OPENAI"` fallback strings in `src/utils/llm.py` that should be `"OpenAI"` (matching `ModelProvider` enum values), which caused `get_model()` to silently return `None` and crash with `AttributeError: 'NoneType'`
- Added case-insensitive provider string normalisation in `get_model()` so casing mismatches never silently return `None`

## Changes

| File | What changed |
|---|---|
| `app/backend/services/openai_compatible_service.py` | New async service — fetches models from custom base URL, falls back to `OPENAI_MODELS` |
| `app/backend/routes/language_models.py` | Merges dynamically discovered models into the `/language-models/` response |
| `src/llm/models.py` | `get_dynamic_llm_order()` — sync version for CLI; provider normalisation in `get_model()` |
| `src/cli/input.py` | Appends dynamic models to CLI picker; removes incorrect `"Unknown"` provider override |
| `src/backtesting/cli.py` | Same dynamic model injection for the backtesting CLI |
| `src/utils/llm.py` | Fix `"OPENAI"` → `"OpenAI"` fallback strings |
| `.env.example` | Document `OPENAI_API_BASE` and `OPENAI_MODELS` |

## Usage

```bash
# Any OpenAI-compatible provider (Alibaba DashScope, vLLM, LM Studio, Together, etc.)
OPENAI_API_KEY=your-key
OPENAI_API_BASE=https://dashscope.aliyuncs.com/compatible-mode/v1

# Optional: manually list models if the provider doesn't support GET /v1/models
OPENAI_MODELS=qwen-max,qwen-plus,qwen-turbo
```

Models appear automatically in the web UI dropdown and the CLI selector under the **OpenAI** provider and route through the existing `OPENAI_API_KEY` + `OPENAI_API_BASE` path.

## Test plan

- [ ] Set `OPENAI_API_BASE` to a provider that supports `GET /v1/models` — confirm models appear in CLI and web UI
- [ ] Set `OPENAI_MODELS` for a provider without `/models` — confirm models appear
- [ ] Leave both unset — confirm existing behaviour is unchanged
- [ ] Run with a dynamically discovered model — confirm no `NoneType` crash