### PR TITLE
fix: Remove src prefix from module imports

### DIFF
--- a/app/backend/models/schemas.py
+++ b/app/backend/models/schemas.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../..'))
+
 from datetime import datetime, timedelta
 from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional, Dict, Any

--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../..'))
+
 from fastapi import APIRouter, HTTPException, Request, Depends
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session

--- a/app/backend/routes/language_models.py
+++ b/app/backend/routes/language_models.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../..'))
+
 from fastapi import APIRouter, HTTPException
 from typing import List, Dict, Any
 

--- a/app/backend/services/agent_service.py
+++ b/app/backend/services/agent_service.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../..'))
+
 from functools import partial
 from typing import Callable
 from src.graph.state import AgentState

--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../..'))
+
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 import pandas as pd

--- a/app/backend/services/graph.py
+++ b/app/backend/services/graph.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../..'))
+
 import asyncio
 import json
 import re

--- a/app/backend/services/ollama_service.py
+++ b/app/backend/services/ollama_service.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../..'))
+
 import asyncio
 import os
 import sys

--- a/src/agents/aswath_damodaran.py
+++ b/src/agents/aswath_damodaran.py
@@ -4,18 +4,18 @@ import json
 from typing_extensions import Literal
 from pydantic import BaseModel
 
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 
-from src.tools.api import (
+from tools.api import (
     get_financial_metrics,
     get_market_cap,
     search_line_items,
 )
-from src.utils.api_key import get_api_key_from_state
-from src.utils.llm import call_llm
-from src.utils.progress import progress
+from utils.api_key import get_api_key_from_state
+from utils.llm import call_llm
+from utils.progress import progress
 
 
 class AswathDamodaranSignal(BaseModel):

--- a/src/agents/ben_graham.py
+++ b/src/agents/ben_graham.py
@@ -1,14 +1,14 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 import math
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 
 class BenGrahamSignal(BaseModel):

--- a/src/agents/bill_ackman.py
+++ b/src/agents/bill_ackman.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class BillAckmanSignal(BaseModel):

--- a/src/agents/cathie_wood.py
+++ b/src/agents/cathie_wood.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class CathieWoodSignal(BaseModel):

--- a/src/agents/charlie_munger.py
+++ b/src/agents/charlie_munger.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items, get_insider_trades, get_company_news
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items, get_insider_trades, get_company_news
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 class CharlieMungerSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/fundamentals.py
+++ b/src/agents/fundamentals.py
@@ -1,10 +1,10 @@
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.api_key import get_api_key_from_state
-from src.utils.progress import progress
+from graph.state import AgentState, show_agent_reasoning
+from utils.api_key import get_api_key_from_state
+from utils.progress import progress
 import json
 
-from src.tools.api import get_financial_metrics
+from tools.api import get_financial_metrics
 
 
 ##### Fundamental Agent #####

--- a/src/agents/growth_agent.py
+++ b/src/agents/growth_agent.py
@@ -8,10 +8,10 @@ Implements a growth-focused valuation methodology.
 import json
 import statistics
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
+from tools.api import (
     get_financial_metrics,
     get_insider_trades,
 )

--- a/src/agents/michael_burry.py
+++ b/src/agents/michael_burry.py
@@ -4,21 +4,21 @@ from datetime import datetime, timedelta
 import json
 from typing_extensions import Literal
 
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.messages import HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel
 
-from src.tools.api import (
+from tools.api import (
     get_company_news,
     get_financial_metrics,
     get_insider_trades,
     get_market_cap,
     search_line_items,
 )
-from src.utils.llm import call_llm
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
+from utils.llm import call_llm
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
 
 
 class MichaelBurrySignal(BaseModel):

--- a/src/agents/mohnish_pabrai.py
+++ b/src/agents/mohnish_pabrai.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class MohnishPabraiSignal(BaseModel):

--- a/src/agents/news_sentiment.py
+++ b/src/agents/news_sentiment.py
@@ -2,16 +2,16 @@
 
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel, Field
-from src.data.models import CompanyNews
+from data.models import CompanyNews
 import pandas as pd
 import numpy as np
 import json
 
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_company_news
-from src.utils.api_key import get_api_key_from_state
-from src.utils.llm import call_llm
-from src.utils.progress import progress
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_company_news
+from utils.api_key import get_api_key_from_state
+from utils.llm import call_llm
+from utils.progress import progress
 from typing_extensions import Literal
 
 

--- a/src/agents/peter_lynch.py
+++ b/src/agents/peter_lynch.py
@@ -1,5 +1,5 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import (
     get_market_cap,
     search_line_items,
     get_insider_trades,
@@ -10,9 +10,9 @@ from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class PeterLynchSignal(BaseModel):

--- a/src/agents/phil_fisher.py
+++ b/src/agents/phil_fisher.py
@@ -1,5 +1,5 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import (
     get_market_cap,
     search_line_items,
     get_insider_trades,
@@ -10,10 +10,10 @@ from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 import statistics
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 class PhilFisherSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/portfolio_manager.py
+++ b/src/agents/portfolio_manager.py
@@ -3,11 +3,11 @@ import time
 from langchain_core.messages import HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
 
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 
 
 class PortfolioDecision(BaseModel):

--- a/src/agents/rakesh_jhunjhunwala.py
+++ b/src/agents/rakesh_jhunjhunwala.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
-from src.utils.llm import call_llm
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
+from utils.llm import call_llm
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
 
 class RakeshJhunjhunwalaSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -1,11 +1,11 @@
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
-from src.tools.api import get_prices, prices_to_df
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
+from tools.api import get_prices, prices_to_df
 import json
 import numpy as np
 import pandas as pd
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 ##### Risk Management Agent #####
 def risk_management_agent(state: AgentState, agent_id: str = "risk_management_agent"):

--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -1,11 +1,11 @@
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
 import pandas as pd
 import numpy as np
 import json
-from src.utils.api_key import get_api_key_from_state
-from src.tools.api import get_insider_trades, get_company_news
+from utils.api_key import get_api_key_from_state
+from tools.api import get_insider_trades, get_company_news
 
 
 ##### Sentiment Agent #####

--- a/src/agents/stanley_druckenmiller.py
+++ b/src/agents/stanley_druckenmiller.py
@@ -1,5 +1,5 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import (
     get_financial_metrics,
     get_market_cap,
     search_line_items,
@@ -12,10 +12,10 @@ from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 import statistics
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 class StanleyDruckenmillerSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/technicals.py
+++ b/src/agents/technicals.py
@@ -2,14 +2,14 @@ import math
 
 from langchain_core.messages import HumanMessage
 
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.api_key import get_api_key_from_state
+from graph.state import AgentState, show_agent_reasoning
+from utils.api_key import get_api_key_from_state
 import json
 import pandas as pd
 import numpy as np
 
-from src.tools.api import get_prices, prices_to_df
-from src.utils.progress import progress
+from tools.api import get_prices, prices_to_df
+from utils.progress import progress
 
 
 def safe_float(value, default=0.0):

--- a/src/agents/valuation.py
+++ b/src/agents/valuation.py
@@ -9,10 +9,10 @@ configurable weights.
 import json
 import statistics
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
+from tools.api import (
     get_financial_metrics,
     get_market_cap,
     search_line_items,

--- a/src/agents/warren_buffett.py
+++ b/src/agents/warren_buffett.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel, Field
 import json
 from typing_extensions import Literal
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
-from src.utils.llm import call_llm
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
+from utils.llm import call_llm
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
 
 
 class WarrenBuffettSignal(BaseModel):

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -2,10 +2,10 @@ import sys
 
 from colorama import Fore, Style
 
-from src.main import run_hedge_fund
-from src.backtesting.engine import BacktestEngine
-from src.backtesting.types import PerformanceMetrics
-from src.cli.input import (
+from main import run_hedge_fund
+from backtesting.engine import BacktestEngine
+from backtesting.types import PerformanceMetrics
+from cli.input import (
     parse_cli_inputs,
 )
 

--- a/src/backtesting/benchmarks.py
+++ b/src/backtesting/benchmarks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from src.tools.api import get_price_data
+from tools.api import get_price_data
 
 
 class BenchmarkCalculator:

--- a/src/backtesting/cli.py
+++ b/src/backtesting/cli.py
@@ -9,10 +9,10 @@ from colorama import Fore, Style, init
 import questionary
 
 from .engine import BacktestEngine
-from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider
-from src.utils.analysts import ANALYST_ORDER
-from src.main import run_hedge_fund
-from src.utils.ollama import ensure_ollama_and_model
+from llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider
+from utils.analysts import ANALYST_ORDER
+from main import run_hedge_fund
+from utils.ollama import ensure_ollama_and_model
 
 
 def main() -> int:

--- a/src/backtesting/engine.py
+++ b/src/backtesting/engine.py
@@ -15,7 +15,7 @@ from .valuation import calculate_portfolio_value, compute_exposures
 from .output import OutputBuilder
 from .benchmarks import BenchmarkCalculator
 
-from src.tools.api import (
+from tools.api import (
     get_company_news,
     get_price_data,
     get_prices,

--- a/src/backtesting/output.py
+++ b/src/backtesting/output.py
@@ -4,7 +4,7 @@ from typing import List, Mapping, Sequence
 
 from .portfolio import Portfolio
 from .types import AgentOutput
-from src.utils.display import format_backtest_row, print_backtest_results
+from utils.display import format_backtest_row, print_backtest_results
 from .valuation import compute_portfolio_summary
 
 

--- a/src/cli/input.py
+++ b/src/cli/input.py
@@ -5,9 +5,9 @@ import argparse
 import questionary
 from colorama import Fore, Style
 
-from src.utils.analysts import ANALYST_ORDER
-from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, find_model_by_name
-from src.utils.ollama import ensure_ollama_and_model
+from utils.analysts import ANALYST_ORDER
+from llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, find_model_by_name
+from utils.ollama import ensure_ollama_and_model
 
 from dataclasses import dataclass
 from typing import Optional

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -6,7 +6,6 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_groq import ChatGroq
 from langchain_xai import ChatXAI
 from langchain_openai import ChatOpenAI, AzureChatOpenAI
-from langchain_openai import ChatOpenAI
 from langchain_gigachat import GigaChat
 from langchain_ollama import ChatOllama
 from enum import Enum

--- a/src/main.py
+++ b/src/main.py
@@ -5,14 +5,14 @@ from langchain_core.messages import HumanMessage
 from langgraph.graph import END, StateGraph
 from colorama import Fore, Style, init
 import questionary
-from src.agents.portfolio_manager import portfolio_management_agent
-from src.agents.risk_manager import risk_management_agent
-from src.graph.state import AgentState
-from src.utils.display import print_trading_output
-from src.utils.analysts import ANALYST_ORDER, get_analyst_nodes
-from src.utils.progress import progress
-from src.utils.visualize import save_graph_as_png
-from src.cli.input import (
+from agents.portfolio_manager import portfolio_management_agent
+from agents.risk_manager import risk_management_agent
+from graph.state import AgentState
+from utils.display import print_trading_output
+from utils.analysts import ANALYST_ORDER, get_analyst_nodes
+from utils.progress import progress
+from utils.visualize import save_graph_as_png
+from cli.input import (
     parse_cli_inputs,
 )
 

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -4,8 +4,8 @@ import pandas as pd
 import requests
 import time
 
-from src.data.cache import get_cache
-from src.data.models import (
+from data.cache import get_cache
+from data.models import (
     CompanyNews,
     CompanyNewsResponse,
     FinancialMetrics,

--- a/src/utils/analysts.py
+++ b/src/utils/analysts.py
@@ -1,24 +1,24 @@
 """Constants and utilities related to analysts configuration."""
 
-from src.agents import portfolio_manager
-from src.agents.aswath_damodaran import aswath_damodaran_agent
-from src.agents.ben_graham import ben_graham_agent
-from src.agents.bill_ackman import bill_ackman_agent
-from src.agents.cathie_wood import cathie_wood_agent
-from src.agents.charlie_munger import charlie_munger_agent
-from src.agents.fundamentals import fundamentals_analyst_agent
-from src.agents.michael_burry import michael_burry_agent
-from src.agents.phil_fisher import phil_fisher_agent
-from src.agents.peter_lynch import peter_lynch_agent
-from src.agents.sentiment import sentiment_analyst_agent
-from src.agents.stanley_druckenmiller import stanley_druckenmiller_agent
-from src.agents.technicals import technical_analyst_agent
-from src.agents.valuation import valuation_analyst_agent
-from src.agents.warren_buffett import warren_buffett_agent
-from src.agents.rakesh_jhunjhunwala import rakesh_jhunjhunwala_agent
-from src.agents.mohnish_pabrai import mohnish_pabrai_agent
-from src.agents.news_sentiment import news_sentiment_agent
-from src.agents.growth_agent import growth_analyst_agent
+from agents import portfolio_manager
+from agents.aswath_damodaran import aswath_damodaran_agent
+from agents.ben_graham import ben_graham_agent
+from agents.bill_ackman import bill_ackman_agent
+from agents.cathie_wood import cathie_wood_agent
+from agents.charlie_munger import charlie_munger_agent
+from agents.fundamentals import fundamentals_analyst_agent
+from agents.michael_burry import michael_burry_agent
+from agents.phil_fisher import phil_fisher_agent
+from agents.peter_lynch import peter_lynch_agent
+from agents.sentiment import sentiment_analyst_agent
+from agents.stanley_druckenmiller import stanley_druckenmiller_agent
+from agents.technicals import technical_analyst_agent
+from agents.valuation import valuation_analyst_agent
+from agents.warren_buffett import warren_buffett_agent
+from agents.rakesh_jhunjhunwala import rakesh_jhunjhunwala_agent
+from agents.mohnish_pabrai import mohnish_pabrai_agent
+from agents.news_sentiment import news_sentiment_agent
+from agents.growth_agent import growth_analyst_agent
 
 # Define analyst configuration - single source of truth
 ANALYST_CONFIG = {

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -2,9 +2,9 @@
 
 import json
 from pydantic import BaseModel
-from src.llm.models import get_model, get_model_info
-from src.utils.progress import progress
-from src.graph.state import AgentState
+from llm.models import get_model, get_model_info
+from utils.progress import progress
+from graph.state import AgentState
 
 
 def call_llm(

--- a/tests/backtesting/conftest.py
+++ b/tests/backtesting/conftest.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 import pytest
 
 from src.backtesting.portfolio import Portfolio

--- a/tests/backtesting/integration/mocks.py
+++ b/tests/backtesting/integration/mocks.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.types import AgentOutput
 
 

--- a/tests/backtesting/integration/test_integration_long_only.py
+++ b/tests/backtesting/integration/test_integration_long_only.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.engine import BacktestEngine
 from tests.backtesting.integration.mocks import MockConfigurableAgent
 

--- a/tests/backtesting/integration/test_integration_long_short.py
+++ b/tests/backtesting/integration/test_integration_long_short.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.engine import BacktestEngine
 from tests.backtesting.integration.mocks import MockConfigurableAgent
 

--- a/tests/backtesting/integration/test_integration_short_only.py
+++ b/tests/backtesting/integration/test_integration_short_only.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.engine import BacktestEngine
 from tests.backtesting.integration.mocks import MockConfigurableAgent
 

--- a/tests/backtesting/test_controller.py
+++ b/tests/backtesting/test_controller.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.controller import AgentController
 
 

--- a/tests/backtesting/test_execution.py
+++ b/tests/backtesting/test_execution.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.trader import TradeExecutor
 
 

--- a/tests/backtesting/test_metrics.py
+++ b/tests/backtesting/test_metrics.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from datetime import datetime, timedelta
 
 import numpy as np

--- a/tests/backtesting/test_portfolio.py
+++ b/tests/backtesting/test_portfolio.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 import math
 
 import pytest

--- a/tests/backtesting/test_results.py
+++ b/tests/backtesting/test_results.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.output import OutputBuilder
 
 

--- a/tests/backtesting/test_valuation.py
+++ b/tests/backtesting/test_valuation.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 from src.backtesting.valuation import calculate_portfolio_value, compute_exposures, compute_portfolio_summary
 
 

--- a/tests/test_api_rate_limiting.py
+++ b/tests/test_api_rate_limiting.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 import os
 import pytest
 from unittest.mock import Mock, patch, call


### PR DESCRIPTION
When running python src/main.py, Python adds the src directory to sys.path, so all modules within src can be imported directly without the src. prefix.

This fixes ModuleNotFoundError: No module named src on Windows 11 and other environments where the src prefix causes issues.

Fixes #517