### PR TITLE
docs: add Community Tools section with market-sages

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ Please see detailed instructions on how to install and run the web application [
 
 If you have a feature request, please open an [issue](https://github.com/virattt/ai-hedge-fund/issues) and make sure it is tagged with `enhancement`.
 
+## Community Tools
+
+Projects built by the community on top of ai-hedge-fund:
+
+- **[market-sages](https://github.com/hyhmrright/market-sages)** — A Claude Code skill that summons 13 legendary investors (Buffett, Munger, Graham, Burry, Taleb, and more) to analyze any stock, directly inside your terminal. Works with Claude Code, Gemini CLI, and Codex CLI. Real-time data via web search. No API keys, no setup — just `/sages AAPL`.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.


### PR DESCRIPTION
## Summary

Adds a new **Community Tools** section to the README, positioned before the License section. This section is a place for community-built projects that extend or complement ai-hedge-fund.

The first entry is [market-sages](https://github.com/hyhmrright/market-sages) — a CLI skill I built on top of this project. It brings a similar multi-analyst philosophy directly into the terminal via Claude Code (and also supports Gemini CLI and Codex CLI):

- 13 legendary investor personas: Buffett, Munger, Graham, Burry, Taleb, Damodaran, Lynch, Ackman, and more
- Real-time data fetched via web search before each analysis
- Responds in the user's language automatically
- Zero setup: no API keys, no Python environment — just install the skill and run `/sages AAPL`

## Why this section?

ai-hedge-fund has a strong community (54k+ stars, 9.5k forks). A "Community Tools" section gives a lightweight, low-maintenance way to surface useful projects without cluttering the main docs. Happy to remove or restructure if this doesn't fit the project's direction.