### PR TITLE
feat(consensus): add pure aggregation layer for analyst signals (#586, phase 1)

### DIFF
--- a/src/consensus/__init__.py
+++ b/src/consensus/__init__.py
@@ -1,0 +1,20 @@
+"""Consensus layer — aggregate analyst signals into a single decision.
+
+Phase 1 exposes pure aggregation math with no LLM calls. See
+``src/consensus/aggregation.py`` for the entry point ``aggregate_signals``.
+"""
+
+from src.consensus.aggregation import (
+    Strategy,
+    aggregate_signals,
+    compute_agreement,
+)
+from src.consensus.models import AgentContribution, ConsensusSignal
+
+__all__ = [
+    "AgentContribution",
+    "ConsensusSignal",
+    "Strategy",
+    "aggregate_signals",
+    "compute_agreement",
+]

--- a/src/consensus/aggregation.py
+++ b/src/consensus/aggregation.py
@@ -1,0 +1,202 @@
+"""Pure aggregation math for the consensus layer — no LLM, no state.
+
+``aggregate_signals`` takes a dict of ``{agent_name: {"signal", "confidence"}}``
+for a single ticker and returns a ``ConsensusSignal`` with a composite score,
+aggregate confidence, and an agreement measure.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing_extensions import Literal
+
+from src.consensus.models import AgentContribution, ConsensusSignal
+
+logger = logging.getLogger(__name__)
+
+_SIGNAL_TO_SIGN: dict[str, int] = {"bullish": 1, "bearish": -1, "neutral": 0}
+_VALID_SIGNALS = frozenset(_SIGNAL_TO_SIGN.keys())
+
+Strategy = Literal["weighted", "majority", "mean"]
+
+
+def compute_agreement(weight_by_camp: dict[str, float]) -> float:
+    """Return the share of total weight held by the largest camp, in [0, 1].
+
+    Unanimous → 1.0; perfect 2-way split → 0.5; perfect 3-way split → ~0.333.
+    Returns 0.0 when no weight is present.
+    """
+    total = sum(weight_by_camp.values())
+    if total <= 0.0:
+        return 0.0
+    return max(weight_by_camp.values()) / total
+
+
+def aggregate_signals(
+    ticker_signals: dict[str, dict],
+    *,
+    weights: dict[str, float] | None = None,
+    strategy: Strategy = "weighted",
+    neutral_deadband: float = 0.15,
+) -> ConsensusSignal:
+    """Combine per-agent signals for one ticker into a single ``ConsensusSignal``.
+
+    Args:
+        ticker_signals: ``{agent_name: {"signal": "bullish"|"bearish"|"neutral",
+            "confidence": 0-100}}``. Entries with missing or invalid signals are
+            silently skipped.
+        weights: optional ``{agent_name: weight}`` overrides. Missing agents
+            default to ``1.0``. Negative weights are clamped to ``0.0``.
+        strategy: ``"weighted"`` (default) scales by ``weight * confidence``;
+            ``"majority"`` ignores confidence; ``"mean"`` ignores custom weights.
+        neutral_deadband: ``|score|`` below this threshold maps to ``"neutral"``.
+    """
+
+    entries = _normalise_inputs(ticker_signals, weights, strategy)
+    if not entries:
+        return _empty_consensus()
+
+    contributions: dict[str, AgentContribution] = {}
+    vote_counts = {"bullish": 0, "bearish": 0, "neutral": 0}
+    weight_by_camp = {"bullish": 0.0, "bearish": 0.0, "neutral": 0.0}
+    score_numerator = 0.0
+    weight_sum = 0.0
+    conf_weighted_sum = 0.0
+
+    for agent, signal, confidence, weight in entries:
+        sign = _SIGNAL_TO_SIGN[signal]
+        conf_frac = 1.0 if strategy == "majority" else confidence / 100.0
+        contribution = sign * weight * conf_frac
+
+        contributions[agent] = AgentContribution(
+            signal=signal,
+            confidence=confidence,
+            weight=weight,
+            contribution=contribution,
+        )
+        vote_counts[signal] += 1
+        weight_by_camp[signal] += weight
+        score_numerator += contribution
+        weight_sum += weight
+        conf_weighted_sum += weight * confidence
+
+    if weight_sum <= 0.0:
+        score = 0.0
+        weighted_mean_conf = 0.0
+    else:
+        score = score_numerator / weight_sum
+        weighted_mean_conf = conf_weighted_sum / weight_sum
+
+    # Clamp against floating point drift
+    score = max(-1.0, min(1.0, score))
+
+    agreement = compute_agreement(weight_by_camp)
+    aggregate_confidence = agreement * weighted_mean_conf
+
+    discrete = _apply_deadband(score, neutral_deadband)
+    reasoning = _build_reasoning(discrete, score, agreement, vote_counts, contributions)
+
+    return ConsensusSignal(
+        signal=discrete,
+        score=score,
+        confidence=aggregate_confidence,
+        agreement=agreement,
+        vote_breakdown=vote_counts,
+        contributions=contributions,
+        reasoning=reasoning,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _normalise_inputs(
+    ticker_signals: dict[str, dict],
+    weights: dict[str, float] | None,
+    strategy: Strategy,
+) -> list[tuple[str, str, float, float]]:
+    """Filter and coerce raw signal dicts into ``(agent, signal, conf, weight)``."""
+    weights = weights or {}
+    out: list[tuple[str, str, float, float]] = []
+
+    for agent, payload in ticker_signals.items():
+        if not isinstance(payload, dict):
+            continue
+        signal = payload.get("signal")
+        if signal not in _VALID_SIGNALS:
+            logger.debug("consensus: skipping %s — invalid signal %r", agent, signal)
+            continue
+
+        confidence = _coerce_confidence(payload.get("confidence"))
+
+        if strategy == "mean":
+            weight = 1.0
+        else:
+            raw_weight = weights.get(agent, 1.0)
+            try:
+                weight = float(raw_weight)
+            except (TypeError, ValueError):
+                weight = 1.0
+            if weight < 0.0:
+                weight = 0.0
+
+        out.append((agent, signal, confidence, weight))
+
+    return out
+
+
+def _coerce_confidence(value) -> float:
+    """Clamp confidence into [0, 100]. Bad values become 0.0."""
+    try:
+        conf = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if conf != conf:  # NaN check without importing math
+        return 0.0
+    if conf < 0.0:
+        return 0.0
+    if conf > 100.0:
+        return 100.0
+    return conf
+
+
+def _apply_deadband(score: float, deadband: float) -> str:
+    if abs(score) < deadband:
+        return "neutral"
+    return "bullish" if score > 0.0 else "bearish"
+
+
+def _empty_consensus() -> ConsensusSignal:
+    return ConsensusSignal(
+        signal="neutral",
+        score=0.0,
+        confidence=0.0,
+        agreement=0.0,
+        vote_breakdown={"bullish": 0, "bearish": 0, "neutral": 0},
+        contributions={},
+        reasoning="No valid analyst signals",
+    )
+
+
+def _build_reasoning(
+    discrete: str,
+    score: float,
+    agreement: float,
+    vote_counts: dict[str, int],
+    contributions: dict[str, AgentContribution],
+) -> str:
+    top = sorted(
+        contributions.items(),
+        key=lambda item: abs(item[1].contribution),
+        reverse=True,
+    )[:3]
+    top_str = ", ".join(f"{agent} ({c.contribution:+.2f})" for agent, c in top)
+    return (
+        f"{discrete} (score={score:+.2f}, agreement={agreement:.2f}); "
+        f"bull/bear/neut = "
+        f"{vote_counts['bullish']}/{vote_counts['bearish']}/{vote_counts['neutral']}; "
+        f"top: {top_str}"
+    )

--- a/src/consensus/models.py
+++ b/src/consensus/models.py
@@ -1,0 +1,42 @@
+"""Pydantic models for the consensus layer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+from typing_extensions import Literal
+
+
+class AgentContribution(BaseModel):
+    """How a single agent influenced the consensus for one ticker."""
+
+    signal: Literal["bullish", "bearish", "neutral"]
+    confidence: float = Field(description="Reported confidence 0-100")
+    weight: float = Field(description="Voting weight assigned to this agent")
+    contribution: float = Field(
+        description="Signed contribution to the composite score, same scale as score"
+    )
+
+
+class ConsensusSignal(BaseModel):
+    """Aggregated analyst signal for a single ticker on a single date."""
+
+    signal: Literal["bullish", "bearish", "neutral"]
+    score: float = Field(description="Weighted composite in [-1.0, +1.0]")
+    confidence: float = Field(
+        description="Aggregate confidence 0-100; degraded by disagreement"
+    )
+    agreement: float = Field(
+        description="Share of total weight in the dominant vote camp, in [0.0, 1.0]"
+    )
+    vote_breakdown: dict[str, int] = Field(
+        default_factory=lambda: {"bullish": 0, "bearish": 0, "neutral": 0},
+        description="Raw vote counts keyed by 'bullish' / 'bearish' / 'neutral'",
+    )
+    contributions: dict[str, AgentContribution] = Field(default_factory=dict)
+    arbitration: dict[str, Any] | None = Field(
+        default=None,
+        description="Populated by the optional LLM arbiter in Phase 4",
+    )
+    reasoning: str = ""

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,0 +1,284 @@
+import pytest
+
+from src.consensus import (
+    AgentContribution,
+    ConsensusSignal,
+    aggregate_signals,
+    compute_agreement,
+)
+
+
+def _sig(signal: str, confidence: float) -> dict:
+    return {"signal": signal, "confidence": confidence}
+
+
+class TestComputeAgreement:
+    def test_unanimous_returns_one(self):
+        assert compute_agreement({"bullish": 5.0, "bearish": 0.0, "neutral": 0.0}) == 1.0
+
+    def test_perfect_two_way_split_returns_half(self):
+        assert compute_agreement({"bullish": 3.0, "bearish": 3.0, "neutral": 0.0}) == 0.5
+
+    def test_three_way_split_returns_third(self):
+        assert compute_agreement({"bullish": 1.0, "bearish": 1.0, "neutral": 1.0}) == pytest.approx(1.0 / 3.0)
+
+    def test_empty_returns_zero(self):
+        assert compute_agreement({"bullish": 0.0, "bearish": 0.0, "neutral": 0.0}) == 0.0
+
+    def test_weighted_majority(self):
+        # 1 bullish with weight 10 beats 3 bearish with weight 1 each
+        assert compute_agreement({"bullish": 10.0, "bearish": 3.0, "neutral": 0.0}) == pytest.approx(10.0 / 13.0)
+
+
+class TestAggregateSignalsHappyPath:
+    def test_unanimous_bullish_high_conf(self):
+        signals = {
+            "warren_buffett_agent": _sig("bullish", 80),
+            "ben_graham_agent": _sig("bullish", 80),
+            "aswath_damodaran_agent": _sig("bullish", 80),
+        }
+        result = aggregate_signals(signals)
+        assert result.signal == "bullish"
+        assert result.score == pytest.approx(0.8)
+        assert result.agreement == 1.0
+        assert result.confidence == pytest.approx(80.0)
+        assert result.vote_breakdown == {"bullish": 3, "bearish": 0, "neutral": 0}
+
+    def test_unanimous_bearish_high_conf(self):
+        signals = {
+            "a": _sig("bearish", 90),
+            "b": _sig("bearish", 90),
+        }
+        result = aggregate_signals(signals)
+        assert result.signal == "bearish"
+        assert result.score == pytest.approx(-0.9)
+        assert result.agreement == 1.0
+
+    def test_all_neutral(self):
+        signals = {"a": _sig("neutral", 70), "b": _sig("neutral", 70)}
+        result = aggregate_signals(signals)
+        assert result.signal == "neutral"
+        assert result.score == 0.0
+        assert result.agreement == 1.0  # all weight in neutral camp
+        assert result.confidence == pytest.approx(70.0)
+
+    def test_half_and_half_returns_neutral_low_confidence(self):
+        signals = {
+            "a": _sig("bullish", 80),
+            "b": _sig("bullish", 80),
+            "c": _sig("bearish", 80),
+            "d": _sig("bearish", 80),
+        }
+        result = aggregate_signals(signals)
+        assert result.signal == "neutral"
+        assert result.score == pytest.approx(0.0)
+        assert result.agreement == 0.5
+        # Weighted mean conf is 80, scaled by agreement=0.5
+        assert result.confidence == pytest.approx(40.0)
+
+    def test_vote_breakdown_counts_every_agent(self):
+        signals = {
+            "a": _sig("bullish", 50),
+            "b": _sig("bearish", 50),
+            "c": _sig("neutral", 50),
+            "d": _sig("bullish", 50),
+        }
+        result = aggregate_signals(signals)
+        assert result.vote_breakdown == {"bullish": 2, "bearish": 1, "neutral": 1}
+
+
+class TestAggregateSignalsWeights:
+    def test_missing_weight_defaults_to_one(self):
+        signals = {"a": _sig("bullish", 100), "b": _sig("bullish", 100)}
+        # No weights dict supplied at all
+        result = aggregate_signals(signals)
+        assert result.score == pytest.approx(1.0)
+
+    def test_high_weight_overrides_many_low_weight(self):
+        signals = {
+            "bull_1": _sig("bullish", 80),
+            "bull_2": _sig("bullish", 80),
+            "bull_3": _sig("bullish", 80),
+            "bear_heavy": _sig("bearish", 80),
+        }
+        weights = {"bull_1": 1.0, "bull_2": 1.0, "bull_3": 1.0, "bear_heavy": 5.0}
+        result = aggregate_signals(signals, weights=weights)
+        # numerator = 3 * 0.8 - 1 * 5 * 0.8 = 2.4 - 4.0 = -1.6
+        # denominator = 3 + 5 = 8 → score = -0.2
+        assert result.score == pytest.approx(-0.2)
+        assert result.signal == "bearish"
+
+    def test_negative_weight_is_clamped_to_zero(self):
+        signals = {"a": _sig("bullish", 100), "b": _sig("bearish", 100)}
+        weights = {"a": 1.0, "b": -5.0}
+        result = aggregate_signals(signals, weights=weights)
+        # b contributes 0, a drives the score
+        assert result.score == pytest.approx(1.0)
+        assert result.signal == "bullish"
+        assert result.contributions["b"].weight == 0.0
+
+    def test_non_numeric_weight_falls_back_to_one(self):
+        signals = {"a": _sig("bullish", 100)}
+        weights = {"a": "not_a_number"}
+        result = aggregate_signals(signals, weights=weights)
+        assert result.contributions["a"].weight == 1.0
+
+
+class TestAggregateSignalsStrategies:
+    def test_majority_strategy_ignores_confidence(self):
+        # 3 low-confidence bullish would lose a confidence-weighted vote
+        # against 1 high-confidence bearish, but majority ignores confidence.
+        signals = {
+            "a": _sig("bullish", 10),
+            "b": _sig("bullish", 10),
+            "c": _sig("bullish", 10),
+            "d": _sig("bearish", 90),
+        }
+        result = aggregate_signals(signals, strategy="majority")
+        # score = (3*1 - 1) / 4 = 0.5
+        assert result.score == pytest.approx(0.5)
+        assert result.signal == "bullish"
+
+    def test_mean_strategy_ignores_custom_weights(self):
+        signals = {
+            "light_bull": _sig("bullish", 100),
+            "heavy_bear": _sig("bearish", 100),
+        }
+        weights = {"light_bull": 1.0, "heavy_bear": 100.0}
+        result = aggregate_signals(signals, weights=weights, strategy="mean")
+        # Both reduced to weight 1 → score = 0
+        assert result.score == pytest.approx(0.0)
+        assert result.contributions["heavy_bear"].weight == 1.0
+
+    def test_weighted_strategy_uses_both_confidence_and_weight(self):
+        signals = {
+            "a": _sig("bullish", 50),
+            "b": _sig("bullish", 50),
+        }
+        result = aggregate_signals(signals)
+        assert result.score == pytest.approx(0.5)
+
+
+class TestAggregateSignalsDeadband:
+    def test_score_below_deadband_is_neutral(self):
+        # Craft signals so score == 0.14
+        signals = {
+            "a": _sig("bullish", 50),  # +0.5
+            "b": _sig("bullish", 50),  # +0.5
+            "c": _sig("bearish", 36),  # -0.36
+            "d": _sig("bearish", 50),  # -0.5
+        }
+        result = aggregate_signals(signals, neutral_deadband=0.15)
+        assert result.score == pytest.approx(0.035)
+        assert result.signal == "neutral"
+
+    def test_score_above_deadband_is_directional(self):
+        signals = {
+            "a": _sig("bullish", 80),
+            "b": _sig("bearish", 50),
+        }
+        # score = (0.8 - 0.5) / 2 = 0.15; with default deadband 0.15 → neutral
+        # Pick a narrower deadband to verify bullish classification
+        result = aggregate_signals(signals, neutral_deadband=0.1)
+        assert result.score == pytest.approx(0.15)
+        assert result.signal == "bullish"
+
+    def test_zero_deadband_never_returns_neutral_on_nonzero_score(self):
+        signals = {"a": _sig("bullish", 1)}
+        result = aggregate_signals(signals, neutral_deadband=0.0)
+        assert result.signal == "bullish"
+
+
+class TestAggregateSignalsEdgeCases:
+    def test_empty_signals_returns_neutral_zero_confidence(self):
+        result = aggregate_signals({})
+        assert result.signal == "neutral"
+        assert result.score == 0.0
+        assert result.confidence == 0.0
+        assert result.agreement == 0.0
+        assert "No valid" in result.reasoning
+
+    def test_invalid_signal_string_is_skipped(self):
+        signals = {
+            "valid": _sig("bullish", 80),
+            "invalid": {"signal": "strong_buy", "confidence": 90},
+        }
+        result = aggregate_signals(signals)
+        assert "valid" in result.contributions
+        assert "invalid" not in result.contributions
+        assert result.score == pytest.approx(0.8)
+
+    def test_non_dict_payload_is_skipped(self):
+        signals = {
+            "valid": _sig("bullish", 80),
+            "broken": "not-a-dict",
+        }
+        result = aggregate_signals(signals)
+        assert "broken" not in result.contributions
+
+    def test_missing_confidence_coerced_to_zero(self):
+        signals = {"a": {"signal": "bullish"}}  # no confidence
+        result = aggregate_signals(signals)
+        assert result.contributions["a"].confidence == 0.0
+        assert result.score == 0.0  # conf=0 → contribution=0
+        assert result.signal == "neutral"
+
+    def test_none_confidence_coerced_to_zero(self):
+        signals = {"a": {"signal": "bullish", "confidence": None}}
+        result = aggregate_signals(signals)
+        assert result.contributions["a"].confidence == 0.0
+
+    def test_bad_confidence_string_coerced_to_zero(self):
+        signals = {"a": {"signal": "bullish", "confidence": "very confident"}}
+        result = aggregate_signals(signals)
+        assert result.contributions["a"].confidence == 0.0
+
+    def test_confidence_over_100_is_clamped(self):
+        signals = {"a": _sig("bullish", 250)}
+        result = aggregate_signals(signals)
+        assert result.contributions["a"].confidence == 100.0
+        assert result.score == pytest.approx(1.0)
+
+    def test_confidence_below_zero_is_clamped(self):
+        signals = {"a": _sig("bullish", -50)}
+        result = aggregate_signals(signals)
+        assert result.contributions["a"].confidence == 0.0
+
+    def test_all_zero_confidence_unanimous_is_neutral(self):
+        # Everyone says bullish but with zero confidence → no real signal
+        signals = {"a": _sig("bullish", 0), "b": _sig("bullish", 0)}
+        result = aggregate_signals(signals)
+        assert result.score == 0.0
+        assert result.signal == "neutral"
+        assert result.agreement == 1.0  # they still all voted bullish
+        assert result.confidence == 0.0
+
+
+class TestReturnTypes:
+    def test_result_is_consensus_signal(self):
+        result = aggregate_signals({"a": _sig("bullish", 50)})
+        assert isinstance(result, ConsensusSignal)
+
+    def test_contributions_are_agent_contribution(self):
+        result = aggregate_signals({"a": _sig("bullish", 50)})
+        assert isinstance(result.contributions["a"], AgentContribution)
+
+    def test_reasoning_mentions_top_contributors(self):
+        signals = {
+            "heavy_hitter": _sig("bullish", 100),
+            "quiet_one": _sig("neutral", 10),
+        }
+        result = aggregate_signals(signals)
+        assert "heavy_hitter" in result.reasoning
+
+    def test_contribution_sum_equals_score_times_weight_sum(self):
+        signals = {
+            "a": _sig("bullish", 80),
+            "b": _sig("bearish", 60),
+            "c": _sig("neutral", 50),
+        }
+        weights = {"a": 2.0, "b": 1.0, "c": 1.5}
+        result = aggregate_signals(signals, weights=weights)
+        total_contribution = sum(c.contribution for c in result.contributions.values())
+        weight_sum = sum(c.weight for c in result.contributions.values())
+        assert result.score == pytest.approx(total_contribution / weight_sum)


### PR DESCRIPTION
## Summary

Phase 1 of #586 — a **pure, deterministic** consensus aggregation library under [`src/consensus/`](src/consensus/). No LLM calls, no graph changes; this lands the foundation that follow-up PRs will wire into the LangGraph workflow and the portfolio manager.

### What's in

- [`src/consensus/models.py`](src/consensus/models.py) — `ConsensusSignal` and `AgentContribution` (pydantic).
- [`src/consensus/aggregation.py`](src/consensus/aggregation.py) — `aggregate_signals()` combines per-agent `{signal, confidence}` for one ticker into:
  - a composite `score` in `[-1.0, +1.0]`
  - a discrete `signal` (bullish/bearish/neutral) with a configurable neutral deadband
  - an aggregate `confidence` that's degraded by disagreement
  - an `agreement` measure (weighted-majority share of the dominant camp)
  - a per-agent `contribution` breakdown for observability
- Three strategies: `weighted` (default; uses `weight × confidence`), `majority` (ignores confidence), `mean` (ignores custom weights).
- [`src/consensus/__init__.py`](src/consensus/__init__.py) — public API.
- [`tests/test_consensus.py`](tests/test_consensus.py) — 33 unit tests.

### What's *not* in (follow-up PRs)

- Phase 2: `consensus_agent` graph node + `create_workflow` wiring
- Phase 3: `portfolio_manager` integration
- Phase 4: opt-in LLM arbiter for high-disagreement cases
- Phase 5: backend/frontend surface
- Per-agent weights on `ANALYST_CONFIG` (defaults to equal-weighted until then)

### Design notes

- **Single-ticker API.** Callers loop if they need multiple tickers — keeps the public surface small and easy to test.
- **Permissive inputs.** Invalid signal strings, bad confidences, and non-numeric weights are coerced or silently skipped rather than raising. Matches the pragmatic style of `src/tools/api.py`.
- **No behaviour change.** Nothing currently imports from `src/consensus/`; existing workflows are untouched.

## Test plan

- [x] `poetry run pytest tests/test_consensus.py -v` → **33 passed in 0.36s**
- [ ] CI on Python 3.11 (the project's supported version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)