### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,7 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 AZURE_OPENAI_API_KEY=your-azure-openai-api-key
 AZURE_OPENAI_ENDPOINT=your-azure-openai-endpoint
 AZURE_OPENAI_DEPLOYMENT_NAME=your-azure-openai-deployment-name
+
+# For running LLMs hosted by MiniMax (MiniMax-M2.5, MiniMax-M2.5-highspeed)
+# Get your MiniMax API key from https://platform.minimax.io/
+MINIMAX_API_KEY=your-minimax-api-key

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,6 @@ AZURE_OPENAI_API_KEY=your-azure-openai-api-key
 AZURE_OPENAI_ENDPOINT=your-azure-openai-endpoint
 AZURE_OPENAI_DEPLOYMENT_NAME=your-azure-openai-deployment-name
 
-# For running LLMs hosted by MiniMax (MiniMax-M2.5, MiniMax-M2.5-highspeed)
+# For running LLMs hosted by MiniMax (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed)
 # Get your MiniMax API key from https://platform.minimax.io/
 MINIMAX_API_KEY=your-minimax-api-key

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,6 @@ AZURE_OPENAI_API_KEY=your-azure-openai-api-key
 AZURE_OPENAI_ENDPOINT=your-azure-openai-endpoint
 AZURE_OPENAI_DEPLOYMENT_NAME=your-azure-openai-deployment-name
 
-# For running LLMs hosted by MiniMax (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed)
+# For running LLMs hosted by MiniMax (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed)
 # Get your MiniMax API key from https://platform.minimax.io/
 MINIMAX_API_KEY=your-minimax-api-key

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ OPENAI_API_KEY=your-openai-api-key
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 ```
 
-**Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work. 
+**Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`, or `MINIMAX_API_KEY`) for the hedge fund to work.
 
 **Financial Data**: Data for AAPL, GOOGL, MSFT, NVDA, and TSLA is free and does not require an API key. For any other ticker, you will need to set the `FINANCIAL_DATASETS_API_KEY` in the .env file.
 

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -76,7 +76,7 @@ const LLM_API_KEYS: ApiKey[] = [
   {
     key: 'MINIMAX_API_KEY',
     label: 'MiniMax API',
-    description: 'For MiniMax models (MiniMax-M2.5, MiniMax-M2.5-highspeed)',
+    description: 'For MiniMax models (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed)',
     url: 'https://platform.minimax.io/',
     placeholder: 'your-minimax-api-key'
   }

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -72,6 +72,13 @@ const LLM_API_KEYS: ApiKey[] = [
     description: 'For GigaChat models (GigaChat-2-Max, etc.)',
     url: 'https://github.com/ai-forever/gigachat',
     placeholder: 'your-gigachat-api-key'
+  },
+  {
+    key: 'MINIMAX_API_KEY',
+    label: 'MiniMax API',
+    description: 'For MiniMax models (MiniMax-M2.5, MiniMax-M2.5-highspeed)',
+    url: 'https://platform.minimax.io/',
+    placeholder: 'your-minimax-api-key'
   }
 ];
 

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -76,7 +76,7 @@ const LLM_API_KEYS: ApiKey[] = [
   {
     key: 'MINIMAX_API_KEY',
     label: 'MiniMax API',
-    description: 'For MiniMax models (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed)',
+    description: 'For MiniMax models (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed)',
     url: 'https://platform.minimax.io/',
     placeholder: 'your-minimax-api-key'
   }

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -70,6 +70,16 @@
     "provider": "Azure OpenAI"
   },
   {
+    "display_name": "MiniMax M2.7",
+    "model_name": "MiniMax-M2.7",
+    "provider": "MiniMax"
+  },
+  {
+    "display_name": "MiniMax M2.7 High Speed",
+    "model_name": "MiniMax-M2.7-highspeed",
+    "provider": "MiniMax"
+  },
+  {
     "display_name": "MiniMax M2.5",
     "model_name": "MiniMax-M2.5",
     "provider": "MiniMax"

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -68,5 +68,15 @@
     "display_name": "Azure Open AI Deployment",
     "model_name": "",
     "provider": "Azure OpenAI"
+  },
+  {
+    "display_name": "MiniMax M2.5",
+    "model_name": "MiniMax-M2.5",
+    "provider": "MiniMax"
+  },
+  {
+    "display_name": "MiniMax M2.5 High Speed",
+    "model_name": "MiniMax-M2.5-highspeed",
+    "provider": "MiniMax"
   }
 ]

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -70,6 +70,11 @@
     "provider": "Azure OpenAI"
   },
   {
+    "display_name": "MiniMax M3",
+    "model_name": "MiniMax-M3",
+    "provider": "MiniMax"
+  },
+  {
     "display_name": "MiniMax M2.7",
     "model_name": "MiniMax-M2.7",
     "provider": "MiniMax"
@@ -77,16 +82,6 @@
   {
     "display_name": "MiniMax M2.7 High Speed",
     "model_name": "MiniMax-M2.7-highspeed",
-    "provider": "MiniMax"
-  },
-  {
-    "display_name": "MiniMax M2.5",
-    "model_name": "MiniMax-M2.5",
-    "provider": "MiniMax"
-  },
-  {
-    "display_name": "MiniMax M2.5 High Speed",
-    "model_name": "MiniMax-M2.5-highspeed",
     "provider": "MiniMax"
   }
 ]

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -31,6 +31,7 @@ class ModelProvider(str, Enum):
     GIGACHAT = "GigaChat"
     AZURE_OPENAI = "Azure OpenAI"
     XAI = "xAI"
