### PR TITLE
feat: add DashScope LLM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,11 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 AZURE_OPENAI_API_KEY=your-azure-openai-api-key
 AZURE_OPENAI_ENDPOINT=your-azure-openai-endpoint
 AZURE_OPENAI_DEPLOYMENT_NAME=your-azure-openai-deployment-name
+
+# For running LLMs hosted by Alibaba Cloud DashScope (both regular and Coding Plan modes)
+# Get your DashScope API key from https://dashscope.console.aliyun.com/
+DASHSCOPE_API_KEY=your-dashscope-api-key
+
+# Optional: Set to "coding" to use Coding Plan mode (fixed monthly fee)
+# Leave empty or unset for regular pay-per-use mode
+# DASHSCOPE_API_BASE=coding

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -65,6 +65,46 @@
     "provider": "GigaChat"
   },
   {
+    "display_name": "Qwen3.5 Plus",
+    "model_name": "qwen3.5-plus",
+    "provider": "DashScope"
+  },
+  {
+    "display_name": "Qwen3 Max (2026-01-23)",
+    "model_name": "qwen3-max-2026-01-23",
+    "provider": "DashScope"
+  },
+  {
+    "display_name": "Qwen3 Coder Next",
+    "model_name": "qwen3-coder-next",
+    "provider": "DashScope"
+  },
+  {
+    "display_name": "Qwen3 Coder Plus",
+    "model_name": "qwen3-coder-plus",
+    "provider": "DashScope"
+  },
+  {
+    "display_name": "GLM-5",
+    "model_name": "glm-5",
+    "provider": "DashScope"
+  },
+  {
+    "display_name": "GLM-4.7",
+    "model_name": "glm-4.7",
+    "provider": "DashScope"
+  },
+  {
+    "display_name": "Kimi K2.5",
+    "model_name": "kimi-k2.5",
+    "provider": "DashScope"
+  },
+  {
+    "display_name": "MiniMax M2.5",
+    "model_name": "MiniMax-M2.5",
+    "provider": "DashScope"
+  },
+  {
     "display_name": "Azure Open AI Deployment",
     "model_name": "",
     "provider": "Azure OpenAI"

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -30,6 +30,7 @@ class ModelProvider(str, Enum):
     GIGACHAT = "GigaChat"
     AZURE_OPENAI = "Azure OpenAI"
     XAI = "xAI"
+    DASHSCOPE = "DashScope"
 
 
 class LLMModel(BaseModel):
@@ -205,6 +206,21 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             print(f"API Key Error: Please make sure XAI_API_KEY is set in your .env file or provided via API keys.")
             raise ValueError("xAI API key not found. Please make sure XAI_API_KEY is set in your .env file or provided via API keys.")
         return ChatXAI(model=model_name, api_key=api_key)
+    elif model_provider == ModelProvider.DASHSCOPE:
+        api_key = (api_keys or {}).get("DASHSCOPE_API_KEY") or os.getenv("DASHSCOPE_API_KEY")
+        if not api_key:
+            print(f"API Key Error: Please make sure DASHSCOPE_API_KEY is set in your .env file or provided via API keys.")
+            raise ValueError("DashScope API key not found. Please make sure DASHSCOPE_API_KEY is set in your .env file or provided via API keys.")
+        
+        # Determine base URL based on DASHSCOPE_API_BASE setting
+        # Set DASHSCOPE_API_BASE="coding" to use Coding Plan mode
+        api_base_config = os.getenv("DASHSCOPE_API_BASE", "")
+        if api_base_config == "coding":
+            base_url = "https://coding.dashscope.aliyuncs.com/v1"
+        else:
+            base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)
     elif model_provider == ModelProvider.GIGACHAT:
         if os.getenv("GIGACHAT_USER") or os.getenv("GIGACHAT_PASSWORD"):
             return GigaChat(model=model_name)


### PR DESCRIPTION
## Summary

- Add DASHSCOPE provider enum in models.py
- Add 8 DashScope models (qwen3.5-plus, qwen3-max, glm-5, kimi-k2.5, MiniMax-M2.5, etc.)
- Implement get_model() with OpenAI-compatible protocol
- Support both regular mode and Coding Plan mode via DASHSCOPE_API_BASE environment variable
- Add environment variables to .env.example

## Usage

**Regular mode (pay-per-use):**
```bash
DASHSCOPE_API_KEY=your-api-key
```

**Coding Plan mode:**
```bash
DASHSCOPE_API_KEY=your-coding-plan-api-key
DASHSCOPE_API_BASE=coding
```

## Test Plan

- [x] Verified DashScope models load correctly
- [x] Verified regular mode uses correct base URL
- [x] Verified Coding Plan mode uses correct base URL