### PR TITLE
fix: correct model provider string casing in llm.py fallbacks

### DIFF
--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -36,7 +36,7 @@ def call_llm(
     else:
         # Use system defaults when no state or agent_name is provided
         model_name = "gpt-4.1"
-        model_provider = "OPENAI"
+        model_provider = "OpenAI"
 
     # Extract API keys from state if available
     api_keys = None
@@ -138,7 +138,7 @@ def get_agent_model_config(state, agent_name):
     
     # Fall back to global configuration (system defaults)
     model_name = state.get("metadata", {}).get("model_name") or "gpt-4.1"
-    model_provider = state.get("metadata", {}).get("model_provider") or "OPENAI"
+    model_provider = state.get("metadata", {}).get("model_provider") or "OpenAI"
     
     # Convert enum to string if necessary
     if hasattr(model_provider, 'value'):


### PR DESCRIPTION
## Summary

Two hardcoded fallback strings in `src/utils/llm.py` used `"OPENAI"` (all-caps) but `ModelProvider.OPENAI.value` is `"OpenAI"` (title case).

## The bug

When no agent-specific model config is found, `call_llm()` and `get_agent_model_config()` fall back to the string `"OPENAI"`. This string is passed to `get_model()`, which compares it against `ModelProvider` enum values — none match, so the function returns `None`. The caller then crashes with:

```
AttributeError: 'NoneType' object has no attribute 'with_structured_output'
```

## Fix

```python
# before
model_provider = "OPENAI"

# after
model_provider = "OpenAI"  # matches ModelProvider.OPENAI.value
```

Two lines changed in `src/utils/llm.py`.