+    MINIMAX = "MiniMax"
 
 
 class LLMModel(BaseModel):
@@ -48,9 +49,13 @@ class LLMModel(BaseModel):
         """Check if the model is a Gemini model"""
         return self.model_name == "-"
 
+    def is_minimax(self) -> bool:
+        """Check if the model is a MiniMax model"""
+        return self.provider == ModelProvider.MINIMAX
+
     def has_json_mode(self) -> bool:
         """Check if the model supports JSON mode"""
-        if self.is_deepseek() or self.is_gemini():
+        if self.is_deepseek() or self.is_gemini() or self.is_minimax():
             return False
         # Only certain Ollama models support JSON mode
         if self.is_ollama():
@@ -236,3 +241,10 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             print(f"Azure Deployment Name Error: Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
             raise ValueError("Azure OpenAI deployment name not found.  Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
         return AzureChatOpenAI(azure_endpoint=azure_endpoint, azure_deployment=azure_deployment_name, api_key=api_key, api_version="2024-10-21")
+    elif model_provider == ModelProvider.MINIMAX:
+        api_key = (api_keys or {}).get("MINIMAX_API_KEY") or os.getenv("MINIMAX_API_KEY")
+        if not api_key:
+            print(f"API Key Error: Please make sure MINIMAX_API_KEY is set in your .env file or provided via API keys.")
+            raise ValueError("MiniMax API key not found. Please make sure MINIMAX_API_KEY is set in your .env file or provided via API keys.")
+        base_url = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,174 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.llm.models import (
+    ModelProvider,
+    LLMModel,
+    get_model,
+    get_model_info,
+    find_model_by_name,
+    AVAILABLE_MODELS,
+)
+
+
+class TestMiniMaxProviderEnum:
+    """Test that MiniMax is properly registered as a provider."""
+
+    def test_minimax_enum_exists(self):
+        assert hasattr(ModelProvider, "MINIMAX")
+        assert ModelProvider.MINIMAX.value == "MiniMax"
+
+    def test_minimax_enum_is_string(self):
+        assert isinstance(ModelProvider.MINIMAX, str)
+        assert ModelProvider.MINIMAX == "MiniMax"
+
+
+class TestMiniMaxModelConfig:
+    """Test MiniMax model configuration in api_models.json."""
+
+    def test_minimax_m25_in_available_models(self):
+        model = find_model_by_name("MiniMax-M2.5")
+        assert model is not None
+        assert model.display_name == "MiniMax M2.5"
+        assert model.model_name == "MiniMax-M2.5"
+        assert model.provider == ModelProvider.MINIMAX
+
+    def test_minimax_m25_highspeed_in_available_models(self):
+        model = find_model_by_name("MiniMax-M2.5-highspeed")
+        assert model is not None
+        assert model.display_name == "MiniMax M2.5 High Speed"
+        assert model.model_name == "MiniMax-M2.5-highspeed"
+        assert model.provider == ModelProvider.MINIMAX
+
+    def test_get_model_info_minimax(self):
+        model_info = get_model_info("MiniMax-M2.5", "MiniMax")
+        assert model_info is not None
+        assert model_info.provider == ModelProvider.MINIMAX
+
+
+class TestMiniMaxModelProperties:
+    """Test MiniMax model behavior properties."""
+
+    def test_minimax_has_no_json_mode(self):
+        model = LLMModel(
+            display_name="MiniMax M2.5",
+            model_name="MiniMax-M2.5",
+            provider=ModelProvider.MINIMAX,
+        )
+        assert model.has_json_mode() is False
+
+    def test_minimax_is_minimax(self):
+        model = LLMModel(
+            display_name="MiniMax M2.5",
+            model_name="MiniMax-M2.5",
+            provider=ModelProvider.MINIMAX,
+        )
+        assert model.is_minimax() is True
+
+    def test_minimax_is_not_deepseek(self):
+        model = LLMModel(
+            display_name="MiniMax M2.5",
+            model_name="MiniMax-M2.5",
+            provider=ModelProvider.MINIMAX,
+        )
+        assert model.is_deepseek() is False
+
+    def test_minimax_is_not_ollama(self):
+        model = LLMModel(
+            display_name="MiniMax M2.5",
+            model_name="MiniMax-M2.5",
+            provider=ModelProvider.MINIMAX,
+        )
+        assert model.is_ollama() is False
+
+    def test_minimax_to_choice_tuple(self):
+        model = LLMModel(
+            display_name="MiniMax M2.5",
+            model_name="MiniMax-M2.5",
+            provider=ModelProvider.MINIMAX,
+        )
+        assert model.to_choice_tuple() == ("MiniMax M2.5", "MiniMax-M2.5", "MiniMax")
+
+
+class TestMiniMaxGetModel:
+    """Test get_model() factory for MiniMax provider."""
+
+    @patch("src.llm.models.ChatOpenAI")
+    def test_get_model_with_api_key(self, mock_chat_openai):
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+
+        result = get_model(
+            "MiniMax-M2.5",
+            ModelProvider.MINIMAX,
+            api_keys={"MINIMAX_API_KEY": "test-key"},
+        )
+
+        mock_chat_openai.assert_called_once_with(
+            model="MiniMax-M2.5",
+            api_key="test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        assert result == mock_instance
+
+    @patch("src.llm.models.ChatOpenAI")
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "env-test-key"})
+    def test_get_model_with_env_api_key(self, mock_chat_openai):
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+
+        result = get_model("MiniMax-M2.5", ModelProvider.MINIMAX)
+
+        mock_chat_openai.assert_called_once_with(
+            model="MiniMax-M2.5",
+            api_key="env-test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        assert result == mock_instance
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_model_raises_without_api_key(self):
+        # Remove MINIMAX_API_KEY from env if present
+        os.environ.pop("MINIMAX_API_KEY", None)
+        with pytest.raises(ValueError, match="MiniMax API key not found"):
+            get_model("MiniMax-M2.5", ModelProvider.MINIMAX)
+
+    @patch("src.llm.models.ChatOpenAI")
+    @patch.dict(
+        os.environ,
+        {
+            "MINIMAX_API_KEY": "test-key",
+            "MINIMAX_BASE_URL": "https://api.minimaxi.com/v1",
+        },
+    )
+    def test_get_model_with_custom_base_url(self, mock_chat_openai):
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+
+        result = get_model("MiniMax-M2.5", ModelProvider.MINIMAX)
+
+        mock_chat_openai.assert_called_once_with(
+            model="MiniMax-M2.5",
+            api_key="test-key",
+            base_url="https://api.minimaxi.com/v1",
+        )
+        assert result == mock_instance
+
+    @patch("src.llm.models.ChatOpenAI")
+    def test_get_model_highspeed(self, mock_chat_openai):
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+
+        result = get_model(
+            "MiniMax-M2.5-highspeed",
+            ModelProvider.MINIMAX,
+            api_keys={"MINIMAX_API_KEY": "test-key"},
+        )
+
+        mock_chat_openai.assert_called_once_with(
+            model="MiniMax-M2.5-highspeed",
+            api_key="test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        assert result == mock_instance

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -27,6 +27,27 @@ class TestMiniMaxProviderEnum:
 class TestMiniMaxModelConfig:
     """Test MiniMax model configuration in api_models.json."""
 
+    def test_minimax_m27_in_available_models(self):
+        model = find_model_by_name("MiniMax-M2.7")
+        assert model is not None
+        assert model.display_name == "MiniMax M2.7"
+        assert model.model_name == "MiniMax-M2.7"
+        assert model.provider == ModelProvider.MINIMAX
+
+    def test_minimax_m27_highspeed_in_available_models(self):
+        model = find_model_by_name("MiniMax-M2.7-highspeed")
+        assert model is not None
+        assert model.display_name == "MiniMax M2.7 High Speed"
+        assert model.model_name == "MiniMax-M2.7-highspeed"
+        assert model.provider == ModelProvider.MINIMAX
+
+    def test_minimax_m27_is_default(self):
+        """M2.7 should appear before M2.5 in the model list."""
+        minimax_models = [m for m in AVAILABLE_MODELS if m.provider == ModelProvider.MINIMAX]
+        assert len(minimax_models) >= 2
+        assert minimax_models[0].model_name == "MiniMax-M2.7"
+        assert minimax_models[1].model_name == "MiniMax-M2.7-highspeed"
+
     def test_minimax_m25_in_available_models(self):
         model = find_model_by_name("MiniMax-M2.5")
         assert model is not None
@@ -42,7 +63,7 @@ class TestMiniMaxModelConfig:
         assert model.provider == ModelProvider.MINIMAX
 
     def test_get_model_info_minimax(self):
-        model_info = get_model_info("MiniMax-M2.5", "MiniMax")
+        model_info = get_model_info("MiniMax-M2.7", "MiniMax")
         assert model_info is not None
         assert model_info.provider == ModelProvider.MINIMAX
 
@@ -152,6 +173,42 @@ class TestMiniMaxGetModel:
             model="MiniMax-M2.5",
             api_key="test-key",
             base_url="https://api.minimaxi.com/v1",
+        )
+        assert result == mock_instance
+
+    @patch("src.llm.models.ChatOpenAI")
+    def test_get_model_m27(self, mock_chat_openai):
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+
+        result = get_model(
+            "MiniMax-M2.7",
+            ModelProvider.MINIMAX,
+            api_keys={"MINIMAX_API_KEY": "test-key"},
+        )
+
+        mock_chat_openai.assert_called_once_with(
+            model="MiniMax-M2.7",
+            api_key="test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        assert result == mock_instance
+
+    @patch("src.llm.models.ChatOpenAI")
+    def test_get_model_m27_highspeed(self, mock_chat_openai):
+        mock_instance = MagicMock()
+        mock_chat_openai.return_value = mock_instance
+
+        result = get_model(
+            "MiniMax-M2.7-highspeed",
+            ModelProvider.MINIMAX,
+            api_keys={"MINIMAX_API_KEY": "test-key"},
+        )
+
+        mock_chat_openai.assert_called_once_with(
+            model="MiniMax-M2.7-highspeed",
+            api_key="test-key",
+            base_url="https://api.minimax.io/v1",
         )
         assert result == mock_instance
 

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -27,6 +27,13 @@ class TestMiniMaxProviderEnum:
 class TestMiniMaxModelConfig:
     """Test MiniMax model configuration in api_models.json."""
 
+    def test_minimax_m3_in_available_models(self):
+        model = find_model_by_name("MiniMax-M3")
+        assert model is not None
+        assert model.display_name == "MiniMax M3"
+        assert model.model_name == "MiniMax-M3"
+        assert model.provider == ModelProvider.MINIMAX
+
     def test_minimax_m27_in_available_models(self):
         model = find_model_by_name("MiniMax-M2.7")
         assert model is not None
@@ -41,29 +48,27 @@ class TestMiniMaxModelConfig:
         assert model.model_name == "MiniMax-M2.7-highspeed"
         assert model.provider == ModelProvider.MINIMAX
 
-    def test_minimax_m27_is_default(self):
-        """M2.7 should appear before M2.5 in the model list."""
+    def test_minimax_m3_is_default(self):
+        """M3 should appear first among MiniMax models."""
         minimax_models = [m for m in AVAILABLE_MODELS if m.provider == ModelProvider.MINIMAX]
-        assert len(minimax_models) >= 2
-        assert minimax_models[0].model_name == "MiniMax-M2.7"
-        assert minimax_models[1].model_name == "MiniMax-M2.7-highspeed"
+        assert len(minimax_models) >= 3
+        assert minimax_models[0].model_name == "MiniMax-M3"
+        assert minimax_models[1].model_name == "MiniMax-M2.7"
+        assert minimax_models[2].model_name == "MiniMax-M2.7-highspeed"
 
-    def test_minimax_m25_in_available_models(self):
-        model = find_model_by_name("MiniMax-M2.5")
-        assert model is not None
-        assert model.display_name == "MiniMax M2.5"
-        assert model.model_name == "MiniMax-M2.5"
-        assert model.provider == ModelProvider.MINIMAX
-
-    def test_minimax_m25_highspeed_in_available_models(self):
-        model = find_model_by_name("MiniMax-M2.5-highspeed")
-        assert model is not None
-        assert model.display_name == "MiniMax M2.5 High Speed"
-        assert model.model_name == "MiniMax-M2.5-highspeed"
-        assert model.provider == ModelProvider.MINIMAX
+    def test_minimax_older_models_removed(self):
+        """Older M2.5/M2.1/M2/M1 models should no longer be present."""
+        for old_model in (
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+            "MiniMax-M2.1",
+            "MiniMax-M2",
+            "MiniMax-M1",
+        ):
+            assert find_model_by_name(old_model) is None
 
     def test_get_model_info_minimax(self):
-        model_info = get_model_info("MiniMax-M2.7", "MiniMax")
+        model_info = get_model_info("MiniMax-M3", "MiniMax")
         assert model_info is not None
         assert model_info.provider == ModelProvider.MINIMAX
 
@@ -73,43 +78,43 @@ class TestMiniMaxModelProperties:
 
     def test_minimax_has_no_json_mode(self):
         model = LLMModel(
-            display_name="MiniMax M2.5",
-            model_name="MiniMax-M2.5",
+            display_name="MiniMax M3",
+            model_name="MiniMax-M3",
             provider=ModelProvider.MINIMAX,
         )
         assert model.has_json_mode() is False
 
     def test_minimax_is_minimax(self):
         model = LLMModel(
-            display_name="MiniMax M2.5",
-            model_name="MiniMax-M2.5",
+            display_name="MiniMax M3",
+            model_name="MiniMax-M3",
             provider=ModelProvider.MINIMAX,
         )
         assert model.is_minimax() is True
 
     def test_minimax_is_not_deepseek(self):
         model = LLMModel(
-            display_name="MiniMax M2.5",
-            model_name="MiniMax-M2.5",
+            display_name="MiniMax M3",
+            model_name="MiniMax-M3",
             provider=ModelProvider.MINIMAX,
         )
         assert model.is_deepseek() is False
 
     def test_minimax_is_not_ollama(self):
         model = LLMModel(
-            display_name="MiniMax M2.5",
-            model_name="MiniMax-M2.5",
+            display_name="MiniMax M3",
+            model_name="MiniMax-M3",
             provider=ModelProvider.MINIMAX,
         )
         assert model.is_ollama() is False
 
     def test_minimax_to_choice_tuple(self):
         model = LLMModel(
-            display_name="MiniMax M2.5",
-            model_name="MiniMax-M2.5",
+            display_name="MiniMax M3",
+            model_name="MiniMax-M3",
             provider=ModelProvider.MINIMAX,
         )
-        assert model.to_choice_tuple() == ("MiniMax M2.5", "MiniMax-M2.5", "MiniMax")
+        assert model.to_choice_tuple() == ("MiniMax M3", "MiniMax-M3", "MiniMax")
 
 
 class TestMiniMaxGetModel:
@@ -121,13 +126,13 @@ class TestMiniMaxGetModel:
         mock_chat_openai.return_value = mock_instance
 
         result = get_model(
-            "MiniMax-M2.5",
+            "MiniMax-M3",
             ModelProvider.MINIMAX,
             api_keys={"MINIMAX_API_KEY": "test-key"},
         )
 
         mock_chat_openai.assert_called_once_with(
-            model="MiniMax-M2.5",
+            model="MiniMax-M3",
             api_key="test-key",
             base_url="https://api.minimax.io/v1",
         )
@@ -139,10 +144,10 @@ class TestMiniMaxGetModel:
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
 
-        result = get_model("MiniMax-M2.5", ModelProvider.MINIMAX)
+        result = get_model("MiniMax-M3", ModelProvider.MINIMAX)
 
         mock_chat_openai.assert_called_once_with(
-            model="MiniMax-M2.5",
+            model="MiniMax-M3",
             api_key="env-test-key",
             base_url="https://api.minimax.io/v1",
         )
@@ -153,7 +158,7 @@ class TestMiniMaxGetModel:
         # Remove MINIMAX_API_KEY from env if present
         os.environ.pop("MINIMAX_API_KEY", None)
         with pytest.raises(ValueError, match="MiniMax API key not found"):
-            get_model("MiniMax-M2.5", ModelProvider.MINIMAX)
+            get_model("MiniMax-M3", ModelProvider.MINIMAX)
 
     @patch("src.llm.models.ChatOpenAI")
     @patch.dict(
@@ -167,10 +172,10 @@ class TestMiniMaxGetModel:
         mock_instance = MagicMock()
         mock_chat_openai.return_value = mock_instance
 
-        result = get_model("MiniMax-M2.5", ModelProvider.MINIMAX)
+        result = get_model("MiniMax-M3", ModelProvider.MINIMAX)
 
         mock_chat_openai.assert_called_once_with(
-            model="MiniMax-M2.5",
+            model="MiniMax-M3",
             api_key="test-key",
             base_url="https://api.minimaxi.com/v1",
         )
@@ -207,24 +212,6 @@ class TestMiniMaxGetModel:
 
         mock_chat_openai.assert_called_once_with(
             model="MiniMax-M2.7-highspeed",
-            api_key="test-key",
-            base_url="https://api.minimax.io/v1",
-        )
-        assert result == mock_instance
-
-    @patch("src.llm.models.ChatOpenAI")
-    def test_get_model_highspeed(self, mock_chat_openai):
-        mock_instance = MagicMock()
-        mock_chat_openai.return_value = mock_instance
-
-        result = get_model(
-            "MiniMax-M2.5-highspeed",
-            ModelProvider.MINIMAX,
-            api_keys={"MINIMAX_API_KEY": "test-key"},
-        )
-
-        mock_chat_openai.assert_called_once_with(
-            model="MiniMax-M2.5-highspeed",
             api_key="test-key",
             base_url="https://api.minimax.io/v1",
         )


### PR DESCRIPTION
## Summary
Upgrade the MiniMax provider to use the latest **MiniMax-M3** as the default model. M3 has a 512K context window, up to 128K max output, and supports image input.

## Changes
- Add `MiniMax-M3` to the model list and set it as the default (first among MiniMax models)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`
- Update `.env.example` and frontend settings description to list `M3, M2.7, M2.7-highspeed`
- Update unit tests in `tests/test_minimax_provider.py`:
  - Add tests for M3 presence and that M3 is first in the MiniMax model list
  - Add test that older M2.5/M2.1/M2/M1 models are no longer present
  - Re-point existing get_model / property tests to use M3

## Why
MiniMax-M3 is the latest flagship model from MiniMax, with a 512K context window, up to 128K max output, and image input support via the same OpenAI-compatible endpoint (`https://api.minimax.io/v1`). Promoting it to default lets new users get the strongest model out of the box, while keeping M2.7 / M2.7-highspeed available for cost / latency-sensitive workloads.

## Testing
- Unit tests in `tests/test_minimax_provider.py` updated and cover: provider enum, model registration, M3 being first / default, older models removed, and `get_model()` factory for M3 / M2.7 / M2.7-highspeed.
- Verified `src/llm/api_models.json` is valid JSON and lists M3 → M2.7 → M2.7-highspeed in that order.