### PR TITLE
fix: prevent pagination infinite loop in insider trades and company news

### DIFF
--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -203,8 +203,9 @@ def get_insider_trades(
 
     all_trades = []
     current_end_date = end_date
+    max_iterations = 100
 
-    while True:
+    for _ in range(max_iterations):
         url = f"https://api.financialdatasets.ai/insider-trades/?ticker={ticker}&filing_date_lte={current_end_date}"
         if start_date:
             url += f"&filing_date_gte={start_date}"
@@ -232,7 +233,12 @@ def get_insider_trades(
             break
 
         # Update end_date to the oldest filing date from current batch for next iteration
+        prev_end_date = current_end_date
         current_end_date = min(trade.filing_date for trade in insider_trades).split("T")[0]
+
+        # Break if no progress (all items share the same date, so end_date didn't change)
+        if current_end_date == prev_end_date:
+            break
 
         # If we've reached or passed the start_date, we can stop
         if current_end_date <= start_date:
@@ -269,8 +275,9 @@ def get_company_news(
 
     all_news = []
     current_end_date = end_date
+    max_iterations = 100
 
-    while True:
+    for _ in range(max_iterations):
         url = f"https://api.financialdatasets.ai/news/?ticker={ticker}&end_date={current_end_date}"
         if start_date:
             url += f"&start_date={start_date}"
@@ -298,7 +305,12 @@ def get_company_news(
             break
 
         # Update end_date to the oldest date from current batch for next iteration
+        prev_end_date = current_end_date
         current_end_date = min(news.date for news in company_news).split("T")[0]
+
+        # Break if no progress (all items share the same date, so end_date didn't change)
+        if current_end_date == prev_end_date:
+            break
 
         # If we've reached or passed the start_date, we can stop
         if current_end_date <= start_date:


### PR DESCRIPTION
Closes #537, related to #395 and #400

Both `get_insider_trades` and `get_company_news` can enter an infinite loop when all items in a page share the same date, because `current_end_date` doesn't advance.

**Fix:**
- Track the previous end date and break if no progress is made
- Add a max iteration guard (100 iterations) as a safety net

This prevents the system from hanging during data fetches.