### PR TITLE
Fix direct src entrypoint imports

### DIFF
--- a/src/_entrypoint.py
+++ b/src/_entrypoint.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_project_root_on_path(current_file: str) -> None:
+    """Allow direct `python src/<script>.py` entrypoints to import the `src` package."""
+    project_root = Path(current_file).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -1,13 +1,20 @@
 import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from colorama import Fore, Style
 
+from src._entrypoint import ensure_project_root_on_path
 from src.main import run_hedge_fund
 from src.backtesting.engine import BacktestEngine
 from src.backtesting.types import PerformanceMetrics
 from src.cli.input import (
     parse_cli_inputs,
 )
+
+ensure_project_root_on_path(__file__)
 
 
 def run_backtest(backtester: BacktestEngine) -> PerformanceMetrics | None:

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,16 @@
 import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage
 from langgraph.graph import END, StateGraph
 from colorama import Fore, Style, init
 import questionary
+
+from src._entrypoint import ensure_project_root_on_path
 from src.agents.portfolio_manager import portfolio_management_agent
 from src.agents.risk_manager import risk_management_agent
 from src.graph.state import AgentState
@@ -20,6 +26,8 @@ import argparse
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import json
+
+ensure_project_root_on_path(__file__)
 
 # Load environment variables from .env file
 load_dotenv()

--- a/tests/test_entrypoint_bootstrap.py
+++ b/tests/test_entrypoint_bootstrap.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = PROJECT_ROOT / "src" / "_entrypoint.py"
+
+spec = importlib.util.spec_from_file_location("_entrypoint", MODULE_PATH)
+entrypoint = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(entrypoint)
+
+
+def test_ensure_project_root_on_path_inserts_repo_root(monkeypatch):
+    script_path = PROJECT_ROOT / "src" / "main.py"
+    monkeypatch.setattr(sys, "path", ["/tmp/fake-site-packages", str(script_path.parent)])
+
+    entrypoint.ensure_project_root_on_path(str(script_path))
+
+    assert sys.path[0] == str(PROJECT_ROOT)
+    assert str(script_path.parent) in sys.path
+
+
+def test_ensure_project_root_on_path_is_idempotent(monkeypatch):
+    script_path = PROJECT_ROOT / "src" / "backtester.py"
+    monkeypatch.setattr(sys, "path", [str(PROJECT_ROOT), str(script_path.parent)])
+
+    entrypoint.ensure_project_root_on_path(str(script_path))
+
+    assert sys.path.count(str(PROJECT_ROOT)) == 1


### PR DESCRIPTION
## Summary
- add a tiny entrypoint bootstrap so `python src/main.py` and `python src/backtester.py` can resolve the `src` package from the repo root
- keep the existing `src.*` package imports intact instead of rewriting imports across the codebase
- add focused regression tests for the path bootstrap helper

## Testing
- `pytest -q tests/test_entrypoint_bootstrap.py`
- `python3 -m py_compile src/_entrypoint.py src/main.py src/backtester.py tests/test_entrypoint_bootstrap.py`

Closes #517