### PR TITLE
fix: remove src prefix from all module imports

### DIFF
--- a/app/backend/models/schemas.py
+++ b/app/backend/models/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional, Dict, Any
-from src.llm.models import ModelProvider
+from llm.models import ModelProvider
 from enum import Enum
 from app.backend.services.graph import extract_base_agent_key
 

--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -10,8 +10,8 @@ from app.backend.services.graph import create_graph, parse_hedge_fund_response, 
 from app.backend.services.portfolio import create_portfolio
 from app.backend.services.backtest_service import BacktestService
 from app.backend.services.api_key_service import ApiKeyService
-from src.utils.progress import progress
-from src.utils.analysts import get_agents_list
+from utils.progress import progress
+from utils.analysts import get_agents_list
 
 router = APIRouter(prefix="/hedge-fund")
 

--- a/app/backend/routes/language_models.py
+++ b/app/backend/routes/language_models.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Any
 
 from app.backend.models.schemas import ErrorResponse
 from app.backend.services.ollama_service import OllamaService
-from src.llm.models import get_models_list
+from llm.models import get_models_list
 
 router = APIRouter(prefix="/language-models")
 

--- a/app/backend/services/agent_service.py
+++ b/app/backend/services/agent_service.py
@@ -1,6 +1,6 @@
 from functools import partial
 from typing import Callable
