### PR TITLE
fix: prefetch full backtest date range, not just end_date minus 1yr

### DIFF
--- a/src/backtesting/engine.py
+++ b/src/backtesting/engine.py
@@ -80,8 +80,12 @@ class BacktestEngine:
 
     def _prefetch_data(self) -> None:
         end_date_dt = datetime.strptime(self._end_date, "%Y-%m-%d")
-        start_date_dt = end_date_dt - relativedelta(years=1)
-        start_date_str = start_date_dt.strftime("%Y-%m-%d")
+        one_year_ago = (end_date_dt - relativedelta(years=1)).strftime("%Y-%m-%d")
+        # Use whichever date is earlier so the prefetch covers the full backtest window.
+        # Without this, backtests longer than 1 year silently bypass the cache for
+        # dates before (end_date - 1yr), causing uncached API calls on every loop
+        # iteration for those trading days. (Fixes #572)
+        start_date_str = min(self._start_date, one_year_ago)
 
         for ticker in self._tickers:
             get_prices(ticker, start_date_str, self._end_date)


### PR DESCRIPTION
Closes #572

## Problem

`BacktestEngine._prefetch_data()` always prefetches price data starting from `end_date - 1 year`, ignoring `self._start_date`. For any backtest spanning more than one year the cache is never populated for the early trading days, so every call to `get_price_data()` inside the hot `run_backtest` loop for those days hits the API uncached — causing rate-limit errors, slowdowns, and potential data gaps.

## Fix

Compute `one_year_ago = end_date - 1yr` as before (needed for analyst look-back data), then use `min(self._start_date, one_year_ago)` as the actual prefetch start date. This ensures that:

1. The full backtest price window is always warmed into the cache.
2. Analyst look-back data still reaches back at least 1 year from `end_date`.
3. SPY benchmark data is already fetched from `self._start_date` (unchanged).

## Changed file
- `src/backtesting/engine.py` — `BacktestEngine._prefetch_data`

## Testing
Run a backtest with `start_date` more than 1 year before `end_date` (e.g. 2020-01-01 to 2024-12-31) and verify no uncached API calls are made for the early dates.