### PR TITLE
fix: prevent infinite pagination loop when dates are identical

### DIFF
--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -203,8 +203,14 @@ def get_insider_trades(
 
     all_trades = []
     current_end_date = end_date
+    previous_end_date = None
 
     while True:
+        # Break if we're stuck in a loop (no progress between iterations)
+        if previous_end_date is not None and current_end_date == previous_end_date:
+            break
+        previous_end_date = current_end_date
+
         url = f"https://api.financialdatasets.ai/insider-trades/?ticker={ticker}&filing_date_lte={current_end_date}"
         if start_date:
             url += f"&filing_date_gte={start_date}"
@@ -269,8 +275,14 @@ def get_company_news(
 
     all_news = []
     current_end_date = end_date
+    previous_end_date = None
 
     while True:
+        # Break if we're stuck in a loop (no progress between iterations)
+        if previous_end_date is not None and current_end_date == previous_end_date:
+            break
+        previous_end_date = current_end_date
+
         url = f"https://api.financialdatasets.ai/news/?ticker={ticker}&end_date={current_end_date}"
         if start_date:
             url += f"&start_date={start_date}"


### PR DESCRIPTION
## Summary

When all items in a page share the same filing/publication date, current_end_date doesn't change between iterations, causing the same page to be fetched repeatedly.

This fix tracks the previous end_date and breaks the loop if there's no progress between iterations.

## Changes

- Added previous_end_date tracking in both get_insider_trades() and get_company_news() functions
- Break the pagination loop if current_end_date == previous_end_date

## Fixes

Fixes #537