### PR TITLE
feat: add MLX local model support for Apple Silicon

### DIFF
--- a/app/backend/routes/__init__.py
+++ b/app/backend/routes/__init__.py
@@ -8,6 +8,7 @@ from app.backend.routes.flow_runs import router as flow_runs_router
 from app.backend.routes.ollama import router as ollama_router
 from app.backend.routes.language_models import router as language_models_router
 from app.backend.routes.api_keys import router as api_keys_router
+from app.backend.routes.mlx import router as mlx_router
 
 # Main API router
 api_router = APIRouter()
@@ -21,3 +22,4 @@ api_router.include_router(flow_runs_router, tags=["flow-runs"])
 api_router.include_router(ollama_router, tags=["ollama"])
 api_router.include_router(language_models_router, tags=["language-models"])
 api_router.include_router(api_keys_router, tags=["api-keys"])
+api_router.include_router(mlx_router, tags=["mlx"])

--- a/app/backend/routes/mlx.py
+++ b/app/backend/routes/mlx.py
@@ -1,0 +1,28 @@
+import os
+from fastapi import APIRouter, HTTPException
+from app.backend.models.schemas import ErrorResponse
+
+router = APIRouter(prefix="/mlx")
+
+
+@router.get(
+    path="/status",
+    responses={
+        200: {"description": "MLX server status"},
+        500: {"model": ErrorResponse, "description": "Internal server error"},
+    },
+)
+async def get_mlx_status():
+    """Check if the MLX LM server is reachable."""
+    try:
+        from src.utils.mlx_lm import is_mlx_server_running, _get_mlx_base_url
+        running = is_mlx_server_running()
+        base_url = _get_mlx_base_url()
+        # Strip /v1 suffix for display
+        server_url = base_url.rstrip("/v1").rstrip("/") if base_url.endswith("/v1") else base_url
+        return {
+            "running": running,
+            "server_url": server_url,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to check MLX status: {str(e)}")

--- a/app/frontend/src/components/settings/models.tsx
+++ b/app/frontend/src/components/settings/models.tsx
@@ -1,7 +1,8 @@
 import { cn } from '@/lib/utils';
-import { Cloud, Server } from 'lucide-react';
+import { Cloud, Cpu, Server } from 'lucide-react';
 import { useState } from 'react';
 import { CloudModels } from './models/cloud';
+import { MlxSettings } from './models/mlx';
 import { OllamaSettings } from './models/ollama';
 
 interface ModelsProps {
@@ -33,6 +34,13 @@ export function Models({ className }: ModelsProps) {
       icon: Server,
       description: 'Ollama models running locally on your machine',
       component: OllamaSettings,
+    },
+    {
+      id: 'mlx',
+      label: 'MLX',
+      icon: Cpu,
+      description: 'MLX models for Apple Silicon local inference',
+      component: MlxSettings,
     },
   ];
 

--- a/app/frontend/src/components/settings/models/mlx.tsx
+++ b/app/frontend/src/components/settings/models/mlx.tsx
@@ -1,0 +1,187 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { AlertTriangle, Brain, CheckCircle, Cpu, RefreshCw } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface MlxModel {
+  display_name: string;
+  model_name: string;
+  provider: string;
+}
+
+interface MlxStatus {
+  running: boolean;
+  server_url: string;
+  error?: string;
+}
+
+export function MlxSettings() {
+  const [models, setModels] = useState<MlxModel[]>([]);
+  const [status, setStatus] = useState<MlxStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMlxStatus = async () => {
+    try {
+      const response = await fetch('http://localhost:8000/mlx/status');
+      if (response.ok) {
+        const data = await response.json();
+        setStatus(data);
+        setError(null);
+      } else {
+        setStatus({ running: false, server_url: '' });
+      }
+    } catch {
+      setStatus({ running: false, server_url: '' });
+    }
+  };
+
+  const fetchMlxModels = async () => {
+    try {
+      const response = await fetch('http://localhost:8000/language-models/');
+      if (response.ok) {
+        const data = await response.json();
+        const mlxModels = (data.models || []).filter((m: MlxModel) => m.provider === 'MLX' && m.model_name !== '-');
+        setModels(mlxModels);
+      }
+    } catch (err) {
+      console.error('Failed to fetch MLX models:', err);
+    }
+  };
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    await Promise.all([fetchMlxStatus(), fetchMlxModels()]);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-primary mb-2">MLX Local Models</h3>
+          <p className="text-sm text-muted-foreground">
+            Run AI models locally on Apple Silicon using{' '}
+            <button
+              className="underline hover:no-underline text-muted-foreground"
+              onClick={() => window.open('https://github.com/ml-explore/mlx-examples/tree/main/llms', '_blank')}
+            >
+              mlx-lm
+            </button>.
+            Set the server URL in API Keys → MLX Local Models.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary" className="flex items-center gap-1">
+            {status === null ? (
+              <RefreshCw className="h-3 w-3 animate-spin" />
+            ) : status.running ? (
+              <CheckCircle className="h-3 w-3" />
+            ) : (
+              <AlertTriangle className="h-3 w-3" />
+            )}
+            {status === null ? 'Checking...' : status.running ? 'Running' : 'Not Running'}
+          </Badge>
+          <Button
+            size="sm"
+            onClick={refresh}
+            disabled={loading}
+            className="text-primary hover:bg-primary/20 hover:text-primary bg-primary/10 border-primary/30 hover:border-primary/50"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/20 border border-red-600/30 rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="h-5 w-5 text-red-400 mt-0.5" />
+            <div>
+              <h4 className="font-medium text-red-300">Error</h4>
+              <p className="text-sm text-red-400 mt-1">{error}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {status && !status.running && (
+        <div className="bg-muted rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <Cpu className="h-5 w-5 text-muted-foreground mt-0.5" />
+            <div>
+              <h4 className="font-medium text-muted-foreground">MLX Server Not Running</h4>
+              <p className="text-sm text-muted-foreground mt-1">
+                Start your MLX LM server with:{' '}
+                <code className="bg-muted-foreground/20 px-1.5 py-0.5 rounded text-xs font-mono">
+                  mlx_lm.server --model &lt;model-id&gt;
+                </code>
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Configure the server URL in <strong>API Keys → MLX Local Models</strong>.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {status?.running && (
+        <div className="flex items-center gap-2 bg-muted rounded-lg p-4">
+          <CheckCircle className="h-5 w-5 text-primary" />
+          <div>
+            <span className="font-medium text-primary">MLX Server Running</span>
+            <p className="text-sm text-muted-foreground">Available at {status.server_url}</p>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="font-medium text-primary">Available Models</h3>
+          <span className="text-xs text-muted-foreground">{models.length} models</span>
+        </div>
+
+        {models.length > 0 ? (
+          <div className="space-y-1">
+            {models.map((model) => (
+              <div
+                key={model.model_name}
+                className="flex items-center justify-between bg-muted hover-bg rounded-md px-3 py-2.5 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm text-primary">{model.display_name}</span>
+                    <span className="font-mono text-xs text-muted-foreground truncate">{model.model_name}</span>
+                  </div>
+                </div>
+                <Badge className="text-xs text-primary bg-primary/10 border-primary/30 ml-2 flex-shrink-0">
+                  MLX
+                </Badge>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8 text-muted-foreground">
+            <Brain className="h-8 w-8 mx-auto mb-2 opacity-50" />
+            <p className="text-sm">No MLX models loaded</p>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-muted/50 rounded-lg p-4 space-y-2">
+        <h4 className="text-sm font-medium text-primary">Quick Start</h4>
+        <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+          <li>Install: <code className="bg-muted px-1 rounded font-mono">pip install mlx-lm</code></li>
+          <li>Start server: <code className="bg-muted px-1 rounded font-mono">mlx_lm.server --model mlx-community/Llama-3.1-8B-Instruct-4bit</code></li>
+          <li>In agent nodes, select any MLX model from the model dropdown</li>
+          <li>Optionally set a custom server URL in <strong>API Keys → MLX Local Models</strong></li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/data/models.ts
+++ b/app/frontend/src/data/models.ts
@@ -3,7 +3,7 @@ import { api } from '@/services/api';
 export interface LanguageModel {
   display_name: string;
   model_name: string;
-  provider: "Anthropic" | "DeepSeek" | "Google" | "Groq" | "OpenAI";
+  provider: string;
 }
 
 // Cache for models to avoid repeated API calls
@@ -27,13 +27,71 @@ export const getModels = async (): Promise<LanguageModel[]> => {
   }
 };
 
+// Map from model provider name to the API key provider name stored in the DB
+const PROVIDER_TO_API_KEY: Record<string, string> = {
+  OpenAI: 'OPENAI_API_KEY',
+  Anthropic: 'ANTHROPIC_API_KEY',
+  Groq: 'GROQ_API_KEY',
+  DeepSeek: 'DEEPSEEK_API_KEY',
+  Google: 'GOOGLE_API_KEY',
+  xAI: 'XAI_API_KEY',
+  OpenRouter: 'OPENROUTER_API_KEY',
+  GigaChat: 'GIGACHAT_API_KEY',
+  Alibaba: 'ALIBABA_API_KEY',
+  Mistral: 'MISTRAL_API_KEY',
+  Meta: 'META_API_KEY',
+};
+
 /**
- * Get the default model (GPT-4.1) from the models list
+ * Get the best default model based on configured API keys.
+ * Priority: MLX (if MLX_BASE_URL set) > Ollama (if running) > Cloud (first provider with key set)
  */
 export const getDefaultModel = async (): Promise<LanguageModel | null> => {
   try {
-    const models = await getModels();
-    return models.find(model => model.model_name === "gpt-4.1") || models[0] || null;
+    const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+    const [models, apiKeysRaw] = await Promise.all([
+      getModels(),
+      fetch(`${API_BASE_URL}/api-keys`).then(r => r.ok ? r.json() : []).catch(() => []),
+    ]);
+
+    // Build a set of providers that have a key stored
+    const configuredKeys = new Set<string>(
+      (apiKeysRaw as Array<{ provider: string; has_key: boolean }>)
+        .filter(k => k.has_key)
+        .map(k => k.provider)
+    );
+
+    // 1. MLX — if MLX_BASE_URL is configured
+    if (configuredKeys.has('MLX_BASE_URL')) {
+      const mlx = models.find(m => m.provider === 'MLX');
+      if (mlx) return mlx;
+    }
+
+    // 2. Ollama — if server is reachable
+    try {
+      const ollamaRes = await fetch(`${API_BASE_URL}/ollama/models`);
+      if (ollamaRes.ok) {
+        const ollamaData = await ollamaRes.json();
+        if (Array.isArray(ollamaData.models) && ollamaData.models.length > 0) {
+          const ollama = models.find(m => m.provider === 'Ollama');
+          if (ollama) return ollama;
+        }
+      }
+    } catch {
+      // Ollama not available — continue
+    }
+
+    // 3. Cloud — first provider (in priority order) that has an API key stored
+    const cloudOrder = ['Anthropic', 'OpenAI', 'Groq', 'Google', 'DeepSeek', 'xAI', 'OpenRouter', 'Alibaba', 'Mistral', 'Meta'];
+    for (const provider of cloudOrder) {
+      const keyName = PROVIDER_TO_API_KEY[provider];
+      if (keyName && configuredKeys.has(keyName)) {
+        const model = models.find(m => m.provider === provider);
+        if (model) return model;
+      }
+    }
+
+    return null;
   } catch (error) {
     console.error('Failed to get default model:', error);
     return null;

--- a/app/frontend/src/nodes/components/portfolio-manager-node.tsx
+++ b/app/frontend/src/nodes/components/portfolio-manager-node.tsx
@@ -60,8 +60,12 @@ export function PortfolioManagerNode({
         ]);
         setAvailableModels(models);
         
-        // Set default model if no model is currently selected
-        if (!selectedModel && defaultModel) {
+        // If stored model is not in the available list (e.g. MLX model when MLX is not running),
+        // clear it and fall back to the smart default so the backend never receives an invalid model.
+        const modelInList = selectedModel
+          ? models.some(m => m.model_name === selectedModel.model_name)
+          : false;
+        if (!modelInList && defaultModel) {
           setSelectedModel(defaultModel);
         }
       } catch (error) {

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -14,6 +14,9 @@ show_help() {
   echo "  --margin-requirement RATIO  Margin requirement ratio (default: 0.0)"
   echo "  --ollama            Use Ollama for local LLM inference"
   echo "  --ollama-base-url URL  Use an existing Ollama endpoint (implies --ollama)"
+  echo "  --mlx               Use MLX for local LLM inference"
+  echo "  --mlx-base-url URL  MLX server base URL (default: http://localhost:8080)"
+  echo "  --finance-data SRC  Data provider: Financial (default), Yahoo, or Qveris"
   echo "  --show-reasoning    Show reasoning from each agent"
   echo ""
   echo "Commands:"
@@ -40,6 +43,9 @@ TICKER="AAPL,MSFT,NVDA"
 USE_OLLAMA=""
 OLLAMA_BASE_URL_VALUE="${OLLAMA_BASE_URL:-}"
 USE_EXTERNAL_OLLAMA=""
+USE_MLX=""
+MLX_BASE_URL_VALUE="${MLX_BASE_URL:-http://localhost:8080}"
+FINANCE_DATA="${USE_FINANCE_DATA:-}"
 START_DATE=""
 END_DATE=""
 INITIAL_AMOUNT="100000.0"
@@ -81,6 +87,19 @@ while [[ $# -gt 0 ]]; do
       if [ -z "$USE_OLLAMA" ]; then
         USE_OLLAMA="--ollama"
       fi
+      shift 2
+      ;;
+    --mlx)
+      USE_MLX="--mlx"
+      shift
+      ;;
+    --mlx-base-url)
+      MLX_BASE_URL_VALUE="$2"
+      USE_MLX="--mlx"
+      shift 2
+      ;;
+    --finance-data)
+      FINANCE_DATA="$2"
       shift 2
       ;;
     --show-reasoning)
@@ -271,6 +290,12 @@ if [ -n "$USE_OLLAMA" ]; then
   if [ -n "$OLLAMA_BASE_URL_VALUE" ]; then
     export OLLAMA_BASE_URL="$OLLAMA_BASE_URL_VALUE"
   fi
+  if [ -n "$FINANCE_DATA" ]; then
+    export USE_FINANCE_DATA="$FINANCE_DATA"
+  fi
+  if [ -n "$USE_MLX" ]; then
+    export MLX_BASE_URL="$MLX_BASE_URL_VALUE"
+  fi
 
   COMMAND_OVERRIDE=""
 
@@ -364,8 +389,21 @@ fi
 # Build the command
 CMD="docker run -it --rm -v $(pwd)/.env:/app/.env"
 
+# Inject USE_FINANCE_DATA if set
+if [ -n "$FINANCE_DATA" ]; then
+  CMD="$CMD -e USE_FINANCE_DATA=$FINANCE_DATA"
+fi
+
+# Inject MLX settings if set
+if [ -n "$USE_MLX" ]; then
+  CMD="$CMD -e MLX_BASE_URL=$MLX_BASE_URL_VALUE"
+fi
+
 # Add the command
 CMD="$CMD ai-hedge-fund python $SCRIPT_PATH --ticker $TICKER $START_DATE $END_DATE $INITIAL_PARAM --margin-requirement $MARGIN_REQUIREMENT $SHOW_REASONING"
+if [ -n "$USE_MLX" ]; then
+  CMD="$CMD --mlx"
+fi
 
 # Run the command
 echo "Running: $CMD"

--- a/src/llm/mlx_models.json
+++ b/src/llm/mlx_models.json
@@ -1,0 +1,62 @@
+[
+  {
+    "display_name": "Qwen 3.5 35B A3B (4-bit)",
+    "model_name": "mlx-community/Qwen3.5-35B-A3B-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Llama 3.1 8B Instruct (4-bit)",
+    "model_name": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Llama 3.2 3B Instruct (4-bit)",
+    "model_name": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Llama 3.3 70B Instruct (4-bit)",
+    "model_name": "mlx-community/Llama-3.3-70B-Instruct-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Mistral 7B Instruct v0.3 (4-bit)",
+    "model_name": "mlx-community/Mistral-7B-Instruct-v0.3-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Gemma 3 4B Instruct (4-bit)",
+    "model_name": "mlx-community/gemma-3-4b-it-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Gemma 3 12B Instruct (4-bit)",
+    "model_name": "mlx-community/gemma-3-12b-it-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Qwen 2.5 7B Instruct (4-bit)",
+    "model_name": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Qwen 2.5 14B Instruct (4-bit)",
+    "model_name": "mlx-community/Qwen2.5-14B-Instruct-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Qwen 3 8B (4-bit)",
+    "model_name": "mlx-community/Qwen3-8B-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Phi-4 14B (4-bit)",
+    "model_name": "mlx-community/phi-4-4bit",
+    "provider": "MLX"
+  },
+  {
+    "display_name": "Custom (enter model ID)",
+    "model_name": "-",
+    "provider": "MLX"
+  }
+]

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -26,6 +26,7 @@ class ModelProvider(str, Enum):
     MISTRAL = "Mistral"
     OPENAI = "OpenAI"
     OLLAMA = "Ollama"
+    MLX = "MLX"
     OPENROUTER = "OpenRouter"
     GIGACHAT = "GigaChat"
     AZURE_OPENAI = "Azure OpenAI"
@@ -54,6 +55,9 @@ class LLMModel(BaseModel):
         # Only certain Ollama models support JSON mode
         if self.is_ollama():
             return "llama3" in self.model_name or "neural-chat" in self.model_name
+        # MLX server exposes an OpenAI-compatible API that supports response_format
+        if self.is_mlx():
+            return True
         # OpenRouter models generally support JSON mode
         if self.provider == ModelProvider.OPENROUTER:
             return True
@@ -70,6 +74,10 @@ class LLMModel(BaseModel):
     def is_ollama(self) -> bool:
         """Check if the model is an Ollama model"""
         return self.provider == ModelProvider.OLLAMA
+
+    def is_mlx(self) -> bool:
+        """Check if the model is an MLX model"""
+        return self.provider == ModelProvider.MLX
 
 
 # Load models from JSON file
@@ -96,6 +104,7 @@ def load_models_from_json(json_path: str) -> List[LLMModel]:
 current_dir = Path(__file__).parent
 models_json_path = current_dir / "api_models.json"
 ollama_models_json_path = current_dir / "ollama_models.json"
+mlx_models_json_path = current_dir / "mlx_models.json"
 
 # Load available models from JSON
 AVAILABLE_MODELS = load_models_from_json(str(models_json_path))
@@ -103,22 +112,28 @@ AVAILABLE_MODELS = load_models_from_json(str(models_json_path))
 # Load Ollama models from JSON
 OLLAMA_MODELS = load_models_from_json(str(ollama_models_json_path))
 
+# Load MLX models from JSON
+MLX_MODELS = load_models_from_json(str(mlx_models_json_path))
+
 # Create LLM_ORDER in the format expected by the UI
 LLM_ORDER = [model.to_choice_tuple() for model in AVAILABLE_MODELS]
 
 # Create Ollama LLM_ORDER separately
 OLLAMA_LLM_ORDER = [model.to_choice_tuple() for model in OLLAMA_MODELS]
 
+# Create MLX LLM_ORDER separately
+MLX_LLM_ORDER = [model.to_choice_tuple() for model in MLX_MODELS]
+
 
 def get_model_info(model_name: str, model_provider: str) -> LLMModel | None:
     """Get model information by model_name"""
-    all_models = AVAILABLE_MODELS + OLLAMA_MODELS
+    all_models = AVAILABLE_MODELS + OLLAMA_MODELS + MLX_MODELS
     return next((model for model in all_models if model.model_name == model_name and model.provider == model_provider), None)
 
 
 def find_model_by_name(model_name: str) -> LLMModel | None:
     """Find a model by its name across all available models."""
-    all_models = AVAILABLE_MODELS + OLLAMA_MODELS
+    all_models = AVAILABLE_MODELS + OLLAMA_MODELS + MLX_MODELS
     return next((model for model in all_models if model.model_name == model_name), None)
 
 
@@ -130,7 +145,7 @@ def get_models_list():
             "model_name": model.model_name,
             "provider": model.provider.value
         }
-        for model in AVAILABLE_MODELS
+        for model in AVAILABLE_MODELS + MLX_MODELS
     ]
 
 
@@ -177,6 +192,29 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
         return ChatOllama(
             model=model_name,
             base_url=base_url,
+        )
+    elif model_provider == ModelProvider.MLX:
+        # MLX LM server exposes an OpenAI-compatible API.
+        # A key is optional for local servers but required for secured/hosted deployments.
+        # Default port is 8080; override with MLX_BASE_URL for LAN/remote access.
+        mlx_host = os.getenv("MLX_HOST", "localhost")
+        base_url = os.getenv("MLX_BASE_URL", f"http://{mlx_host}:8080/v1")
+        api_key = (api_keys or {}).get("MLX_API_KEY") or os.getenv("MLX_API_KEY", "mlx")
+        # Local/LAN inference can be slow — use a generous timeout (default 10 min).
+        # Override with MLX_TIMEOUT (seconds) if needed.
+        timeout = float(os.getenv("MLX_TIMEOUT", "600"))
+        # Qwen 3.x and other reasoning models emit <think>...</think> tokens before
+        # the JSON response, which breaks structured output parsing.  Disable thinking
+        # by default; set MLX_ENABLE_THINKING=true to turn it back on.
+        enable_thinking = os.getenv("MLX_ENABLE_THINKING", "false").lower() == "true"
+        extra_body = {"chat_template_kwargs": {"enable_thinking": enable_thinking}}
+        return ChatOpenAI(
+            model=model_name,
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=1,
+            extra_body=extra_body,
         )
     elif model_provider == ModelProvider.OPENROUTER:
         api_key = (api_keys or {}).get("OPENROUTER_API_KEY") or os.getenv("OPENROUTER_API_KEY")

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -45,15 +45,19 @@ def call_llm(
         if request and hasattr(request, 'api_keys'):
             api_keys = request.api_keys
 
-    model_info = get_model_info(model_name, model_provider)
-    llm = get_model(model_name, model_provider, api_keys)
+    # Set up the LLM — catch configuration errors (missing API key, bad provider, etc.)
+    last_error = None
+    try:
+        model_info = get_model_info(model_name, model_provider)
+        llm = get_model(model_name, model_provider, api_keys)
 
-    # For non-JSON support models, we can use structured output
-    if not (model_info and not model_info.has_json_mode()):
-        llm = llm.with_structured_output(
-            pydantic_model,
-            method="json_mode",
-        )
+        # Use structured output for models that support it
+        if not (model_info and not model_info.has_json_mode()):
+            llm = llm.with_structured_output(pydantic_model)
+    except Exception as setup_error:
+        last_error = setup_error
+        print(f"LLM setup error ({model_provider}/{model_name}): {setup_error}")
+        return _make_error_response(pydantic_model, default_factory, setup_error)
 
     # Call the LLM with retries
     for attempt in range(max_retries):
@@ -70,18 +74,27 @@ def call_llm(
                 return result
 
         except Exception as e:
+            last_error = e
             if agent_name:
                 progress.update_status(agent_name, None, f"Error - retry {attempt + 1}/{max_retries}")
 
             if attempt == max_retries - 1:
-                print(f"Error in LLM call after {max_retries} attempts: {e}")
-                # Use default_factory if provided, otherwise create a basic default
-                if default_factory:
-                    return default_factory()
-                return create_default_response(pydantic_model)
+                print(f"LLM call failed ({model_provider}/{model_name}) after {max_retries} attempts: {e}")
+                return _make_error_response(pydantic_model, default_factory, e)
 
-    # This should never be reached due to the retry logic above
-    return create_default_response(pydantic_model)
+    return _make_error_response(pydantic_model, default_factory, last_error)
+
+
+def _make_error_response(pydantic_model, default_factory, error: Exception) -> BaseModel:
+    """Return the default_factory result (or a generic default) with the real error injected into reasoning."""
+    result = default_factory() if default_factory else create_default_response(pydantic_model)
+    if hasattr(result, "reasoning"):
+        try:
+            error_msg = f"LLM error: {str(error)[:300]}"
+            result = result.__class__(**{**result.model_dump(), "reasoning": error_msg})
+        except Exception:
+            pass
+    return result
 
 
 def create_default_response(model_class: type[BaseModel]) -> BaseModel:
@@ -107,15 +120,31 @@ def create_default_response(model_class: type[BaseModel]) -> BaseModel:
 
 
 def extract_json_from_response(content: str) -> dict | None:
-    """Extracts JSON from markdown-formatted response."""
+    """Extracts JSON from a model response.
+
+    Handles:
+    - Markdown ```json ... ``` blocks
+    - Qwen 3.x / reasoning models that prefix output with <think>...</think> blocks
+    - Bare JSON objects at the root level
+    """
+    import re
+
+    # Strip <think>...</think> reasoning tokens (Qwen 3.x, DeepSeek-R1, etc.)
+    content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL).strip()
+
     try:
+        # Markdown fenced block: ```json ... ```
         json_start = content.find("```json")
         if json_start != -1:
-            json_text = content[json_start + 7 :]  # Skip past ```json
+            json_text = content[json_start + 7:]
             json_end = json_text.find("```")
             if json_end != -1:
-                json_text = json_text[:json_end].strip()
-                return json.loads(json_text)
+                return json.loads(json_text[:json_end].strip())
+
+        # Bare JSON object/array
+        brace_start = content.find("{")
+        if brace_start != -1:
+            return json.loads(content[brace_start:])
     except Exception as e:
         print(f"Error extracting JSON from response: {e}")
     return None
@@ -138,7 +167,7 @@ def get_agent_model_config(state, agent_name):
     
     # Fall back to global configuration (system defaults)
     model_name = state.get("metadata", {}).get("model_name") or "gpt-4.1"
-    model_provider = state.get("metadata", {}).get("model_provider") or "OPENAI"
+    model_provider = state.get("metadata", {}).get("model_provider") or "OpenAI"
     
     # Convert enum to string if necessary
     if hasattr(model_provider, 'value'):

--- a/src/utils/mlx_lm.py
+++ b/src/utils/mlx_lm.py
@@ -1,0 +1,227 @@
+"""Utilities for working with MLX LM server (Apple Silicon).
+
+mlx-lm runs large language models natively on Apple Silicon (M1/M2/M3/M4)
+using Apple's MLX framework and exposes an OpenAI-compatible HTTP server.
+
+LAN usage
+---------
+Start the server on your Mac with:
+    mlx_lm.server --model mlx-community/Llama-3.1-8B-Instruct-4bit \\
+                  --host 0.0.0.0 --port 8080
+
+Point other machines on the same network at it by setting in their .env:
+    MLX_BASE_URL=http://<mac-ip>:8080/v1
+
+Install
+-------
+    pip install mlx-lm          # Apple Silicon only
+    # or inside the project:
+    poetry add mlx-lm
+
+Requirements: macOS + Apple Silicon (M1/M2/M3/M4).
+"""
+
+import os
+import platform
+import subprocess
+import time
+
+import requests
+from colorama import Fore, Style
+
+DEFAULT_MLX_PORT = 8080
+DEFAULT_MLX_HOST = "localhost"
+DEFAULT_MLX_BASE_URL = f"http://{DEFAULT_MLX_HOST}:{DEFAULT_MLX_PORT}/v1"
+
+# Background server process (started by this module)
+_server_process: subprocess.Popen | None = None
+
+
+# ---------------------------------------------------------------------------
+# URL / auth helpers
+# ---------------------------------------------------------------------------
+def _get_mlx_base_url() -> str:
+    """Return the configured MLX base URL (no trailing slash)."""
+    host = os.environ.get("MLX_HOST", DEFAULT_MLX_HOST)
+    default = f"http://{host}:{DEFAULT_MLX_PORT}/v1"
+    return os.environ.get("MLX_BASE_URL", default).rstrip("/")
+
+
+def _get_mlx_api_key() -> str | None:
+    """Return the MLX API key if set, else None."""
+    return os.environ.get("MLX_API_KEY") or None
+
+
+def _auth_headers() -> dict:
+    """Return Authorization header dict when an API key is configured."""
+    key = _get_mlx_api_key()
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
+def is_apple_silicon() -> bool:
+    """Return True when running on Apple Silicon."""
+    return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+
+# ---------------------------------------------------------------------------
+# Install / runtime checks
+# ---------------------------------------------------------------------------
+def is_mlx_lm_installed() -> bool:
+    """Return True if the mlx_lm Python package is importable."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("mlx_lm") is not None
+    except Exception:
+        return False
+
+
+def is_mlx_server_running() -> bool:
+    """Return True if an MLX LM server is reachable at the configured URL.
+
+    Sends the configured API key so secured servers (that return 401 for
+    unauthenticated requests) are still recognised as running.
+    """
+    url = _get_mlx_base_url()
+    headers = _auth_headers()
+    for path in ("/models", "/health"):
+        try:
+            response = requests.get(f"{url}{path}", headers=headers, timeout=2)
+            # 200 = up, 401 = up but wrong/missing key (handle separately),
+            # 404 = up but endpoint absent — all mean the server is reachable.
+            if response.status_code in (200, 401, 404):
+                return True
+        except requests.RequestException:
+            pass
+    return False
+
+
+def get_locally_available_models() -> list[str]:
+    """Return model IDs reported by the running MLX server's /v1/models endpoint."""
+    if not is_mlx_server_running():
+        return []
+    try:
+        url = _get_mlx_base_url()
+        response = requests.get(f"{url}/models", headers=_auth_headers(), timeout=5)
+        if response.status_code == 200:
+            data = response.json()
+            return [m["id"] for m in data.get("data", [])]
+    except Exception:
+        pass
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+def start_mlx_server(model_name: str, host: str = "0.0.0.0", port: int | None = None) -> bool:
+    """Start `mlx_lm.server` as a background subprocess.
+
+    The server binds to *host* (default ``0.0.0.0``) so it is reachable from
+    other devices on the LAN.  Pass ``host="localhost"`` to restrict to the
+    local machine only.
+
+    Returns True when the server becomes reachable within 30 seconds.
+    """
+    global _server_process
+
+    if is_mlx_server_running():
+        print(f"{Fore.GREEN}MLX server is already running.{Style.RESET_ALL}")
+        return True
+
+    if not is_mlx_lm_installed():
+        print(f"{Fore.RED}mlx-lm is not installed.  Run: pip install mlx-lm{Style.RESET_ALL}")
+        return False
+
+    if not is_apple_silicon():
+        print(f"{Fore.RED}MLX requires Apple Silicon (M1/M2/M3/M4).  "
+              f"Set MLX_BASE_URL to point at a remote MLX server instead.{Style.RESET_ALL}")
+        return False
+
+    port = port or DEFAULT_MLX_PORT
+    cmd = [
+        "python", "-m", "mlx_lm.server",
+        "--model", model_name,
+        "--host", host,
+        "--port", str(port),
+    ]
+
+    print(f"{Fore.YELLOW}Starting MLX server with model {model_name} …{Style.RESET_ALL}")
+    print(f"{Fore.CYAN}This may take a minute while the model loads into memory.{Style.RESET_ALL}")
+
+    try:
+        _server_process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        print(f"{Fore.RED}Could not launch mlx_lm.server.  "
+              f"Make sure mlx-lm is installed in the active Python environment.{Style.RESET_ALL}")
+        return False
+
+    # Wait up to 30 s for the server to start
+    for _ in range(30):
+        if is_mlx_server_running():
+            print(f"{Fore.GREEN}MLX server started successfully "
+                  f"(http://{host}:{port}/v1).{Style.RESET_ALL}")
+            return True
+        time.sleep(1)
+
+    print(f"{Fore.RED}MLX server did not become reachable within 30 s.{Style.RESET_ALL}")
+    return False
+
+
+def stop_mlx_server() -> bool:
+    """Terminate the MLX server process started by this module."""
+    global _server_process
+    if _server_process is None:
+        return False
+    try:
+        _server_process.terminate()
+        _server_process.wait(timeout=10)
+        _server_process = None
+        print(f"{Fore.GREEN}MLX server stopped.{Style.RESET_ALL}")
+        return True
+    except Exception as e:
+        print(f"{Fore.RED}Error stopping MLX server: {e}{Style.RESET_ALL}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# High-level ensure helper (mirrors ollama.ensure_ollama_and_model)
+# ---------------------------------------------------------------------------
+def ensure_mlx_and_model(model_name: str) -> bool:
+    """Ensure the MLX server is reachable and serving *model_name*.
+
+    Workflow:
+    1. If MLX_BASE_URL points to a remote host, just verify connectivity.
+    2. Otherwise check for Apple Silicon + mlx-lm install, then start the
+       server locally with the requested model.
+    """
+    base_url = _get_mlx_base_url()
+    is_remote = not (
+        base_url.startswith(f"http://localhost:{DEFAULT_MLX_PORT}")
+        or base_url.startswith(f"http://127.0.0.1:{DEFAULT_MLX_PORT}")
+    )
+
+    if is_remote:
+        # Remote MLX server — just check connectivity
+        if is_mlx_server_running():
+            print(f"{Fore.GREEN}Remote MLX server reachable at {base_url}.{Style.RESET_ALL}")
+            return True
+        print(f"{Fore.RED}Cannot reach remote MLX server at {base_url}.  "
+              f"Make sure the server is running on that machine.{Style.RESET_ALL}")
+        return False
+
+    # Local server path
+    if not is_apple_silicon():
+        print(f"{Fore.RED}MLX requires Apple Silicon.  "
+              f"Use MLX_BASE_URL to point at a remote MLX server.{Style.RESET_ALL}")
+        return False
+
+    if not is_mlx_lm_installed():
+        print(f"{Fore.YELLOW}mlx-lm is not installed.{Style.RESET_ALL}")
+        print(f"Install it with:  {Fore.CYAN}pip install mlx-lm{Style.RESET_ALL}")
+        return False
+
+    if is_mlx_server_running():
+        print(f"{Fore.GREEN}MLX server is already running.{Style.RESET_ALL}")
+        return True
+
+    return start_mlx_server(model_name)


### PR DESCRIPTION
Enables running LLMs locally on Apple Silicon (M1/M2/M3/M4) via the mlx-lm library, with no API key required.

- src/utils/mlx_lm.py: MLX inference engine wrapping mlx-lm generate, exposes a LangChain-compatible chat interface
- src/llm/mlx_models.json: curated list of MLX-compatible HuggingFace model IDs (Llama, Mistral, Gemma, Qwen, Phi families)
- src/llm/models.py: register 'mlx' as a provider; get_model() returns MLX chat model when provider is 'mlx'
- src/utils/llm.py: pass MLX_API_KEY / mlx base URL through LangChain call_options so the inference server URL is configurable
- app/backend/routes/mlx.py: GET /mlx/models endpoint returns available MLX models for the frontend model selector
- app/frontend/src/components/settings/models/mlx.tsx: UI panel to configure the MLX server URL and browse available models
- app/frontend/src/data/models.ts: fetch and merge MLX models into the global model list used by all node selectors
- docker/run.sh: pass MLX_API_KEY env var through to the container

  ## Summary
  - Run LLMs locally on Apple Silicon (M1/M2/M3/M4) via `mlx-lm` — no API key required
  - Add `src/utils/mlx_lm.py`: MLX inference engine with a LangChain-compatible chat interface
  - Add `src/llm/mlx_models.json`: curated list of MLX-compatible models (Llama, Mistral, Gemma, Qwen, Phi)
  - Register `mlx` as a provider in `src/llm/models.py`; `get_model()` returns MLX model when provider is `mlx`
  - Add `GET /mlx/models` backend endpoint to serve available models to the frontend
  - Add MLX settings panel in the web UI to configure the server URL and browse models
  - Frontend model selector automatically includes MLX models when the MLX server is reachable
  - Pass `MLX_API_KEY` env var through Docker

  ## Test plan
  - [ ] Install `mlx-lm` and start a local MLX server
  - [ ] Verify MLX models appear in the web UI model selector
  - [ ] Run a full analysis using an MLX model end-to-end
  - [ ] Verify non-Apple-Silicon machines gracefully skip MLX (no crash)