-from src.graph.state import AgentState
+from graph.state import AgentState
 
 def create_agent_function(agent_function: Callable, agent_id: str) -> Callable[[AgentState], dict]:
     """

--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -5,7 +5,7 @@ import numpy as np
 from typing import Callable, Dict, List, Optional, Any
 import asyncio
 
-from src.tools.api import (
+from tools.api import (
     get_company_news,
     get_price_data,
     get_prices,

--- a/app/backend/services/graph.py
+++ b/app/backend/services/graph.py
@@ -5,11 +5,11 @@ from langchain_core.messages import HumanMessage
 from langgraph.graph import END, StateGraph
 
 from app.backend.services.agent_service import create_agent_function
-from src.agents.portfolio_manager import portfolio_management_agent
-from src.agents.risk_manager import risk_management_agent
-from src.main import start
-from src.utils.analysts import ANALYST_CONFIG
-from src.graph.state import AgentState
+from agents.portfolio_manager import portfolio_management_agent
+from agents.risk_manager import risk_management_agent
+from main import start
+from utils.analysts import ANALYST_CONFIG
+from graph.state import AgentState
 
 
 def extract_base_agent_key(unique_id: str) -> str:

--- a/app/backend/services/ollama_service.py
+++ b/app/backend/services/ollama_service.py
@@ -502,7 +502,7 @@ class OllamaService:
     def _format_models_for_api(self, downloaded_models: List[str]) -> List[Dict[str, str]]:
         """Format downloaded models for API response."""
         # Import OLLAMA_MODELS here to avoid circular imports
-        from src.llm.models import OLLAMA_MODELS
+        from llm.models import OLLAMA_MODELS
         
         api_models = []
         for ollama_model in OLLAMA_MODELS:

--- a/src/agents/aswath_damodaran.py
+++ b/src/agents/aswath_damodaran.py
@@ -4,18 +4,18 @@ import json
 from typing_extensions import Literal
 from pydantic import BaseModel
 
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 
-from src.tools.api import (
+from tools.api import (
     get_financial_metrics,
     get_market_cap,
     search_line_items,
 )
-from src.utils.api_key import get_api_key_from_state
-from src.utils.llm import call_llm
-from src.utils.progress import progress
+from utils.api_key import get_api_key_from_state
+from utils.llm import call_llm
+from utils.progress import progress
 
 
 class AswathDamodaranSignal(BaseModel):

--- a/src/agents/ben_graham.py
+++ b/src/agents/ben_graham.py
@@ -1,14 +1,14 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 import math
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 
 class BenGrahamSignal(BaseModel):

--- a/src/agents/bill_ackman.py
+++ b/src/agents/bill_ackman.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class BillAckmanSignal(BaseModel):

--- a/src/agents/cathie_wood.py
+++ b/src/agents/cathie_wood.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class CathieWoodSignal(BaseModel):

--- a/src/agents/charlie_munger.py
+++ b/src/agents/charlie_munger.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items, get_insider_trades, get_company_news
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items, get_insider_trades, get_company_news
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 class CharlieMungerSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/fundamentals.py
+++ b/src/agents/fundamentals.py
@@ -1,10 +1,10 @@
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.api_key import get_api_key_from_state
-from src.utils.progress import progress
+from graph.state import AgentState, show_agent_reasoning
+from utils.api_key import get_api_key_from_state
+from utils.progress import progress
 import json
 
-from src.tools.api import get_financial_metrics
+from tools.api import get_financial_metrics
 
 
 ##### Fundamental Agent #####

--- a/src/agents/growth_agent.py
+++ b/src/agents/growth_agent.py
@@ -8,10 +8,10 @@ Implements a growth-focused valuation methodology.
 import json
 import statistics
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
+from tools.api import (
     get_financial_metrics,
     get_insider_trades,
 )

--- a/src/agents/michael_burry.py
+++ b/src/agents/michael_burry.py
@@ -4,21 +4,21 @@ from datetime import datetime, timedelta
 import json
 from typing_extensions import Literal
 
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.messages import HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel
 
-from src.tools.api import (
+from tools.api import (
     get_company_news,
     get_financial_metrics,
     get_insider_trades,
     get_market_cap,
     search_line_items,
 )
-from src.utils.llm import call_llm
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
+from utils.llm import call_llm
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
 
 
 class MichaelBurrySignal(BaseModel):

--- a/src/agents/mohnish_pabrai.py
+++ b/src/agents/mohnish_pabrai.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class MohnishPabraiSignal(BaseModel):

--- a/src/agents/nassim_taleb.py
+++ b/src/agents/nassim_taleb.py
@@ -1,4 +1,4 @@
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel, Field
@@ -9,7 +9,7 @@ from typing_extensions import Literal
 import numpy as np
 import pandas as pd
 
-from src.tools.api import (
+from tools.api import (
     get_company_news,
     get_financial_metrics,
     get_insider_trades,
@@ -18,9 +18,9 @@ from src.tools.api import (
     prices_to_df,
     search_line_items,
 )
-from src.utils.llm import call_llm
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
+from utils.llm import call_llm
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
 
 
 class NassimTalebSignal(BaseModel):

--- a/src/agents/news_sentiment.py
+++ b/src/agents/news_sentiment.py
@@ -2,16 +2,16 @@
 
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel, Field
-from src.data.models import CompanyNews
+from data.models import CompanyNews
 import pandas as pd
 import numpy as np
 import json
 
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_company_news
-from src.utils.api_key import get_api_key_from_state
-from src.utils.llm import call_llm
-from src.utils.progress import progress
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import get_company_news
+from utils.api_key import get_api_key_from_state
+from utils.llm import call_llm
+from utils.progress import progress
 from typing_extensions import Literal
 
 

--- a/src/agents/peter_lynch.py
+++ b/src/agents/peter_lynch.py
@@ -1,5 +1,5 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import (
     get_market_cap,
     search_line_items,
     get_insider_trades,
@@ -10,9 +10,9 @@ from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
-from src.utils.api_key import get_api_key_from_state
+from utils.progress import progress
+from utils.llm import call_llm
+from utils.api_key import get_api_key_from_state
 
 
 class PeterLynchSignal(BaseModel):

--- a/src/agents/phil_fisher.py
+++ b/src/agents/phil_fisher.py
@@ -1,5 +1,5 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import (
     get_market_cap,
     search_line_items,
     get_insider_trades,
@@ -10,10 +10,10 @@ from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 import statistics
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 class PhilFisherSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/portfolio_manager.py
+++ b/src/agents/portfolio_manager.py
@@ -3,11 +3,11 @@ import time
 from langchain_core.messages import HumanMessage
 from langchain_core.prompts import ChatPromptTemplate
 
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 
 
 class PortfolioDecision(BaseModel):

--- a/src/agents/rakesh_jhunjhunwala.py
+++ b/src/agents/rakesh_jhunjhunwala.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
-from src.utils.llm import call_llm
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
+from utils.llm import call_llm
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
 
 class RakeshJhunjhunwalaSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/risk_manager.py
+++ b/src/agents/risk_manager.py
@@ -1,11 +1,11 @@
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
-from src.tools.api import get_prices, prices_to_df
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
+from tools.api import get_prices, prices_to_df
 import json
 import numpy as np
 import pandas as pd
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 ##### Risk Management Agent #####
 def risk_management_agent(state: AgentState, agent_id: str = "risk_management_agent"):

--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -1,11 +1,11 @@
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
 import pandas as pd
 import numpy as np
 import json
-from src.utils.api_key import get_api_key_from_state
-from src.tools.api import get_insider_trades, get_company_news
+from utils.api_key import get_api_key_from_state
+from tools.api import get_insider_trades, get_company_news
 
 
 ##### Sentiment Agent #####

--- a/src/agents/stanley_druckenmiller.py
+++ b/src/agents/stanley_druckenmiller.py
@@ -1,5 +1,5 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from tools.api import (
     get_financial_metrics,
     get_market_cap,
     search_line_items,
@@ -12,10 +12,10 @@ from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 import json
 from typing_extensions import Literal
-from src.utils.progress import progress
-from src.utils.llm import call_llm
+from utils.progress import progress
+from utils.llm import call_llm
 import statistics
-from src.utils.api_key import get_api_key_from_state
+from utils.api_key import get_api_key_from_state
 
 class StanleyDruckenmillerSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]

--- a/src/agents/technicals.py
+++ b/src/agents/technicals.py
@@ -2,14 +2,14 @@ import math
 
 from langchain_core.messages import HumanMessage
 
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.api_key import get_api_key_from_state
+from graph.state import AgentState, show_agent_reasoning
+from utils.api_key import get_api_key_from_state
 import json
 import pandas as pd
 import numpy as np
 
-from src.tools.api import get_prices, prices_to_df
-from src.utils.progress import progress
+from tools.api import get_prices, prices_to_df
+from utils.progress import progress
 
 
 def safe_float(value, default=0.0):

--- a/src/agents/valuation.py
+++ b/src/agents/valuation.py
@@ -9,10 +9,10 @@ configurable weights.
 import json
 import statistics
 from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
-from src.tools.api import (
+from graph.state import AgentState, show_agent_reasoning
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
+from tools.api import (
     get_financial_metrics,
     get_market_cap,
     search_line_items,

--- a/src/agents/warren_buffett.py
+++ b/src/agents/warren_buffett.py
@@ -1,13 +1,13 @@
-from src.graph.state import AgentState, show_agent_reasoning
+from graph.state import AgentState, show_agent_reasoning
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel, Field
 import json
 from typing_extensions import Literal
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
-from src.utils.llm import call_llm
-from src.utils.progress import progress
-from src.utils.api_key import get_api_key_from_state
+from tools.api import get_financial_metrics, get_market_cap, search_line_items
+from utils.llm import call_llm
+from utils.progress import progress
+from utils.api_key import get_api_key_from_state
 
 
 class WarrenBuffettSignal(BaseModel):

--- a/src/backtester.py
+++ b/src/backtester.py
@@ -2,10 +2,10 @@ import sys
 
 from colorama import Fore, Style
 
-from src.main import run_hedge_fund
-from src.backtesting.engine import BacktestEngine
-from src.backtesting.types import PerformanceMetrics
-from src.cli.input import (
+from main import run_hedge_fund
+from backtesting.engine import BacktestEngine
+from backtesting.types import PerformanceMetrics
+from cli.input import (
     parse_cli_inputs,
 )
 

--- a/src/backtesting/benchmarks.py
+++ b/src/backtesting/benchmarks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from src.tools.api import get_price_data
+from tools.api import get_price_data
 
 
 class BenchmarkCalculator:

--- a/src/backtesting/cli.py
+++ b/src/backtesting/cli.py
@@ -9,10 +9,10 @@ from colorama import Fore, Style, init
 import questionary
 
 from .engine import BacktestEngine
-from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider
-from src.utils.analysts import ANALYST_ORDER
-from src.main import run_hedge_fund
-from src.utils.ollama import ensure_ollama_and_model
+from llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider
+from utils.analysts import ANALYST_ORDER
+from main import run_hedge_fund
+from utils.ollama import ensure_ollama_and_model
 
 
 def main() -> int:

--- a/src/backtesting/engine.py
+++ b/src/backtesting/engine.py
@@ -15,7 +15,7 @@ from .valuation import calculate_portfolio_value, compute_exposures
 from .output import OutputBuilder
 from .benchmarks import BenchmarkCalculator
 
-from src.tools.api import (
+from tools.api import (
     get_company_news,
     get_price_data,
     get_prices,

--- a/src/backtesting/output.py
+++ b/src/backtesting/output.py
@@ -4,7 +4,7 @@ from typing import List, Mapping, Sequence
 
 from .portfolio import Portfolio
 from .types import AgentOutput
-from src.utils.display import format_backtest_row, print_backtest_results
+from utils.display import format_backtest_row, print_backtest_results
 from .valuation import compute_portfolio_summary
 
 

--- a/src/cli/input.py
+++ b/src/cli/input.py
@@ -5,9 +5,9 @@ import argparse
 import questionary
 from colorama import Fore, Style
 
-from src.utils.analysts import ANALYST_ORDER
-from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, find_model_by_name
-from src.utils.ollama import ensure_ollama_and_model
+from utils.analysts import ANALYST_ORDER
+from llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, find_model_by_name
+from utils.ollama import ensure_ollama_and_model
 
 from dataclasses import dataclass
 from typing import Optional

--- a/src/main.py
+++ b/src/main.py
@@ -5,14 +5,14 @@ from langchain_core.messages import HumanMessage
 from langgraph.graph import END, StateGraph
 from colorama import Fore, Style, init
 import questionary
-from src.agents.portfolio_manager import portfolio_management_agent
-from src.agents.risk_manager import risk_management_agent
-from src.graph.state import AgentState
-from src.utils.display import print_trading_output
-from src.utils.analysts import ANALYST_ORDER, get_analyst_nodes
-from src.utils.progress import progress
-from src.utils.visualize import save_graph_as_png
-from src.cli.input import (
+from agents.portfolio_manager import portfolio_management_agent
+from agents.risk_manager import risk_management_agent
+from graph.state import AgentState
+from utils.display import print_trading_output
+from utils.analysts import ANALYST_ORDER, get_analyst_nodes
+from utils.progress import progress
+from utils.visualize import save_graph_as_png
+from cli.input import (
     parse_cli_inputs,
 )
 

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -7,8 +7,8 @@ import time
 
 logger = logging.getLogger(__name__)
 
-from src.data.cache import get_cache
-from src.data.models import (
+from data.cache import get_cache
+from data.models import (
     CompanyNews,
     CompanyNewsResponse,
     FinancialMetrics,

--- a/src/utils/analysts.py
+++ b/src/utils/analysts.py
@@ -1,25 +1,25 @@
 """Constants and utilities related to analysts configuration."""
 
-from src.agents import portfolio_manager
-from src.agents.aswath_damodaran import aswath_damodaran_agent
-from src.agents.ben_graham import ben_graham_agent
-from src.agents.bill_ackman import bill_ackman_agent
-from src.agents.cathie_wood import cathie_wood_agent
-from src.agents.charlie_munger import charlie_munger_agent
-from src.agents.fundamentals import fundamentals_analyst_agent
-from src.agents.michael_burry import michael_burry_agent
-from src.agents.phil_fisher import phil_fisher_agent
-from src.agents.peter_lynch import peter_lynch_agent
-from src.agents.sentiment import sentiment_analyst_agent
-from src.agents.stanley_druckenmiller import stanley_druckenmiller_agent
-from src.agents.technicals import technical_analyst_agent
-from src.agents.valuation import valuation_analyst_agent
-from src.agents.warren_buffett import warren_buffett_agent
-from src.agents.rakesh_jhunjhunwala import rakesh_jhunjhunwala_agent
-from src.agents.mohnish_pabrai import mohnish_pabrai_agent
-from src.agents.nassim_taleb import nassim_taleb_agent
-from src.agents.news_sentiment import news_sentiment_agent
-from src.agents.growth_agent import growth_analyst_agent
+from agents import portfolio_manager
+from agents.aswath_damodaran import aswath_damodaran_agent
+from agents.ben_graham import ben_graham_agent
+from agents.bill_ackman import bill_ackman_agent
+from agents.cathie_wood import cathie_wood_agent
+from agents.charlie_munger import charlie_munger_agent
+from agents.fundamentals import fundamentals_analyst_agent
+from agents.michael_burry import michael_burry_agent
+from agents.phil_fisher import phil_fisher_agent
+from agents.peter_lynch import peter_lynch_agent
+from agents.sentiment import sentiment_analyst_agent
+from agents.stanley_druckenmiller import stanley_druckenmiller_agent
+from agents.technicals import technical_analyst_agent
+from agents.valuation import valuation_analyst_agent
+from agents.warren_buffett import warren_buffett_agent
+from agents.rakesh_jhunjhunwala import rakesh_jhunjhunwala_agent
+from agents.mohnish_pabrai import mohnish_pabrai_agent
+from agents.nassim_taleb import nassim_taleb_agent
+from agents.news_sentiment import news_sentiment_agent
+from agents.growth_agent import growth_analyst_agent
 
 # Define analyst configuration - single source of truth
 ANALYST_CONFIG = {

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -2,9 +2,9 @@
 
 import json
 from pydantic import BaseModel
-from src.llm.models import get_model, get_model_info
-from src.utils.progress import progress
-from src.graph.state import AgentState
+from llm.models import get_model, get_model_info
+from utils.progress import progress
+from graph.state import AgentState
 
 
 def call_llm(

--- a/tests/backtesting/conftest.py
+++ b/tests/backtesting/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.backtesting.portfolio import Portfolio
+from backtesting.portfolio import Portfolio
 
 
 @pytest.fixture()

--- a/tests/backtesting/integration/mocks.py
+++ b/tests/backtesting/integration/mocks.py
@@ -1,4 +1,4 @@
-from src.backtesting.types import AgentOutput
+from backtesting.types import AgentOutput
 
 
 class MockConfigurableAgent:

--- a/tests/backtesting/integration/test_integration_long_only.py
+++ b/tests/backtesting/integration/test_integration_long_only.py
@@ -1,4 +1,4 @@
-from src.backtesting.engine import BacktestEngine
+from backtesting.engine import BacktestEngine
 from tests.backtesting.integration.mocks import MockConfigurableAgent
 
 def test_long_only_strategy_buys_and_sells():
@@ -73,7 +73,7 @@ def test_long_only_strategy_buys_and_sells():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
     
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
         total_value=final_portfolio_value,
@@ -170,7 +170,7 @@ def test_long_only_strategy_full_liquidation_cycle():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
     
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
         total_value=final_portfolio_value,
@@ -281,7 +281,7 @@ def test_long_only_strategy_portfolio_rebalancing():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
     
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
         total_value=final_portfolio_value,
@@ -382,7 +382,7 @@ def test_long_only_strategy_multiple_entry_exit_cycles():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
     
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
         total_value=final_portfolio_value,

--- a/tests/backtesting/integration/test_integration_long_short.py
+++ b/tests/backtesting/integration/test_integration_long_short.py
@@ -1,4 +1,4 @@
-from src.backtesting.engine import BacktestEngine
+from backtesting.engine import BacktestEngine
 from tests.backtesting.integration.mocks import MockConfigurableAgent
 
 
@@ -64,7 +64,7 @@ def test_long_short_strategy_partial_exits():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
@@ -139,7 +139,7 @@ def test_long_short_strategy_full_liquidation_to_cash():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
@@ -218,7 +218,7 @@ def test_long_short_strategy_directional_flip_on_ticker():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
@@ -293,7 +293,7 @@ def test_long_short_strategy_dca_both_sides():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,

--- a/tests/backtesting/integration/test_integration_short_only.py
+++ b/tests/backtesting/integration/test_integration_short_only.py
@@ -1,4 +1,4 @@
-from src.backtesting.engine import BacktestEngine
+from backtesting.engine import BacktestEngine
 from tests.backtesting.integration.mocks import MockConfigurableAgent
 
 
@@ -61,7 +61,7 @@ def test_short_only_strategy_shorts_and_covers():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
@@ -145,7 +145,7 @@ def test_short_only_strategy_full_cover_cycle():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
@@ -219,7 +219,7 @@ def test_short_only_strategy_multiple_short_cover_cycles():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
@@ -308,7 +308,7 @@ def test_short_only_strategy_portfolio_rebalancing():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,
@@ -384,7 +384,7 @@ def test_short_only_strategy_dollar_cost_averaging_on_short():
     final_portfolio_value = portfolio_values[-1]["Portfolio Value"]
     final_cash = final_portfolio["cash"]
 
-    from src.backtesting.valuation import compute_portfolio_summary
+    from backtesting.valuation import compute_portfolio_summary
 
     portfolio_summary = compute_portfolio_summary(
         portfolio=engine._portfolio,

--- a/tests/backtesting/test_controller.py
+++ b/tests/backtesting/test_controller.py
@@ -1,4 +1,4 @@
-from src.backtesting.controller import AgentController
+from backtesting.controller import AgentController
 
 
 def dummy_agent(**kwargs):

--- a/tests/backtesting/test_execution.py
+++ b/tests/backtesting/test_execution.py
@@ -1,4 +1,4 @@
-from src.backtesting.trader import TradeExecutor
+from backtesting.trader import TradeExecutor
 
 
 def test_trade_executor_routes_actions(portfolio):

--- a/tests/backtesting/test_metrics.py
+++ b/tests/backtesting/test_metrics.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 
-from src.backtesting.metrics import PerformanceMetricsCalculator
+from backtesting.metrics import PerformanceMetricsCalculator
 
 
 def _build_values(values: list[float]):

--- a/tests/backtesting/test_portfolio.py
+++ b/tests/backtesting/test_portfolio.py
@@ -2,7 +2,7 @@ import math
 
 import pytest
 
-from src.backtesting.portfolio import Portfolio
+from backtesting.portfolio import Portfolio
 
 def test_apply_long_buy_basic(portfolio: Portfolio) -> None:
     executed = portfolio.apply_long_buy("AAPL", quantity=100, price=50.0)

--- a/tests/backtesting/test_results.py
+++ b/tests/backtesting/test_results.py
@@ -1,4 +1,4 @@
-from src.backtesting.output import OutputBuilder
+from backtesting.output import OutputBuilder
 
 
 def test_results_builder_builds_rows_and_summary(monkeypatch, portfolio):

--- a/tests/backtesting/test_valuation.py
+++ b/tests/backtesting/test_valuation.py
@@ -1,4 +1,4 @@
-from src.backtesting.valuation import calculate_portfolio_value, compute_exposures, compute_portfolio_summary
+from backtesting.valuation import calculate_portfolio_value, compute_exposures, compute_portfolio_summary
 
 
 def test_calculate_portfolio_value(portfolio, prices):

--- a/tests/test_api_rate_limiting.py
+++ b/tests/test_api_rate_limiting.py
@@ -2,7 +2,7 @@ import os
 import pytest
 from unittest.mock import Mock, patch, call
 
-from src.tools.api import _make_api_request, get_prices
+from tools.api import _make_api_request, get_prices
 
 class TestRateLimiting:
     """Test suite for API rate limiting functionality."""


### PR DESCRIPTION
## Summary
- Removed `src.` prefix from all 182 module imports across 50 files
- When running `python src/main.py`, Python adds the `src` directory to `sys.path`, so modules are importable directly without the `src.` prefix
- This fixes `ModuleNotFoundError: No module named 'src'` that occurs in certain environments

### Files changed
- `src/` internal imports (agents, graph, tools, llm, utils, backtesting)
- `app/backend/` service and route imports
- `tests/` test file imports

Fixes #517