### PR TITLE
fix: raise ValueError for unsupported providers and remove duplicate import

### DIFF
--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -6,7 +6,6 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_groq import ChatGroq
 from langchain_xai import ChatXAI
 from langchain_openai import ChatOpenAI, AzureChatOpenAI
-from langchain_openai import ChatOpenAI
 from langchain_gigachat import GigaChat
 from langchain_ollama import ChatOllama
 from enum import Enum
@@ -236,3 +235,8 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             print(f"Azure Deployment Name Error: Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
             raise ValueError("Azure OpenAI deployment name not found.  Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
         return AzureChatOpenAI(azure_endpoint=azure_endpoint, azure_deployment=azure_deployment_name, api_key=api_key, api_version="2024-10-21")
+    else:
+        raise ValueError(
+            f"Unsupported model provider: {model_provider}. "
+            f"Supported providers: {', '.join(p.value for p in ModelProvider)}"
+        )


### PR DESCRIPTION
## Summary

- `get_model()` silently returns `None` when called with `ALIBABA`, `META`, or `MISTRAL` providers (defined in `ModelProvider` enum but missing from the if/elif chain). Callers then invoke `None.invoke(prompt)`, raising an opaque `AttributeError`.
- Add an explicit `else` branch that raises `ValueError` with a clear error message listing all supported providers.
- Remove duplicate `from langchain_openai import ChatOpenAI` import (line 9 duplicates line 8).

## Changes

| File | Change |
|------|--------|
| `src/llm/models.py` | Add `else: raise ValueError(...)` at end of `get_model()` |
| `src/llm/models.py` | Remove duplicate import on line 9 |

## Test plan

- [ ] Verify existing provider handling is unchanged
- [ ] Call `get_model("test", ModelProvider.ALIBABA)` and confirm clear `ValueError` instead of silent `None`