### PR TITLE
feat(llm): add Moonshot Kimi as a model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ GOOGLE_API_KEY=your-google-api-key
 # For running LLMs hosted by xAI (Grok 4, etc.)
 XAI_API_KEY=your-xai-api-key
 
+# For running LLMs hosted by Moonshot / Kimi (kimi-k2, kimi-latest, moonshot-v1-*)
+# Get your Moonshot API key from https://platform.moonshot.ai/
+# Mainland China users: set MOONSHOT_BASE_URL=https://api.moonshot.cn/v1
+MOONSHOT_API_KEY=your-moonshot-api-key
+
 # For running LLM GigaChat
 GIGACHAT_API_KEY=your-gigachat-api-key
 

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -60,6 +60,13 @@ const LLM_API_KEYS: ApiKey[] = [
     placeholder: 'your-openai-api-key'
   },
   {
+    key: 'MOONSHOT_API_KEY',
+    label: 'Moonshot (Kimi) API',
+    description: 'For Kimi / Moonshot models (kimi-k2, kimi-latest, moonshot-v1-*)',
+    url: 'https://platform.moonshot.ai/',
+    placeholder: 'your-moonshot-api-key'
+  },
+  {
     key: 'OPENROUTER_API_KEY',
     label: 'OpenRouter API',
     description: 'For OpenRouter models (gpt-4o, gpt-4o-mini, etc.)',

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -40,6 +40,21 @@
     "provider": "DeepSeek"
   },
   {
+    "display_name": "Kimi K2",
+    "model_name": "kimi-k2-0905-preview",
+    "provider": "Kimi"
+  },
+  {
+    "display_name": "Kimi Latest (128k)",
+    "model_name": "kimi-latest",
+    "provider": "Kimi"
+  },
+  {
+    "display_name": "Moonshot v1 128k",
+    "model_name": "moonshot-v1-128k",
+    "provider": "Kimi"
+  },
+  {
     "display_name": "Gemini 3 Pro",
     "model_name": "gemini-3-pro-preview",
     "provider": "Google"

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -22,6 +22,7 @@ class ModelProvider(str, Enum):
     DEEPSEEK = "DeepSeek"
     GOOGLE = "Google"
     GROQ = "Groq"
+    KIMI = "Kimi"
     META = "Meta"
     MISTRAL = "Mistral"
     OPENAI = "OpenAI"
@@ -62,6 +63,10 @@ class LLMModel(BaseModel):
     def is_deepseek(self) -> bool:
         """Check if the model is a DeepSeek model"""
         return self.model_name.startswith("deepseek")
+
+    def is_kimi(self) -> bool:
+        """Check if the model is a Kimi (Moonshot) model"""
+        return self.provider == ModelProvider.KIMI
 
     def is_gemini(self) -> bool:
         """Check if the model is a Gemini model"""
@@ -199,6 +204,16 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
                 }
             }
         )
+    elif model_provider == ModelProvider.KIMI:
+        api_key = (api_keys or {}).get("MOONSHOT_API_KEY") or os.getenv("MOONSHOT_API_KEY") \
+            or (api_keys or {}).get("KIMI_API_KEY") or os.getenv("KIMI_API_KEY")
+        if not api_key:
+            print(f"API Key Error: Please make sure MOONSHOT_API_KEY (or KIMI_API_KEY) is set in your .env file or provided via API keys.")
+            raise ValueError("Kimi API key not found. Please make sure MOONSHOT_API_KEY (or KIMI_API_KEY) is set in your .env file or provided via API keys.")
+        # Kimi exposes an OpenAI-compatible endpoint. Default to the international host;
+        # users in mainland China can override via MOONSHOT_BASE_URL=https://api.moonshot.cn/v1.
+        base_url = os.getenv("MOONSHOT_BASE_URL") or os.getenv("KIMI_BASE_URL") or "https://api.moonshot.ai/v1"
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)
     elif model_provider == ModelProvider.XAI:
         api_key = (api_keys or {}).get("XAI_API_KEY") or os.getenv("XAI_API_KEY")
         if not api_key:


### PR DESCRIPTION
## Summary
Adds Kimi (Moonshot) as a first-class LLM provider so users can run the hedge fund on `kimi-k2-0905-preview`, `kimi-latest`, and `moonshot-v1-128k` without routing through OpenRouter.

Kimi exposes an OpenAI-compatible endpoint, so the new branch in `get_model()` reuses `ChatOpenAI` with a base URL override.

Closes #578.

## Changes
- `src/llm/models.py`
  - `ModelProvider.KIMI`
  - `LLMModel.is_kimi()`
  - `get_model()` branch: `ChatOpenAI(model=..., api_key=..., base_url=...)`
    - Key: `MOONSHOT_API_KEY` or `KIMI_API_KEY`
    - Base URL: `MOONSHOT_BASE_URL` / `KIMI_BASE_URL` override, default `https://api.moonshot.ai/v1`. Mainland China users can set `https://api.moonshot.cn/v1`.
- `src/llm/api_models.json` — 3 new entries under provider `"Kimi"`.
- `.env.example` — adds `MOONSHOT_API_KEY` with a link to the console.
- `app/frontend/src/components/settings/api-keys.tsx` — new card entry so users can paste the key in-app.

## Test plan
- [x] `ModelProvider.KIMI.value == "Kimi"`
- [x] `api_models.json` still parses and the three Kimi models load into `AVAILABLE_MODELS` with `is_kimi() == True`
- [ ] Live smoke with a real `MOONSHOT_API_KEY` (did not run — no key available in my sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)