### PR TITLE
fix: remove duplicate ChatOpenAI import

### DIFF
--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -6,7 +6,6 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_groq import ChatGroq
 from langchain_xai import ChatXAI
 from langchain_openai import ChatOpenAI, AzureChatOpenAI
-from langchain_openai import ChatOpenAI
 from langchain_gigachat import GigaChat
 from langchain_ollama import ChatOllama
 from enum import Enum


### PR DESCRIPTION
## Description
Remove duplicate import of `ChatOpenAI` from `langchain_openai` module.

## Changes
- Removed redundant line: `from langchain_openai import ChatOpenAI`
- The module was already imported in the previous line with `AzureChatOpenAI`