### PR TITLE
fix: log API failures and handle missing data in Ben Graham agent

### DIFF
--- a/src/agents/ben_graham.py
+++ b/src/agents/ben_graham.py
@@ -43,6 +43,16 @@ def ben_graham_agent(state: AgentState, agent_id: str = "ben_graham_agent"):
         progress.update_status(agent_id, ticker, "Getting market cap")
         market_cap = get_market_cap(ticker, end_date, api_key=api_key)
 
+        # If we have no data at all, skip the analysis and return neutral
+        if not metrics and not financial_line_items and not market_cap:
+            graham_analysis[ticker] = {
+                "signal": "neutral",
+                "confidence": 0.0,
+                "reasoning": "Insufficient data available for this ticker. Cannot perform Graham analysis.",
+            }
+            progress.update_status(agent_id, ticker, "Done (no data available)")
+            continue
+
         # Perform sub-analyses
         progress.update_status(agent_id, ticker, "Analyzing earnings stability")
         earnings_analysis = analyze_earnings_stability(metrics, financial_line_items)

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -78,14 +78,15 @@ def get_prices(ticker: str, start_date: str, end_date: str, api_key: str = None)
     url = f"https://api.financialdatasets.ai/prices/?ticker={ticker}&interval=day&interval_multiplier=1&start_date={start_date}&end_date={end_date}"
     response = _make_api_request(url, headers)
     if response.status_code != 200:
+        logger.warning("Could not fetch prices for %s (HTTP %s)", ticker, response.status_code)
         return []
 
     # Parse response with Pydantic model
     try:
         price_response = PriceResponse(**response.json())
         prices = price_response.prices
-    except Exception as e:
-        logger.warning("Failed to parse price response for %s: %s", ticker, e)
+    except (ValueError, KeyError) as e:
+        logger.warning("Failed to parse price data for %s: %s", ticker, e)
         return []
 
     if not prices:
@@ -120,14 +121,15 @@ def get_financial_metrics(
     url = f"https://api.financialdatasets.ai/financial-metrics/?ticker={ticker}&report_period_lte={end_date}&limit={limit}&period={period}"
     response = _make_api_request(url, headers)
     if response.status_code != 200:
+        logger.warning("Could not fetch financial metrics for %s (HTTP %s)", ticker, response.status_code)
         return []
 
     # Parse response with Pydantic model
     try:
         metrics_response = FinancialMetricsResponse(**response.json())
         financial_metrics = metrics_response.financial_metrics
-    except Exception as e:
-        logger.warning("Failed to parse financial metrics response for %s: %s", ticker, e)
+    except (ValueError, KeyError) as e:
+        logger.warning("Failed to parse financial metrics for %s: %s", ticker, e)
         return []
 
     if not financial_metrics:
@@ -164,14 +166,15 @@ def search_line_items(
     }
     response = _make_api_request(url, headers, method="POST", json_data=body)
     if response.status_code != 200:
+        logger.warning("Could not fetch line items for %s (HTTP %s)", ticker, response.status_code)
         return []
-    
+
     try:
         data = response.json()
         response_model = LineItemResponse(**data)
         search_results = response_model.search_results
-    except Exception as e:
-        logger.warning("Failed to parse line items response for %s: %s", ticker, e)
+    except (ValueError, KeyError) as e:
+        logger.warning("Failed to parse line items for %s: %s", ticker, e)
         return []
     if not search_results:
         return []
@@ -212,14 +215,15 @@ def get_insider_trades(
 
         response = _make_api_request(url, headers)
         if response.status_code != 200:
+            logger.warning("Could not fetch insider trades for %s (HTTP %s)", ticker, response.status_code)
             break
 
         try:
             data = response.json()
             response_model = InsiderTradeResponse(**data)
             insider_trades = response_model.insider_trades
-        except Exception as e:
-            logger.warning("Failed to parse insider trades response for %s: %s", ticker, e)
+        except (ValueError, KeyError) as e:
+            logger.warning("Failed to parse insider trades for %s: %s", ticker, e)
             break
 
         if not insider_trades:
@@ -278,14 +282,15 @@ def get_company_news(
 
         response = _make_api_request(url, headers)
         if response.status_code != 200:
+            logger.warning("Could not fetch company news for %s (HTTP %s)", ticker, response.status_code)
             break
 
         try:
             data = response.json()
             response_model = CompanyNewsResponse(**data)
             company_news = response_model.news
-        except Exception as e:
-            logger.warning("Failed to parse company news response for %s: %s", ticker, e)
+        except (ValueError, KeyError) as e:
+            logger.warning("Failed to parse company news for %s: %s", ticker, e)
             break
 
         if not company_news:
@@ -329,7 +334,7 @@ def get_market_cap(
         url = f"https://api.financialdatasets.ai/company/facts/?ticker={ticker}"
         response = _make_api_request(url, headers)
         if response.status_code != 200:
-            print(f"Error fetching company facts: {ticker} - {response.status_code}")
+            logger.warning("Could not fetch company facts for %s (HTTP %s)", ticker, response.status_code)
             return None
 
         data = response.json()


### PR DESCRIPTION
## Summary

- **API calls that fail (e.g. HTTP 401 for unsupported tickers) were completely silent** — returning empty lists with no logging. This made it very difficult to diagnose why agents produced unexpected output.
- **The Ben Graham agent interpreted "no data" as a bearish signal** — when all API calls returned empty, the scoring logic produced a total score of 0, which mapped to "bearish." The agent would then confidently recommend against a stock it knew nothing about.

### Changes

- Add warning messages for non-200 API responses across all functions in `src/tools/api.py`
- Replace bare `except:` clauses with specific exception types (`ValueError`, `KeyError`)
- Short-circuit the Ben Graham agent to return `neutral` with `0.0` confidence when no data is available for a ticker

### Note
The same "no data → false bearish" pattern exists in the other 15 agents. This PR fixes Ben Graham as a focused first step — the same guard could be extended to the remaining agents in a follow-up.

## Test plan
- [x] All 44 existing tests pass
- [ ] Run with a ticker that has full API coverage (e.g. AAPL) — should behave as before
- [ ] Run with a ticker that lacks API coverage (e.g. SYM) — should now show warnings and return neutral/0-confidence instead of bearish

🤖 Generated with [Claude Code](https://claude.com/claude-code)