### PR TITLE
feat: web UI enhancements - data provider selector, flow run trigger,…

### DIFF
--- a/app/backend/models/schemas.py
+++ b/app/backend/models/schemas.py
@@ -68,6 +68,8 @@ class BaseHedgeFundRequest(BaseModel):
     margin_requirement: float = 0.0
     portfolio_positions: Optional[List[PortfolioPosition]] = None
     api_keys: Optional[Dict[str, str]] = None
+    data_provider: Optional[str] = None
+    mlx_base_url: Optional[str] = None
 
     def get_agent_ids(self) -> List[str]:
         """Extract agent IDs from graph structure"""

--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -30,6 +30,19 @@ async def run(request_data: HedgeFundRequest, request: Request, db: Session = De
             api_key_service = ApiKeyService(db)
             request_data.api_keys = api_key_service.get_api_keys_dict()
 
+        # Apply per-request environment settings (request overrides stored settings)
+        import os as _os
+        _api_keys = request_data.api_keys or {}
+        _data_provider = request_data.data_provider or _api_keys.get("USE_FINANCE_DATA")
+        _mlx_base_url = request_data.mlx_base_url or _api_keys.get("MLX_BASE_URL")
+        _mlx_api_key = _api_keys.get("MLX_API_KEY")
+        if _data_provider:
+            _os.environ["USE_FINANCE_DATA"] = _data_provider
+        if _mlx_base_url:
+            _os.environ["MLX_BASE_URL"] = _mlx_base_url
+        if _mlx_api_key:
+            _os.environ["MLX_API_KEY"] = _mlx_api_key
+
         # Create the portfolio
         portfolio = create_portfolio(request_data.initial_cash, request_data.margin_requirement, request_data.tickers, request_data.portfolio_positions)
 
@@ -174,6 +187,19 @@ async def backtest(request_data: BacktestRequest, request: Request, db: Session 
         if not request_data.api_keys:
             api_key_service = ApiKeyService(db)
             request_data.api_keys = api_key_service.get_api_keys_dict()
+
+        # Apply per-request environment settings (request overrides stored settings)
+        import os as _os
+        _api_keys = request_data.api_keys or {}
+        _data_provider = request_data.data_provider or _api_keys.get("USE_FINANCE_DATA")
+        _mlx_base_url = request_data.mlx_base_url or _api_keys.get("MLX_BASE_URL")
+        _mlx_api_key = _api_keys.get("MLX_API_KEY")
+        if _data_provider:
+            _os.environ["USE_FINANCE_DATA"] = _data_provider
+        if _mlx_base_url:
+            _os.environ["MLX_BASE_URL"] = _mlx_base_url
+        if _mlx_api_key:
+            _os.environ["MLX_API_KEY"] = _mlx_api_key
 
         # Convert model_provider to string if it's an enum
         model_provider = request_data.model_provider

--- a/app/frontend/src/components/panels/bottom/tabs/regular-output.tsx
+++ b/app/frontend/src/components/panels/bottom/tabs/regular-output.tsx
@@ -49,6 +49,18 @@ function ProgressSection({ sortedAgents }: { sortedAgents: [string, any][] }) {
 function SummarySection({ outputData }: { outputData: any }) {
   if (!outputData) return null;
 
+  const getSignalCounts = (ticker: string) => {
+    let bullish = 0, bearish = 0, neutral = 0;
+    for (const [agent, signals] of Object.entries(outputData.analyst_signals || {})) {
+      if (agent.includes('risk_management')) continue;
+      const signal = (signals as any)[ticker]?.signal?.toLowerCase();
+      if (signal === 'bullish') bullish++;
+      else if (signal === 'bearish') bearish++;
+      else if (signal === 'neutral') neutral++;
+    }
+    return { bullish, bearish, neutral };
+  };
+
   return (
     <Card className="bg-transparent mb-4">
       <CardHeader>
@@ -59,24 +71,36 @@ function SummarySection({ outputData }: { outputData: any }) {
           <TableHeader>
             <TableRow>
               <TableHead>Ticker</TableHead>
+              <TableHead>Price</TableHead>
               <TableHead>Action</TableHead>
               <TableHead>Quantity</TableHead>
               <TableHead>Confidence</TableHead>
+              <TableHead className="text-green-500">Bullish</TableHead>
+              <TableHead className="text-red-500">Bearish</TableHead>
+              <TableHead className="text-yellow-500">Neutral</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {Object.entries(outputData.decisions).map(([ticker, decision]: [string, any]) => (
-              <TableRow key={ticker}>
-                <TableCell className="font-medium">{ticker}</TableCell>
-                <TableCell>
-                  <span className={cn("font-medium", getActionColor(decision.action || ''))}>
-                    {decision.action?.toUpperCase() || 'UNKNOWN'}
-                  </span>
-                </TableCell>
-                <TableCell>{decision.quantity || 0}</TableCell>
-                <TableCell>{decision.confidence?.toFixed(1) || 0}%</TableCell>
-              </TableRow>
-            ))}
+            {Object.entries(outputData.decisions).map(([ticker, decision]: [string, any]) => {
+              const { bullish, bearish, neutral } = getSignalCounts(ticker);
+              const price = outputData.current_prices?.[ticker];
+              return (
+                <TableRow key={ticker}>
+                  <TableCell className="font-medium">{ticker}</TableCell>
+                  <TableCell>{typeof price === 'number' ? `$${price.toFixed(2)}` : 'N/A'}</TableCell>
+                  <TableCell>
+                    <span className={cn("font-medium", getActionColor(decision.action || ''))}>
+                      {decision.action?.toUpperCase() || 'UNKNOWN'}
+                    </span>
+                  </TableCell>
+                  <TableCell>{decision.quantity || 0}</TableCell>
+                  <TableCell>{decision.confidence?.toFixed(1) || 0}%</TableCell>
+                  <TableCell className="text-green-500 font-medium">{bullish}</TableCell>
+                  <TableCell className="text-red-500 font-medium">{bearish}</TableCell>
+                  <TableCell className="text-yellow-500 font-medium">{neutral}</TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </CardContent>

--- a/app/frontend/src/components/panels/left/flow-context-menu.tsx
+++ b/app/frontend/src/components/panels/left/flow-context-menu.tsx
@@ -1,24 +1,26 @@
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Copy, Edit, Trash2 } from 'lucide-react';
+import { Copy, Edit, Play, Trash2 } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
 interface FlowContextMenuProps {
   isOpen: boolean;
   position: { x: number; y: number };
   onClose: () => void;
+  onRun: () => void;
   onEdit: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
 }
 
-export function FlowContextMenu({ 
-  isOpen, 
-  position, 
-  onClose, 
-  onEdit, 
-  onDuplicate, 
-  onDelete 
+export function FlowContextMenu({
+  isOpen,
+  position,
+  onClose,
+  onRun,
+  onEdit,
+  onDuplicate,
+  onDelete
 }: FlowContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -69,23 +71,35 @@ export function FlowContextMenu({
         <Button
           variant="ghost"
           size="sm"
-          className="w-full justify-start text-primary hover-bg"
+          className="w-full justify-start text-green-400 hover:text-green-300 hover:bg-ramp-grey-700"
+          onClick={() => handleAction(onRun)}
+        >
+          <Play size={14} className="mr-2" />
+          Run
+        </Button>
+
+        <div className="my-1 border-t border-border" />
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start text-white hover:text-white hover:bg-ramp-grey-700"
           onClick={() => handleAction(onEdit)}
         >
           <Edit size={14} className="mr-2" />
           Edit
         </Button>
-        
+
         <Button
           variant="ghost"
           size="sm"
-          className="w-full justify-start text-primary hover:bg-ramp-grey-700"
+          className="w-full justify-start text-white hover:text-white hover:bg-ramp-grey-700"
           onClick={() => handleAction(onDuplicate)}
         >
           <Copy size={14} className="mr-2" />
           Duplicate
         </Button>
-        
+
         <Button
           variant="ghost"
           size="sm"
@@ -98,4 +112,4 @@ export function FlowContextMenu({
       </div>
     </div>
   );
-} 
+}

--- a/app/frontend/src/components/panels/left/flow-item.tsx
+++ b/app/frontend/src/components/panels/left/flow-item.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { useFlowContext } from '@/contexts/flow-context';
 import { useFlowConnectionState } from '@/hooks/use-flow-connection';
 import { cn } from '@/lib/utils';
 import { flowService } from '@/services/flow-service';
@@ -29,6 +30,8 @@ export default function FlowItem({ flow, onLoadFlow, onDeleteFlow, onRefresh, is
     position: { x: 0, y: 0 }
   });
   const [editDialog, setEditDialog] = useState(false);
+
+  const { currentFlowId } = useFlowContext();
 
   // Check if this flow has an active connection
   const connectionState = useFlowConnectionState(flow.id.toString());
@@ -75,6 +78,19 @@ export default function FlowItem({ flow, onLoadFlow, onDeleteFlow, onRefresh, is
     } catch (error) {
       console.error('Failed to duplicate flow:', error);
     }
+  };
+
+  const handleRun = async () => {
+    // Load the flow first if it's not currently active
+    if (flow.id.toString() !== currentFlowId?.toString()) {
+      await onLoadFlow(flow);
+    }
+    // Dispatch trigger event after a short delay to allow flow to load
+    setTimeout(() => {
+      document.dispatchEvent(
+        new CustomEvent('portfolio-run-trigger', { detail: { flowId: flow.id.toString() } })
+      );
+    }, 300);
   };
 
   const handleDeleteFlow = async () => {
@@ -185,6 +201,7 @@ export default function FlowItem({ flow, onLoadFlow, onDeleteFlow, onRefresh, is
         isOpen={contextMenu.isOpen}
         position={contextMenu.position}
         onClose={closeContextMenu}
+        onRun={handleRun}
         onEdit={handleEdit}
         onDuplicate={handleDuplicateFlow}
         onDelete={handleDeleteFlow}

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { apiKeysService } from '@/services/api-keys-api';
-import { Eye, EyeOff, Key, Trash2 } from 'lucide-react';
+import { Database, Eye, EyeOff, Key, Trash2, Cpu } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 interface ApiKey {
@@ -11,6 +11,7 @@ interface ApiKey {
   description: string;
   url: string;
   placeholder: string;
+  type?: 'password' | 'text';
 }
 
 const FINANCIAL_API_KEYS: ApiKey[] = [
@@ -75,13 +76,36 @@ const LLM_API_KEYS: ApiKey[] = [
   }
 ];
 
+const MLX_SETTINGS: ApiKey[] = [
+  {
+    key: 'MLX_BASE_URL',
+    label: 'MLX Server URL',
+    description: 'Base URL of your MLX LM server (default: http://localhost:8080)',
+    url: 'https://github.com/ml-explore/mlx-examples/tree/main/llms',
+    placeholder: 'http://localhost:8080',
+    type: 'text'
+  },
+  {
+    key: 'MLX_API_KEY',
+    label: 'MLX API Key',
+    description: 'Optional API key for your MLX LM server (leave blank if not required)',
+    url: 'https://github.com/ml-explore/mlx-examples/tree/main/llms',
+    placeholder: 'mlx (optional)'
+  }
+];
+
+const DATA_PROVIDERS = [
+  { value: 'Financial', label: 'Financial Datasets (financialdatasets.ai)' },
+  { value: 'Yahoo', label: 'Yahoo Finance (free, no key required)' },
+  { value: 'Qveris', label: 'Qveris (qveris.ai)' },
+];
+
 export function ApiKeysSettings() {
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
   const [visibleKeys, setVisibleKeys] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Load API keys from backend on component mount
   useEffect(() => {
     loadApiKeys();
   }, []);
@@ -91,8 +115,7 @@ export function ApiKeysSettings() {
       setLoading(true);
       setError(null);
       const apiKeysSummary = await apiKeysService.getAllApiKeys();
-      
-      // Load actual key values for existing keys
+
       const keysData: Record<string, string> = {};
       for (const summary of apiKeysSummary) {
         try {
@@ -102,7 +125,7 @@ export function ApiKeysSettings() {
           console.warn(`Failed to load key for ${summary.provider}:`, err);
         }
       }
-      
+
       setApiKeys(keysData);
     } catch (err) {
       console.error('Failed to load API keys:', err);
@@ -113,13 +136,8 @@ export function ApiKeysSettings() {
   };
 
   const handleKeyChange = async (key: string, value: string) => {
-    // Update local state immediately for responsive UI
-    setApiKeys(prev => ({
-      ...prev,
-      [key]: value
-    }));
+    setApiKeys(prev => ({ ...prev, [key]: value }));
 
-    // Auto-save with debouncing
     try {
       if (value.trim()) {
         await apiKeysService.createOrUpdateApiKey({
@@ -128,11 +146,9 @@ export function ApiKeysSettings() {
           is_active: true
         });
       } else {
-        // If value is empty, delete the key
         try {
           await apiKeysService.deleteApiKey(key);
         } catch (err) {
-          // Key might not exist, which is fine
           console.log(`Key ${key} not found for deletion, which is expected`);
         }
       }
@@ -143,10 +159,7 @@ export function ApiKeysSettings() {
   };
 
   const toggleKeyVisibility = (key: string) => {
-    setVisibleKeys(prev => ({
-      ...prev,
-      [key]: !prev[key]
-    }));
+    setVisibleKeys(prev => ({ ...prev, [key]: !prev[key] }));
   };
 
   const clearKey = async (key: string) => {
@@ -175,19 +188,20 @@ export function ApiKeysSettings() {
       <CardContent className="space-y-4">
         {keys.map((apiKey) => (
           <div key={apiKey.key} className="space-y-2">
-                         <button
-               className="text-sm font-medium text-primary hover:text-blue-500 cursor-pointer transition-colors text-left"
-               onClick={() => window.open(apiKey.url, '_blank')}
-             >
-               {apiKey.label}
-             </button>
+            <button
+              className="text-sm font-medium text-primary hover:text-blue-500 cursor-pointer transition-colors text-left"
+              onClick={() => window.open(apiKey.url, '_blank')}
+            >
+              {apiKey.label}
+            </button>
+            <p className="text-xs text-muted-foreground">{apiKey.description}</p>
             <div className="relative">
               <Input
-                type={visibleKeys[apiKey.key] ? 'text' : 'password'}
+                type={apiKey.type === 'text' ? 'text' : (visibleKeys[apiKey.key] ? 'text' : 'password')}
                 placeholder={apiKey.placeholder}
                 value={apiKeys[apiKey.key] || ''}
                 onChange={(e) => handleKeyChange(apiKey.key, e.target.value)}
-                className="pr-20"
+                className={apiKey.type === 'text' ? 'pr-10' : 'pr-20'}
               />
               <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-1">
                 {apiKeys[apiKey.key] && (
@@ -200,18 +214,20 @@ export function ApiKeysSettings() {
                     <Trash2 className="h-3 w-3" />
                   </Button>
                 )}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={() => toggleKeyVisibility(apiKey.key)}
-                >
-                  {visibleKeys[apiKey.key] ? (
-                    <EyeOff className="h-3 w-3" />
-                  ) : (
-                    <Eye className="h-3 w-3" />
-                  )}
-                </Button>
+                {apiKey.type !== 'text' && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    onClick={() => toggleKeyVisibility(apiKey.key)}
+                  >
+                    {visibleKeys[apiKey.key] ? (
+                      <EyeOff className="h-3 w-3" />
+                    ) : (
+                      <Eye className="h-3 w-3" />
+                    )}
+                  </Button>
+                )}
               </div>
             </div>
           </div>
@@ -225,15 +241,11 @@ export function ApiKeysSettings() {
       <div className="space-y-6">
         <div>
           <h2 className="text-xl font-semibold text-primary mb-2">API Keys</h2>
-          <p className="text-sm text-muted-foreground">
-            Loading API keys...
-          </p>
+          <p className="text-sm text-muted-foreground">Loading API keys...</p>
         </div>
         <Card className="bg-panel border-gray-700 dark:border-gray-700">
           <CardContent className="p-6">
-            <div className="text-sm text-muted-foreground">
-              Please wait while we load your API keys...
-            </div>
+            <div className="text-sm text-muted-foreground">Please wait while we load your API keys...</div>
           </CardContent>
         </Card>
       </div>
@@ -250,7 +262,6 @@ export function ApiKeysSettings() {
         </p>
       </div>
 
-      {/* Error Message */}
       {error && (
         <Card className="bg-red-500/5 border-red-500/20">
           <CardContent className="p-4">
@@ -262,10 +273,7 @@ export function ApiKeysSettings() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => {
-                    setError(null);
-                    loadApiKeys();
-                  }}
+                  onClick={() => { setError(null); loadApiKeys(); }}
                   className="text-xs mt-2 p-0 h-auto text-red-500 hover:text-red-400"
                 >
                   Try again
@@ -276,13 +284,76 @@ export function ApiKeysSettings() {
         </Card>
       )}
 
-      {/* Financial Data API Keys */}
-      {renderApiKeySection(
-        'Financial Data',
-        'API keys for accessing financial market data and datasets.',
-        FINANCIAL_API_KEYS,
-        <Key className="h-4 w-4" />
-      )}
+      {/* Financial Data */}
+      <Card className="bg-panel border-gray-700 dark:border-gray-700">
+        <CardHeader>
+          <CardTitle className="text-lg font-medium text-primary flex items-center gap-2">
+            <Database className="h-4 w-4" />
+            Financial Data
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">Data provider and API keys for financial market data.</p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Data Provider selector */}
+          <div className="space-y-2">
+            <div className="text-sm font-medium text-primary">Data Provider</div>
+            <p className="text-xs text-muted-foreground">
+              Select which data source to use for prices, financials, and news.
+              This is the default; per-run overrides are available in the Portfolio node.
+            </p>
+            <select
+              className="w-full h-9 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus:outline-none focus:ring-1 focus:ring-ring text-primary"
+              value={apiKeys['USE_FINANCE_DATA'] || 'Financial'}
+              onChange={(e) => handleKeyChange('USE_FINANCE_DATA', e.target.value)}
+            >
+              {DATA_PROVIDERS.map(p => (
+                <option key={p.value} value={p.value}>{p.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Financial Datasets API key */}
+          {FINANCIAL_API_KEYS.map((apiKey) => (
+            <div key={apiKey.key} className="space-y-2">
+              <button
+                className="text-sm font-medium text-primary hover:text-blue-500 cursor-pointer transition-colors text-left"
+                onClick={() => window.open(apiKey.url, '_blank')}
+              >
+                {apiKey.label}
+              </button>
+              <div className="relative">
+                <Input
+                  type={visibleKeys[apiKey.key] ? 'text' : 'password'}
+                  placeholder={apiKey.placeholder}
+                  value={apiKeys[apiKey.key] || ''}
+                  onChange={(e) => handleKeyChange(apiKey.key, e.target.value)}
+                  className="pr-20"
+                />
+                <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-1">
+                  {apiKeys[apiKey.key] && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 hover:bg-red-500/10 hover:text-red-500"
+                      onClick={() => clearKey(apiKey.key)}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    onClick={() => toggleKeyVisibility(apiKey.key)}
+                  >
+                    {visibleKeys[apiKey.key] ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
 
       {/* LLM API Keys */}
       {renderApiKeySection(
@@ -290,6 +361,14 @@ export function ApiKeysSettings() {
         'API keys for accessing various large language model providers.',
         LLM_API_KEYS,
         <Key className="h-4 w-4" />
+      )}
+
+      {/* MLX Local Models */}
+      {renderApiKeySection(
+        'MLX Local Models',
+        'Settings for Apple Silicon MLX LM server (local inference). See Models → MLX for available models.',
+        MLX_SETTINGS,
+        <Cpu className="h-4 w-4" />
       )}
 
       {/* Security Note */}
@@ -300,7 +379,7 @@ export function ApiKeysSettings() {
             <div className="space-y-1">
               <h4 className="text-sm font-medium text-amber-500">Security Note</h4>
               <p className="text-xs text-muted-foreground">
-                API keys are stored securely on your local system and changes are automatically saved. 
+                API keys are stored securely on your local system and changes are automatically saved.
                 Keep your API keys secure and don't share them with others.
               </p>
             </div>
@@ -309,4 +388,4 @@ export function ApiKeysSettings() {
       </Card>
     </div>
   );
-} 
+}

--- a/app/frontend/src/components/tabs/flow-tab-content.tsx
+++ b/app/frontend/src/components/tabs/flow-tab-content.tsx
@@ -5,7 +5,7 @@ import { setNodeInternalState, setCurrentFlowId as setNodeStateFlowId } from '@/
 import { cn } from '@/lib/utils';
 import { flowService } from '@/services/flow-service';
 import { Flow as FlowType } from '@/types/flow';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 // Import the flow connection manager to check if flow is actively running
 
@@ -15,8 +15,9 @@ interface FlowTabContentProps {
 }
 
 export function FlowTabContent({ flow, className }: FlowTabContentProps) {
-  const { loadFlow } = useFlowContext();
+  const { loadFlow, currentFlowId } = useFlowContext();
   const { activeTabId } = useTabsContext();
+  const hasLoadedRef = useRef(false);
 
   // Enhanced load function that restores both use-node-state and node context data
   const loadFlowWithCompleteState = async (flowToLoad: FlowType) => {
@@ -52,27 +53,36 @@ export function FlowTabContent({ flow, className }: FlowTabContentProps) {
     }
   };
 
-  // Fetch the latest flow state when this tab becomes active
+  // Fetch the latest flow state when this tab becomes active.
+  // Skip the reload if this flow is already loaded in the canvas (e.g. switching
+  // to Settings and back) to avoid wiping unsaved in-memory changes.
   useEffect(() => {
     const isThisTabActive = activeTabId === `flow-${flow.id}`;
-    
+
     if (isThisTabActive) {
+      // If the canvas already has this flow loaded, don't re-fetch from backend.
+      // This preserves unsaved changes when the user switches tabs and returns.
+      const alreadyLoaded = currentFlowId === flow.id && hasLoadedRef.current;
+      if (alreadyLoaded) return;
+
       const fetchAndLoadFlow = async () => {
         try {
           // Fetch the latest flow data from the backend
           const latestFlow = await flowService.getFlow(flow.id);
           // Load the fresh flow data with complete state restoration
           await loadFlowWithCompleteState(latestFlow);
+          hasLoadedRef.current = true;
         } catch (error) {
           console.error('Failed to fetch latest flow state:', error);
           // Fallback to loading the cached flow data with complete state restoration
           await loadFlowWithCompleteState(flow);
+          hasLoadedRef.current = true;
         }
       };
 
       fetchAndLoadFlow();
     }
-  }, [activeTabId, flow.id, flow, loadFlow]);
+  }, [activeTabId, flow.id, flow, loadFlow, currentFlowId]);
 
   return (
     <div className={cn("h-full w-full", className)}>

--- a/app/frontend/src/data/models.ts
+++ b/app/frontend/src/data/models.ts
@@ -3,7 +3,7 @@ import { api } from '@/services/api';
 export interface LanguageModel {
   display_name: string;
   model_name: string;
-  provider: "Anthropic" | "DeepSeek" | "Google" | "Groq" | "OpenAI";
+  provider: string;
 }
 
 // Cache for models to avoid repeated API calls
@@ -17,7 +17,7 @@ export const getModels = async (): Promise<LanguageModel[]> => {
   if (languageModels) {
     return languageModels;
   }
-  
+
   try {
     languageModels = await api.getLanguageModels();
     return languageModels;
@@ -27,13 +27,71 @@ export const getModels = async (): Promise<LanguageModel[]> => {
   }
 };
 
+// Map from model provider name to the API key provider name stored in the DB
+const PROVIDER_TO_API_KEY: Record<string, string> = {
+  OpenAI: 'OPENAI_API_KEY',
+  Anthropic: 'ANTHROPIC_API_KEY',
+  Groq: 'GROQ_API_KEY',
+  DeepSeek: 'DEEPSEEK_API_KEY',
+  Google: 'GOOGLE_API_KEY',
+  xAI: 'XAI_API_KEY',
+  OpenRouter: 'OPENROUTER_API_KEY',
+  GigaChat: 'GIGACHAT_API_KEY',
+  Alibaba: 'ALIBABA_API_KEY',
+  Mistral: 'MISTRAL_API_KEY',
+  Meta: 'META_API_KEY',
+};
+
 /**
- * Get the default model (GPT-4.1) from the models list
+ * Get the best default model based on configured API keys.
+ * Priority: MLX (if MLX_BASE_URL set) > Ollama (if running) > Cloud (first provider with key set)
  */
 export const getDefaultModel = async (): Promise<LanguageModel | null> => {
   try {
-    const models = await getModels();
-    return models.find(model => model.model_name === "gpt-4.1") || models[0] || null;
+    const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+    const [models, apiKeysRaw] = await Promise.all([
+      getModels(),
+      fetch(`${API_BASE_URL}/api-keys`).then(r => r.ok ? r.json() : []).catch(() => []),
+    ]);
+
+    // Build a set of providers that have a key stored
+    const configuredKeys = new Set<string>(
+      (apiKeysRaw as Array<{ provider: string; has_key: boolean }>)
+        .filter(k => k.has_key)
+        .map(k => k.provider)
+    );
+
+    // 1. MLX — if MLX_BASE_URL is configured
+    if (configuredKeys.has('MLX_BASE_URL')) {
+      const mlx = models.find(m => m.provider === 'MLX');
+      if (mlx) return mlx;
+    }
+
+    // 2. Ollama — if server is reachable
+    try {
+      const ollamaRes = await fetch(`${API_BASE_URL}/ollama/models`);
+      if (ollamaRes.ok) {
+        const ollamaData = await ollamaRes.json();
+        if (Array.isArray(ollamaData.models) && ollamaData.models.length > 0) {
+          const ollama = models.find(m => m.provider === 'Ollama');
+          if (ollama) return ollama;
+        }
+      }
+    } catch {
+      // Ollama not available — continue
+    }
+
+    // 3. Cloud — first provider (in priority order) that has an API key stored
+    const cloudOrder = ['Anthropic', 'OpenAI', 'Groq', 'Google', 'DeepSeek', 'xAI', 'OpenRouter', 'Alibaba', 'Mistral', 'Meta'];
+    for (const provider of cloudOrder) {
+      const keyName = PROVIDER_TO_API_KEY[provider];
+      if (keyName && configuredKeys.has(keyName)) {
+        const model = models.find(m => m.provider === provider);
+        if (model) return model;
+      }
+    }
+
+    return null;
   } catch (error) {
     console.error('Failed to get default model:', error);
     return null;

--- a/app/frontend/src/nodes/components/portfolio-manager-node.tsx
+++ b/app/frontend/src/nodes/components/portfolio-manager-node.tsx
@@ -60,7 +60,7 @@ export function PortfolioManagerNode({
         ]);
         setAvailableModels(models);
         
-        // Set default model if no model is currently selected
+        // Auto-select best available model if none chosen yet
         if (!selectedModel && defaultModel) {
           setSelectedModel(defaultModel);
         }
@@ -141,7 +141,7 @@ export function PortfolioManagerNode({
                   models={availableModels}
                   value={selectedModel?.model_name || ''}
                   onChange={handleModelChange}
-                  placeholder="Auto"
+                  placeholder="Select LLM Model"
                 />
               </div>
             </div>

--- a/app/frontend/src/nodes/components/portfolio-manager-node.tsx
+++ b/app/frontend/src/nodes/components/portfolio-manager-node.tsx
@@ -59,9 +59,13 @@ export function PortfolioManagerNode({
           getDefaultModel()
         ]);
         setAvailableModels(models);
-        
-        // Auto-select best available model if none chosen yet
-        if (!selectedModel && defaultModel) {
+
+        // If stored model is not in the available list (e.g. MLX model when MLX is not running),
+        // clear it and fall back to the smart default so the backend never receives an invalid model.
+        const modelInList = selectedModel
+          ? models.some(m => m.model_name === selectedModel.model_name)
+          : false;
+        if (!modelInList && defaultModel) {
           setSelectedModel(defaultModel);
         }
       } catch (error) {

--- a/app/frontend/src/nodes/components/portfolio-start-node.tsx
+++ b/app/frontend/src/nodes/components/portfolio-start-node.tsx
@@ -1,6 +1,6 @@
 import { useReactFlow, type NodeProps } from '@xyflow/react';
 import { ChevronDown, PieChart, Play, Plus, Square, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { CardContent } from '@/components/ui/card';
@@ -12,6 +12,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import { Input } from '@/components/ui/input';
+import { ModelSelector } from '@/components/ui/llm-selector';
 import {
   Popover,
   PopoverContent,
@@ -25,6 +26,7 @@ import { useFlowConnection } from '@/hooks/use-flow-connection';
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
 import { useNodeState } from '@/hooks/use-node-state';
 import { cn, formatKeyboardShortcut } from '@/lib/utils';
+import { getDefaultModel, getModels, type LanguageModel } from '@/data/models';
 import { type PortfolioStartNode } from '../types';
 import { NodeShell } from './node-shell';
 
@@ -37,6 +39,12 @@ interface PortfolioPosition {
 const runModes = [
   { value: 'single', label: 'Single Run' },
   { value: 'backtest', label: 'Backtest' },
+];
+
+const dataProviders = [
+  { value: 'Financial', label: 'Financial Datasets' },
+  { value: 'Yahoo', label: 'Yahoo Finance' },
+  { value: 'Qveris', label: 'Qveris' },
 ];
 
 export function PortfolioStartNode({
@@ -58,7 +66,11 @@ export function PortfolioStartNode({
   const [runMode, setRunMode] = useNodeState(id, 'runMode', 'single');
   const [startDate, setStartDate] = useNodeState(id, 'startDate', threeMonthsAgo.toISOString().split('T')[0]);
   const [endDate, setEndDate] = useNodeState(id, 'endDate', today.toISOString().split('T')[0]);
+  const [dataProvider, setDataProvider] = useNodeState<string | null>(id, 'dataProvider', null);
+  const [selectedModel, setSelectedModel] = useNodeState<LanguageModel | null>(id, 'selectedModel', null);
+  const [availableModels, setAvailableModels] = useState<LanguageModel[]>([]);
   const [open, setOpen] = useState(false);
+  const [providerOpen, setProviderOpen] = useState(false);
   
   const { currentFlowId } = useFlowContext();
   const nodeContext = useNodeContext();
@@ -105,6 +117,46 @@ export function PortfolioStartNode({
       recoverFlowState();
     }
   }, [flowId, recoverFlowState]);
+
+
+  // Load available models and auto-select best default if none chosen.
+  // Also load the stored data provider from API keys settings.
+  useEffect(() => {
+    const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+    (async () => {
+      try {
+        const [models, defaultModel, apiKeys] = await Promise.all([
+          getModels(),
+          getDefaultModel(),
+          fetch(`${API_BASE_URL}/api-keys`).then(r => r.ok ? r.json() : []).catch(() => []),
+        ]);
+
+        setAvailableModels(models);
+
+        if (!selectedModel && defaultModel) {
+          setSelectedModel(defaultModel);
+        }
+
+        // Set data provider from stored setting if the user hasn't chosen one yet
+        if (!dataProvider) {
+          const stored = (apiKeys as Array<{ provider: string; has_key: boolean }>)
+            .find(k => k.provider === 'USE_FINANCE_DATA' && k.has_key);
+          if (stored) {
+            // Fetch the actual value
+            const detail = await fetch(`${API_BASE_URL}/api-keys/USE_FINANCE_DATA`)
+              .then(r => r.ok ? r.json() : null).catch(() => null);
+            const value = detail?.key_value;
+            const valid = ['Financial', 'Yahoo', 'Qveris'];
+            setDataProvider(valid.includes(value) ? value : 'Financial');
+          } else {
+            setDataProvider('Financial');
+          }
+        }
+      } catch {
+        if (!dataProvider) setDataProvider('Financial');
+      }
+    })();
+  }, []);
   
   const handlePositionChange = (index: number, field: keyof PortfolioPosition, value: string) => {
     const newPositions = [...positions];
@@ -224,11 +276,12 @@ export function PortfolioStartNode({
         start_date: startDate,
         end_date: endDate,
         initial_capital: parseFloat(initialCash) || 100000,
-        margin_requirement: 0.0, // Default margin requirement
-        model_name: undefined,
-        model_provider: undefined,
+        margin_requirement: 0.0,
+        model_name: selectedModel?.model_name || undefined,
+        model_provider: selectedModel?.provider as any || undefined,
         // Pass portfolio positions to backend
         portfolio_positions: portfolioPositions,
+        data_provider: dataProvider || undefined,
       });
     } else {
       // Use the regular hedge fund API for single run
@@ -243,17 +296,35 @@ export function PortfolioStartNode({
         })),
         graph_edges: validEdges,
         agent_models: agentModels,
-        // No global model - each agent uses its own model or system default
-        model_name: undefined,
-        model_provider: undefined,
+        model_name: selectedModel?.model_name || undefined,
+        model_provider: selectedModel?.provider as any || undefined,
         start_date: threeMonthsAgo.toISOString().split('T')[0],
         end_date: today.toISOString().split('T')[0],
         initial_cash: parseFloat(initialCash) || 100000,
         // Pass portfolio positions to backend
         portfolio_positions: portfolioPositions,
+        data_provider: dataProvider || undefined,
       });
     }
   };
+
+  // Keep a ref to the latest handlePlay so the event listener always calls the current version
+  const handlePlayRef = useRef(handlePlay);
+  handlePlayRef.current = handlePlay;
+  const canRunRef = useRef(canRunPortfolioAnalyzer);
+  canRunRef.current = canRunPortfolioAnalyzer;
+
+  // Listen for external run trigger (from flow context menu)
+  useEffect(() => {
+    const handleRunTrigger = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { flowId: string };
+      if (detail?.flowId === flowId && canRunRef.current) {
+        handlePlayRef.current();
+      }
+    };
+    document.addEventListener('portfolio-run-trigger', handleRunTrigger);
+    return () => document.removeEventListener('portfolio-run-trigger', handleRunTrigger);
+  }, [flowId]);
 
   // Determine if we're processing (connecting, connected, or any agents running)
   const showAsProcessing = isConnecting || isConnected || isProcessing;
@@ -358,6 +429,56 @@ export function PortfolioStartNode({
                     Add Position
                   </Button>
                 </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="text-subtitle text-primary flex items-center gap-1">
+                  Default Model
+                </div>
+                <ModelSelector
+                  models={availableModels}
+                  value={selectedModel?.model_name || ""}
+                  onChange={(model) => setSelectedModel(model)}
+                  placeholder="Select LLM Model"
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="text-subtitle text-primary flex items-center gap-1">
+                  Data Provider
+                </div>
+                <Popover open={providerOpen} onOpenChange={setProviderOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={providerOpen}
+                      className="w-full justify-between h-10 px-3 py-2 bg-node border border-border hover:bg-accent"
+                    >
+                      <span className="text-subtitle">
+                        {dataProviders.find((p) => p.value === dataProvider)?.label || 'Financial Datasets'}
+                      </span>
+                      <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0 bg-node border border-border shadow-lg">
+                    <Command className="bg-node">
+                      <CommandList className="bg-node">
+                        <CommandEmpty>No provider found.</CommandEmpty>
+                        <CommandGroup>
+                          {dataProviders.map((p) => (
+                            <CommandItem
+                              key={p.value}
+                              value={p.value}
+                              className={cn("cursor-pointer bg-node hover:bg-accent", dataProvider === p.value)}
+                              onSelect={(val) => { setDataProvider(val); setProviderOpen(false); }}
+                            >
+                              {p.label}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
               </div>
               <div className="flex flex-col gap-2">
                 <div className="text-subtitle text-primary flex items-center gap-1">

--- a/app/frontend/src/nodes/components/portfolio-start-node.tsx
+++ b/app/frontend/src/nodes/components/portfolio-start-node.tsx
@@ -133,7 +133,12 @@ export function PortfolioStartNode({
 
         setAvailableModels(models);
 
-        if (!selectedModel && defaultModel) {
+        // If stored model is not in the available list (e.g. MLX model when MLX is not running),
+        // clear it and fall back to the smart default so the backend never receives an invalid model.
+        const modelInList = selectedModel
+          ? models.some(m => m.model_name === selectedModel.model_name)
+          : false;
+        if (!modelInList && defaultModel) {
           setSelectedModel(defaultModel);
         }
 

--- a/app/frontend/src/services/types.ts
+++ b/app/frontend/src/services/types.ts
@@ -4,6 +4,7 @@ export enum ModelProvider {
   ANTHROPIC = 'Anthropic',
   GROQ = 'Groq',
   OLLAMA = 'Ollama',
+  MLX = 'MLX',
 }
 
 export interface AgentModelConfig {
@@ -43,6 +44,8 @@ export interface BaseHedgeFundRequest {
   model_provider?: ModelProvider;
   margin_requirement?: number;
   portfolio_positions?: PortfolioPosition[];
+  data_provider?: string;
+  mlx_base_url?: string;
 }
 
 export interface HedgeFundRequest extends BaseHedgeFundRequest {


### PR DESCRIPTION
… output improvements

Portfolio Input node (portfolio-start-node):
- Add Data Provider dropdown (Financial Datasets / Yahoo Finance / Qveris) that auto-populates from the USE_FINANCE_DATA API key setting
- Add Default Model selector so each flow can override the global model
- Pass data_provider and model selection through to the backend on run

Portfolio Manager node:
- Fix default model selection to respect per-flow model state

Flow context menu:
- Add 'Run' option that triggers the Portfolio Input node in the flow without requiring the user to switch to that tab first
- Dispatches a 'portfolio-run-trigger' CustomEvent; portfolio-start-node listens and calls handlePlay() when the flowId matches

Flow tab stability:
- Add hasLoadedRef guard in FlowTabContent so switching to Settings and back does not re-fetch from the backend and wipe unsaved canvas state

Output panel (regular-output):
- Add Price column to the Summary table (from current_prices)
- Left-align Bullish/Bearish/Neutral signal count columns

API Keys settings:
- Add USE_FINANCE_DATA and QVERIS_API_KEY entries with descriptions
- Reorganise provider sections for clarity

Backend:
- Pass data_provider from request schema through to the hedge fund runner
- Update schemas.py to include data_provider field

  ## Summary
  - **Portfolio Input node**: add Data Provider dropdown (Financial Datasets / Yahoo Finance / Qveris) that auto-populates from the `USE_FINANCE_DATA` API key setting
  - **Portfolio Input node**: add Default Model selector so each flow can override the global model
  - **Flow context menu**: add "Run" option that triggers the Portfolio Input node directly from the sidebar without switching tabs; uses a `portfolio-run-trigger` CustomEvent
  - **Flow tab stability**: add `hasLoadedRef` guard so switching to Settings and back no longer re-fetches from the backend and wipes unsaved canvas state
  - **Output panel**: add Price column to the Summary table; left-align signal count columns
  - **API Keys settings**: add `USE_FINANCE_DATA` and `QVERIS_API_KEY` entries with descriptions
  - **Backend**: pass `data_provider` from request schema through to the hedge fund runner

  ## Test plan
  - [ ] Switch data provider in Portfolio Input node and verify the correct provider is used on run
  - [ ] Click "Run" from the flow sidebar context menu and verify the analysis starts
  - [ ] Switch to Settings tab and back — verify canvas is not wiped
  - [ ] Run an analysis and verify Price column appears in the Summary table


