### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,7 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 AZURE_OPENAI_API_KEY=your-azure-openai-api-key
 AZURE_OPENAI_ENDPOINT=your-azure-openai-endpoint
 AZURE_OPENAI_DEPLOYMENT_NAME=your-azure-openai-deployment-name
+
+# For Exa AI-powered web search (used by the Exa Web Search Analyst)
+# Get your Exa API key from https://exa.ai/
+EXA_API_KEY=your-exa-api-key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ sqlalchemy = "^2.0.22"
 alembic = "^1.12.0"
 langchain-gigachat = "^0.3.12"
 langchain-xai = "^0.2.5"
+exa-py = ">=2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/src/agents/exa_news.py
+++ b/src/agents/exa_news.py
@@ -1,0 +1,173 @@
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, Field
+import json
+from typing_extensions import Literal
+
+from src.graph.state import AgentState, show_agent_reasoning
+from src.tools.exa_search import search_exa
+from src.utils.api_key import get_api_key_from_state
+from src.utils.llm import call_llm
+from src.utils.progress import progress
+
+
+class WebSentiment(BaseModel):
+    """Represents the aggregated sentiment from web search results."""
+
+    sentiment: Literal["positive", "negative", "neutral"]
+    confidence: int = Field(description="Confidence 0-100")
+    reasoning: str = Field(description="Brief explanation of the sentiment assessment")
+
+
+def exa_news_agent(state: AgentState, agent_id: str = "exa_news_agent"):
+    """Analyzes web sentiment for a list of tickers using Exa AI-powered search.
+
+    This agent uses Exa to search for recent news, analysis, and commentary
+    about each ticker. It retrieves article highlights and uses an LLM to
+    assess overall market sentiment, producing a trading signal.
+
+    Args:
+        state: The current state of the agent graph.
+        agent_id: The ID of the agent.
+
+    Returns:
+        A dictionary containing the updated state with the agent's analysis.
+    """
+    data = state.get("data", {})
+    end_date = data.get("end_date")
+    tickers = data.get("tickers")
+    exa_api_key = get_api_key_from_state(state, "EXA_API_KEY")
+    sentiment_analysis = {}
+
+    for ticker in tickers:
+        progress.update_status(agent_id, ticker, "Searching web for news and analysis")
+
+        # Search for recent news about this ticker
+        results = search_exa(
+            query=f"{ticker} stock latest news analysis",
+            num_results=10,
+            search_type="auto",
+            category="news",
+            end_published_date=f"{end_date}T23:59:59.000Z" if end_date else None,
+            api_key=exa_api_key,
+        )
+
+        if not results:
+            # Fallback: try broader search without category filter
+            progress.update_status(agent_id, ticker, "Retrying with broader search")
+            results = search_exa(
+                query=f"{ticker} stock market sentiment outlook",
+                num_results=10,
+                search_type="auto",
+                end_published_date=f"{end_date}T23:59:59.000Z" if end_date else None,
+                api_key=exa_api_key,
+            )
+
+        if not results:
+            sentiment_analysis[ticker] = {
+                "signal": "neutral",
+                "confidence": 0,
+                "reasoning": {
+                    "web_sentiment": {
+                        "signal": "neutral",
+                        "confidence": 0,
+                        "metrics": {
+                            "articles_found": 0,
+                            "articles_analyzed": 0,
+                        },
+                        "details": "No web search results available.",
+                    }
+                },
+            }
+            progress.update_status(agent_id, ticker, "Done (no results)")
+            continue
+
+        progress.update_status(agent_id, ticker, f"Analyzing {len(results)} articles")
+
+        # Build article summaries for the LLM
+        article_summaries = []
+        for i, result in enumerate(results[:10], 1):
+            article = f"Article {i}: {result.title}"
+            if result.published_date:
+                article += f" (Published: {result.published_date})"
+            if result.snippet:
+                article += f"\nContent: {result.snippet[:1000]}"
+            article_summaries.append(article)
+
+        articles_text = "\n\n".join(article_summaries)
+
+        # Use LLM to analyze sentiment from the articles
+        prompt = (
+            f"Analyze the following web articles about the stock {ticker} and determine "
+            f"the overall market sentiment.\n\n"
+            f"Consider:\n"
+            f"- Are the articles generally positive, negative, or neutral about the stock?\n"
+            f"- What is the prevailing market outlook?\n"
+            f"- Are there any significant risks or catalysts mentioned?\n\n"
+            f"Articles:\n{articles_text}\n\n"
+            f"Provide your assessment as JSON with 'sentiment' (positive/negative/neutral), "
+            f"'confidence' (0-100), and 'reasoning' (brief explanation)."
+        )
+
+        llm_result = call_llm(prompt, WebSentiment, agent_name=agent_id, state=state)
+
+        if llm_result:
+            sentiment_label = llm_result.sentiment.lower()
+            confidence = llm_result.confidence
+            llm_reasoning = llm_result.reasoning
+        else:
+            sentiment_label = "neutral"
+            confidence = 0
+            llm_reasoning = "LLM analysis failed, defaulting to neutral."
+
+        # Map sentiment to trading signal
+        if sentiment_label == "positive":
+            overall_signal = "bullish"
+        elif sentiment_label == "negative":
+            overall_signal = "bearish"
+        else:
+            overall_signal = "neutral"
+
+        reasoning = {
+            "web_sentiment": {
+                "signal": overall_signal,
+                "confidence": confidence,
+                "metrics": {
+                    "articles_found": len(results),
+                    "articles_analyzed": min(len(results), 10),
+                },
+                "details": llm_reasoning,
+                "sources": [
+                    {"title": r.title, "url": r.url, "date": r.published_date}
+                    for r in results[:5]
+                ],
+            }
+        }
+
+        sentiment_analysis[ticker] = {
+            "signal": overall_signal,
+            "confidence": confidence,
+            "reasoning": reasoning,
+        }
+
+        progress.update_status(
+            agent_id, ticker, "Done", analysis=json.dumps(reasoning, indent=4)
+        )
+
+    message = HumanMessage(
+        content=json.dumps(sentiment_analysis),
+        name=agent_id,
+    )
+
+    if state.get("metadata", {}).get("show_reasoning"):
+        show_agent_reasoning(sentiment_analysis, "Exa Web Search Analyst")
+
+    if "analyst_signals" not in state["data"]:
+        state["data"]["analyst_signals"] = {}
+    state["data"]["analyst_signals"][agent_id] = sentiment_analysis
+
+    progress.update_status(agent_id, None, "Done")
+
+    return {
+        "messages": [message],
+        "data": state["data"],
+    }

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -169,6 +169,14 @@ class AgentStateData(BaseModel):
     ticker_analyses: dict[str, TickerAnalysis]  # ticker -> analysis mapping
 
 
