### PR TITLE
fix: refresh Ollama models in portfolio manager after server start or download

### DIFF
--- a/app/frontend/src/components/settings/models/ollama.tsx
+++ b/app/frontend/src/components/settings/models/ollama.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { clearModelsCache } from '@/data/models';
 import { cn } from '@/lib/utils';
 import { AlertTriangle, Brain, CheckCircle, Download, Play, RefreshCw, Server, Square, Trash2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -102,6 +103,8 @@ export function OllamaSettings() {
       });
       if (response.ok) {
         await fetchOllamaStatus();
+        // Invalidate the models cache so the portfolio manager picks up Ollama models
+        clearModelsCache();
       } else {
         const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
         setError(`Failed to start server: ${errorData.detail}`);
@@ -200,6 +203,8 @@ export function OllamaSettings() {
                         delete newProgress[modelName];
                         return newProgress;
                       });
+                      // Invalidate the models cache so the portfolio manager discovers the new model
+                      clearModelsCache();
                       // Refresh status to show the new model with retry logic
                       const refreshWithRetry = async (attempts = 0) => {
                         try {
@@ -436,6 +441,8 @@ export function OllamaSettings() {
                 delete newProgress[modelName];
                 return newProgress;
               });
+              // Invalidate the models cache so the portfolio manager discovers the new model
+              clearModelsCache();
               // Refresh status to show the new model with retry logic
               const refreshWithRetry = async (attempts = 0) => {
                 try {
@@ -444,7 +451,7 @@ export function OllamaSettings() {
                     const status = await response.json();
                     setOllamaStatus(status);
                     setError(null);
-                    
+
                     // Check if the model is now in the available models list
                     if (attempts < 5 && status && !status.available_models.includes(modelName)) {
                       // Wait a bit longer and try again

--- a/app/frontend/src/data/models.ts
+++ b/app/frontend/src/data/models.ts
@@ -3,11 +3,22 @@ import { api } from '@/services/api';
 export interface LanguageModel {
   display_name: string;
   model_name: string;
-  provider: "Anthropic" | "DeepSeek" | "Google" | "Groq" | "OpenAI";
+  provider: "Anthropic" | "DeepSeek" | "Google" | "Groq" | "Ollama" | "OpenAI";
 }
 
 // Cache for models to avoid repeated API calls
 let languageModels: LanguageModel[] | null = null;
+
+/**
+ * Clear the models cache so the next call to getModels() fetches fresh data.
+ * Also dispatches a "models-updated" event so mounted components can reload.
+ * Call this after Ollama is started or a new Ollama model is downloaded so
+ * the portfolio manager model selector reflects the updated list.
+ */
+export const clearModelsCache = (): void => {
+  languageModels = null;
+  window.dispatchEvent(new CustomEvent('models-updated'));
+};
 
 /**
  * Get the list of models from the backend API
@@ -17,7 +28,7 @@ export const getModels = async (): Promise<LanguageModel[]> => {
   if (languageModels) {
     return languageModels;
   }
-  
+
   try {
     languageModels = await api.getLanguageModels();
     return languageModels;

--- a/app/frontend/src/nodes/components/portfolio-manager-node.tsx
+++ b/app/frontend/src/nodes/components/portfolio-manager-node.tsx
@@ -59,7 +59,7 @@ export function PortfolioManagerNode({
           getDefaultModel()
         ]);
         setAvailableModels(models);
-        
+
         // Set default model if no model is currently selected
         if (!selectedModel && defaultModel) {
           setSelectedModel(defaultModel);
@@ -71,6 +71,11 @@ export function PortfolioManagerNode({
     };
 
     loadModels();
+
+    // Re-fetch models whenever Ollama is started or a model is downloaded
+    // so newly available Ollama models appear in the selector immediately.
+    window.addEventListener('models-updated', loadModels);
+    return () => window.removeEventListener('models-updated', loadModels);
   }, [setAvailableModels, selectedModel, setSelectedModel]);
 
   // Update the node context when the model changes


### PR DESCRIPTION
Fixes #570

## Problem

When the app loads before Ollama is running (or before any Ollama model is downloaded), `getModels()` caches only cloud models. Even after the user starts the Ollama server or downloads a model through the Settings page, the portfolio manager's model selector stays empty for Ollama — because the module-level cache is never invalidated and the component never re-fetches.

Additionally, `LanguageModel.provider` was typed as `"Anthropic" | "DeepSeek" | "Google" | "Groq" | "OpenAI"`, omitting `"Ollama"`, which caused `as any` casts to be required when passing the provider to the backend.

## Solution

1. **`app/frontend/src/data/models.ts`**
   - Add `"Ollama"` to the `LanguageModel.provider` union type so it matches what the backend actually returns.
   - Export `clearModelsCache()`, which resets the module-level cache **and** dispatches a `"models-updated"` custom DOM event so mounted components can react immediately.

2. **`app/frontend/src/components/settings/models/ollama.tsx`**
   - Import and call `clearModelsCache()` after the Ollama server starts successfully.
   - Call `clearModelsCache()` when a model download completes (both in the streaming download path and in the reconnect/polling path).

3. **`app/frontend/src/nodes/components/portfolio-manager-node.tsx`**
   - Listen for the `"models-updated"` event inside the existing `useEffect` and re-invoke `loadModels()` immediately, so Ollama models appear in the selector without a page reload.

## Testing

1. Open the app with Ollama not running — portfolio manager shows only cloud models.
2. Go to Settings → Ollama → Start Server → download a model.
3. Return to the canvas — the portfolio manager model selector now includes the newly downloaded Ollama model without refreshing the page.