### PR TITLE
fix: replace bare except clauses with Exception in api.py

### DIFF
--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -1,8 +1,11 @@
 import datetime
+import logging
 import os
 import pandas as pd
 import requests
 import time
+
+logger = logging.getLogger(__name__)
 
 from src.data.cache import get_cache
 from src.data.models import (
@@ -81,7 +84,8 @@ def get_prices(ticker: str, start_date: str, end_date: str, api_key: str = None)
     try:
         price_response = PriceResponse(**response.json())
         prices = price_response.prices
-    except:
+    except Exception as e:
+        logger.warning("Failed to parse price response for %s: %s", ticker, e)
         return []
 
     if not prices:
@@ -122,7 +126,8 @@ def get_financial_metrics(
     try:
         metrics_response = FinancialMetricsResponse(**response.json())
         financial_metrics = metrics_response.financial_metrics
-    except:
+    except Exception as e:
+        logger.warning("Failed to parse financial metrics response for %s: %s", ticker, e)
         return []
 
     if not financial_metrics:
@@ -165,7 +170,8 @@ def search_line_items(
         data = response.json()
         response_model = LineItemResponse(**data)
         search_results = response_model.search_results
-    except:
+    except Exception as e:
+        logger.warning("Failed to parse line items response for %s: %s", ticker, e)
         return []
     if not search_results:
         return []
@@ -212,8 +218,9 @@ def get_insider_trades(
             data = response.json()
             response_model = InsiderTradeResponse(**data)
             insider_trades = response_model.insider_trades
-        except:
-            break  # Parsing error, exit loop
+        except Exception as e:
+            logger.warning("Failed to parse insider trades response for %s: %s", ticker, e)
+            break
 
         if not insider_trades:
             break
@@ -277,8 +284,9 @@ def get_company_news(
             data = response.json()
             response_model = CompanyNewsResponse(**data)
             company_news = response_model.news
-        except:
-            break  # Parsing error, exit loop
+        except Exception as e:
+            logger.warning("Failed to parse company news response for %s: %s", ticker, e)
+            break
 
         if not company_news:
             break


### PR DESCRIPTION
## Summary

- Replace all 5 bare `except:` clauses in `src/tools/api.py` with `except Exception as e:`
- Add `logger.warning()` calls so parsing failures are visible in logs instead of silently returning empty results
- Bare `except:` catches `KeyboardInterrupt`, `SystemExit`, and `MemoryError`, making the program uninterruptible and hiding all diagnostic information

## Related Issues

Closes #448 — Users see "Error in analysis, using default" with no diagnostic information because parsing errors are silently swallowed.

Also helps with #409, #400, #395 — all related to missing error diagnostics.

## Changes

| File | Change |
|------|--------|
| `src/tools/api.py` | 5x `except:` → `except Exception as e:` + `logger.warning(...)` |

## Test plan

- [ ] Verify existing tests pass (no behavioral change for success paths)
- [ ] Trigger a parse error to confirm warning appears in logs
- [ ] Verify `KeyboardInterrupt` now properly terminates the program during API calls