+class ExaSearchResult(BaseModel):
+    title: str
+    url: str
+    snippet: str
+    published_date: str | None = None
+    author: str | None = None
+
+
 class AgentStateMetadata(BaseModel):
     show_reasoning: bool = False
     model_config = {"extra": "allow"}

--- a/src/tools/exa_search.py
+++ b/src/tools/exa_search.py
@@ -1,0 +1,121 @@
+import logging
+import os
+
+from src.data.models import ExaSearchResult
+
+logger = logging.getLogger(__name__)
+
+try:
+    from exa_py import Exa
+except ImportError:
+    Exa = None
+
+
+def search_exa(
+    query: str,
+    num_results: int = 10,
+    search_type: str = "auto",
+    category: str | None = None,
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    include_text: list[str] | None = None,
+    exclude_text: list[str] | None = None,
+    start_published_date: str | None = None,
+    end_published_date: str | None = None,
+    api_key: str | None = None,
+) -> list[ExaSearchResult]:
+    """Search the web using Exa's AI-powered search engine.
+
+    Args:
+        query: The search query.
+        num_results: Number of results to return (max 100).
+        search_type: Search type - 'auto', 'neural', 'fast', or 'instant'.
+        category: Filter by category (e.g. 'news', 'company', 'research paper',
+                  'financial report').
+        include_domains: Only include results from these domains.
+        exclude_domains: Exclude results from these domains.
+        include_text: Strings that must appear in page text.
+        exclude_text: Strings to exclude from results.
+        start_published_date: ISO 8601 date; only results published after this.
+        end_published_date: ISO 8601 date; only results published before this.
+        api_key: Exa API key. Falls back to EXA_API_KEY env var.
+
+    Returns:
+        List of ExaSearchResult objects.
+    """
+    if Exa is None:
+        logger.warning("exa-py package not installed. Run: pip install exa-py")
+        return []
+
+    exa_api_key = api_key or os.environ.get("EXA_API_KEY")
+    if not exa_api_key:
+        logger.warning("EXA_API_KEY not set. Exa search will return empty results.")
+        return []
+
+    try:
+        client = Exa(api_key=exa_api_key)
+        client.headers["x-exa-integration"] = "ai-hedge-fund"
+
+        search_kwargs: dict = {
+            "query": query,
+            "num_results": num_results,
+            "type": search_type,
+            "contents": {
+                "highlights": {"max_characters": 4000},
+                "summary": True,
+            },
+        }
+
+        if category:
+            search_kwargs["category"] = category
+        if include_domains:
+            search_kwargs["include_domains"] = include_domains
+        if exclude_domains:
+            search_kwargs["exclude_domains"] = exclude_domains
+        if include_text:
+            search_kwargs["include_text"] = include_text
+        if exclude_text:
+            search_kwargs["exclude_text"] = exclude_text
+        if start_published_date:
+            search_kwargs["start_published_date"] = start_published_date
+        if end_published_date:
+            search_kwargs["end_published_date"] = end_published_date
+
+        response = client.search(**search_kwargs)
+
+        results = []
+        for result in response.results:
+            title = getattr(result, "title", None) or ""
+            url = getattr(result, "url", None) or ""
+            published_date = getattr(result, "published_date", None)
+            author = getattr(result, "author", None)
+
+            # Build content snippet from highlights and summary
+            highlights = getattr(result, "highlights", None) or []
+            summary = getattr(result, "summary", None) or ""
+            text = getattr(result, "text", None) or ""
+
+            if highlights:
+                snippet = "\n".join(highlights)
+            elif summary:
+                snippet = summary
+            elif text:
+                snippet = text[:2000]
+            else:
+                snippet = ""
+
+            results.append(
+                ExaSearchResult(
+                    title=title,
+                    url=url,
+                    snippet=snippet,
+                    published_date=published_date,
+                    author=author,
+                )
+            )
+
+        return results
+
+    except Exception as e:
+        logger.warning("Exa search failed for query '%s': %s", query, e)
+        return []

--- a/src/utils/analysts.py
+++ b/src/utils/analysts.py
@@ -3,6 +3,7 @@
 from src.agents import portfolio_manager
 from src.agents.aswath_damodaran import aswath_damodaran_agent
 from src.agents.ben_graham import ben_graham_agent
+from src.agents.exa_news import exa_news_agent
 from src.agents.bill_ackman import bill_ackman_agent
 from src.agents.cathie_wood import cathie_wood_agent
 from src.agents.charlie_munger import charlie_munger_agent
@@ -174,6 +175,14 @@ ANALYST_CONFIG = {
         "agent_func": valuation_analyst_agent,
         "type": "analyst",
         "order": 18,
+    },
+    "exa_news_analyst": {
+        "display_name": "Exa Web Search Analyst",
+        "description": "AI-Powered Web Sentiment Specialist",
+        "investing_style": "Uses Exa AI-powered web search to find and analyze recent news, articles, and commentary about stocks, extracting market sentiment from web content.",
+        "agent_func": exa_news_agent,
+        "type": "analyst",
+        "order": 19,
     },
 }
 

--- a/tests/test_exa_search.py
+++ b/tests/test_exa_search.py
@@ -1,0 +1,324 @@
+import os
+import pytest
+from unittest.mock import Mock, patch
+
+from src.tools.exa_search import search_exa
+from src.data.models import ExaSearchResult
+
+
+class TestSearchExa:
+    """Test suite for the Exa search tool."""
+
+    def _make_mock_result(self, title="Test Article", url="https://example.com",
+                          highlights=None, summary=None, text=None,
+                          published_date=None, author=None):
+        """Helper to create a mock Exa result object."""
+        result = Mock()
+        result.title = title
+        result.url = url
+        result.highlights = highlights
+        result.summary = summary
+        result.text = text
+        result.published_date = published_date
+        result.author = author
+        return result
+
+    def test_returns_empty_when_no_api_key(self):
+        """Test that search returns empty list when EXA_API_KEY is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            results = search_exa("test query")
+            assert results == []
+
+    @patch("src.tools.exa_search.Exa", None)
+    def test_returns_empty_when_exa_not_installed(self):
+        """Test that search returns empty list when exa-py is not installed."""
+        results = search_exa("test query", api_key="test-key")
+        assert results == []
+
+    @patch("src.tools.exa_search.Exa")
+    def test_successful_search_with_highlights(self, mock_exa_cls):
+        """Test successful search returns parsed results using highlights."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = [
+            self._make_mock_result(
+                title="AAPL Earnings Beat",
+                url="https://news.com/aapl",
+                highlights=["Apple reported record Q4 earnings.", "Revenue up 15% YoY."],
+                summary="Apple had a strong quarter.",
+                published_date="2024-03-15",
+                author="John Doe",
+            )
+        ]
+        mock_client.search.return_value = mock_response
+
+        results = search_exa("AAPL stock news", api_key="test-key")
+
+        assert len(results) == 1
+        assert isinstance(results[0], ExaSearchResult)
+        assert results[0].title == "AAPL Earnings Beat"
+        assert results[0].url == "https://news.com/aapl"
+        assert "Apple reported record Q4 earnings." in results[0].snippet
+        assert "Revenue up 15% YoY." in results[0].snippet
+        assert results[0].published_date == "2024-03-15"
+        assert results[0].author == "John Doe"
+
+    @patch("src.tools.exa_search.Exa")
+    def test_fallback_to_summary_when_no_highlights(self, mock_exa_cls):
+        """Test that snippet falls back to summary when highlights are empty."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = [
+            self._make_mock_result(
+                title="Market Update",
+                url="https://news.com/market",
+                highlights=[],
+                summary="Markets rallied on strong jobs data.",
+            )
+        ]
+        mock_client.search.return_value = mock_response
+
+        results = search_exa("market news", api_key="test-key")
+
+        assert len(results) == 1
+        assert results[0].snippet == "Markets rallied on strong jobs data."
+
+    @patch("src.tools.exa_search.Exa")
+    def test_fallback_to_text_when_no_highlights_or_summary(self, mock_exa_cls):
+        """Test that snippet falls back to text when both highlights and summary are missing."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = [
+            self._make_mock_result(
+                title="Analysis",
+                url="https://blog.com/analysis",
+                highlights=None,
+                summary=None,
+                text="Full article text here about stock performance.",
+            )
+        ]
+        mock_client.search.return_value = mock_response
+
+        results = search_exa("stock analysis", api_key="test-key")
+
+        assert len(results) == 1
+        assert results[0].snippet == "Full article text here about stock performance."
+
+    @patch("src.tools.exa_search.Exa")
+    def test_empty_snippet_when_no_content(self, mock_exa_cls):
+        """Test that snippet is empty when no content fields are available."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = [
+            self._make_mock_result(
+                title="Minimal Result",
+                url="https://example.com",
+            )
+        ]
+        mock_client.search.return_value = mock_response
+
+        results = search_exa("query", api_key="test-key")
+
+        assert len(results) == 1
+        assert results[0].snippet == ""
+
+    @patch("src.tools.exa_search.Exa")
+    def test_passes_search_parameters_correctly(self, mock_exa_cls):
+        """Test that all search parameters are passed to the Exa client."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = []
+        mock_client.search.return_value = mock_response
+
+        search_exa(
+            query="TSLA stock",
+            num_results=5,
+            search_type="neural",
+            category="news",
+            include_domains=["reuters.com"],
+            exclude_domains=["reddit.com"],
+            include_text=["Tesla"],
+            exclude_text=["crypto"],
+            start_published_date="2024-01-01T00:00:00.000Z",
+            end_published_date="2024-03-01T00:00:00.000Z",
+            api_key="test-key",
+        )
+
+        mock_client.search.assert_called_once()
+        call_kwargs = mock_client.search.call_args[1]
+        assert call_kwargs["query"] == "TSLA stock"
+        assert call_kwargs["num_results"] == 5
+        assert call_kwargs["type"] == "neural"
+        assert call_kwargs["category"] == "news"
+        assert call_kwargs["include_domains"] == ["reuters.com"]
+        assert call_kwargs["exclude_domains"] == ["reddit.com"]
+        assert call_kwargs["include_text"] == ["Tesla"]
+        assert call_kwargs["exclude_text"] == ["crypto"]
+        assert call_kwargs["start_published_date"] == "2024-01-01T00:00:00.000Z"
+        assert call_kwargs["end_published_date"] == "2024-03-01T00:00:00.000Z"
+
+    @patch("src.tools.exa_search.Exa")
+    def test_requests_highlights_and_summary_content(self, mock_exa_cls):
+        """Test that search requests both highlights and summary content types."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = []
+        mock_client.search.return_value = mock_response
+
+        search_exa("test", api_key="test-key")
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert "contents" in call_kwargs
+        assert "highlights" in call_kwargs["contents"]
+        assert "summary" in call_kwargs["contents"]
+        assert call_kwargs["contents"]["highlights"]["max_characters"] == 4000
+        assert call_kwargs["contents"]["summary"] is True
+
+    @patch("src.tools.exa_search.Exa")
+    def test_sets_integration_tracking_header(self, mock_exa_cls):
+        """Test that the x-exa-integration header is set on the client."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = []
+        mock_client.search.return_value = mock_response
+
+        search_exa("test", api_key="test-key")
+
+        assert mock_client.headers["x-exa-integration"] == "ai-hedge-fund"
+
+    @patch("src.tools.exa_search.Exa")
+    def test_handles_api_error_gracefully(self, mock_exa_cls):
+        """Test that API errors are caught and return empty list."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+        mock_client.search.side_effect = Exception("API Error: rate limit exceeded")
+
+        results = search_exa("test query", api_key="test-key")
+
+        assert results == []
+
+    @patch("src.tools.exa_search.Exa")
+    def test_multiple_results_parsed(self, mock_exa_cls):
+        """Test that multiple search results are all parsed correctly."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = [
+            self._make_mock_result(title="Article 1", url="https://a.com", highlights=["Content 1"]),
+            self._make_mock_result(title="Article 2", url="https://b.com", summary="Summary 2"),
+            self._make_mock_result(title="Article 3", url="https://c.com", text="Text 3"),
+        ]
+        mock_client.search.return_value = mock_response
+
+        results = search_exa("multi query", api_key="test-key")
+
+        assert len(results) == 3
+        assert results[0].title == "Article 1"
+        assert results[0].snippet == "Content 1"
+        assert results[1].title == "Article 2"
+        assert results[1].snippet == "Summary 2"
+        assert results[2].title == "Article 3"
+        assert results[2].snippet == "Text 3"
+
+    @patch("src.tools.exa_search.Exa")
+    def test_handles_none_fields_gracefully(self, mock_exa_cls):
+        """Test that None values in result fields don't cause errors."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        result = Mock()
+        result.title = None
+        result.url = None
+        result.highlights = None
+        result.summary = None
+        result.text = None
+        result.published_date = None
+        result.author = None
+
+        mock_response = Mock()
+        mock_response.results = [result]
+        mock_client.search.return_value = mock_response
+
+        results = search_exa("test", api_key="test-key")
+
+        assert len(results) == 1
+        assert results[0].title == ""
+        assert results[0].url == ""
+        assert results[0].snippet == ""
+        assert results[0].published_date is None
+        assert results[0].author is None
+
+    @patch("src.tools.exa_search.Exa")
+    def test_optional_params_not_sent_when_none(self, mock_exa_cls):
+        """Test that optional parameters are omitted when not provided."""
+        mock_client = Mock()
+        mock_client.headers = {}
+        mock_exa_cls.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.results = []
+        mock_client.search.return_value = mock_response
+
+        search_exa("simple query", api_key="test-key")
+
+        call_kwargs = mock_client.search.call_args[1]
+        assert "category" not in call_kwargs
+        assert "include_domains" not in call_kwargs
+        assert "exclude_domains" not in call_kwargs
+        assert "include_text" not in call_kwargs
+        assert "exclude_text" not in call_kwargs
+        assert "start_published_date" not in call_kwargs
+        assert "end_published_date" not in call_kwargs
+
+
+class TestExaSearchResultModel:
+    """Test the ExaSearchResult Pydantic model."""
+
+    def test_creates_valid_result(self):
+        result = ExaSearchResult(
+            title="Test",
+            url="https://example.com",
+            snippet="Content here",
+            published_date="2024-01-01",
+            author="Author",
+        )
+        assert result.title == "Test"
+        assert result.url == "https://example.com"
+
+    def test_optional_fields_default_to_none(self):
+        result = ExaSearchResult(
+            title="Test",
+            url="https://example.com",
+            snippet="Content",
+        )
+        assert result.published_date is None
+        assert result.author is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

- Adds a new **Exa Web Search Analyst** agent that uses [Exa's](https://exa.ai) AI-powered search to find and analyze recent news, articles, and commentary about stocks
- The agent searches for web content per ticker, retrieves article highlights/summaries via Exa, and uses the configured LLM to assess sentiment and produce a bullish/bearish/neutral trading signal
- Includes a standalone `search_exa()` tool function with content fallback logic (highlights -> summary -> text), tracking header (`x-exa-integration: ai-hedge-fund`), and graceful error handling

## Usage

1. Set `EXA_API_KEY` in your `.env` file (get a key from https://exa.ai)
2. Select the **Exa Web Search Analyst** when choosing analysts
3. The agent will search the web for recent news and analysis about each ticker and contribute a sentiment signal to the ensemble

```python
# The agent works like any other analyst in the system:
from src.agents.exa_news import exa_news_agent

# It's registered in ANALYST_CONFIG as "exa_news_analyst"
# and automatically available in the CLI and web UI
```

## Files Changed

| File | Change |
|------|--------|
| `src/tools/exa_search.py` | **New** — Exa search wrapper with highlights/summary/text fallback |
| `src/agents/exa_news.py` | **New** — Web sentiment analyst agent |
| `tests/test_exa_search.py` | **New** — 15 unit tests for search tool |
| `src/data/models.py` | Added `ExaSearchResult` Pydantic model |
| `src/utils/analysts.py` | Registered `exa_news_analyst` in `ANALYST_CONFIG` |
| `pyproject.toml` | Added `exa-py>=2.0.0` dependency |
| `.env.example` | Added `EXA_API_KEY` entry |

## Test Plan

- [x] API response parsing with highlights, summary, and text content
- [x] Content/snippet fallback logic (highlights missing, summary missing, all missing)
- [x] Empty results when `EXA_API_KEY` is unset
- [x] Empty results when `exa-py` is not installed
- [x] All search parameters passed correctly to Exa client
- [x] Integration tracking header set on client
- [x] API errors handled gracefully (returns empty list)
- [x] Multiple results parsed correctly
- [x] None/missing fields handled without errors
- [x] All 15 new tests pass; all 19 existing tests still pass