### PR TITLE
fix: make JSON extraction robust for DeepSeek V4 output format

### DIFF
--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -107,15 +107,53 @@ def create_default_response(model_class: type[BaseModel]) -> BaseModel:
 
 
 def extract_json_from_response(content: str) -> dict | None:
-    """Extracts JSON from markdown-formatted response."""
+    """Extracts JSON from a response, handling markdown-wrapped and raw JSON formats."""
     try:
+        # 1. Try markdown code block with ```json
         json_start = content.find("```json")
         if json_start != -1:
-            json_text = content[json_start + 7 :]  # Skip past ```json
+            json_text = content[json_start + 7:]  # Skip past ```json
             json_end = json_text.find("```")
             if json_end != -1:
                 json_text = json_text[:json_end].strip()
-                return json.loads(json_text)
+                try:
+                    return json.loads(json_text)
+                except json.JSONDecodeError:
+                    pass
+
+        # 2. Try markdown code block without json specifier
+        json_start = content.find("```")
+        if json_start != -1:
+            json_text = content[json_start + 3:]
+            json_end = json_text.find("```")
+            if json_end != -1:
+                json_text = json_text[:json_end].strip()
+                try:
+                    return json.loads(json_text)
+                except json.JSONDecodeError:
+                    pass
+
+        # 3. Try to parse the entire content as JSON
+        try:
+            return json.loads(content.strip())
+        except json.JSONDecodeError:
+            pass
+
+        # 4. Find the first top-level JSON object by matching braces
+        brace_start = content.find("{")
+        if brace_start != -1:
+            depth = 0
+            for i, char in enumerate(content[brace_start:], brace_start):
+                if char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        try:
+                            return json.loads(content[brace_start:i + 1])
+                        except json.JSONDecodeError:
+                            break
+
     except Exception as e:
         print(f"Error extracting JSON from response: {e}")
     return None


### PR DESCRIPTION
Fixes #601

## Problem

DeepSeek V4 (`deepseek-chat`) may return JSON without markdown code blocks or using plain backtick fences without the `json` specifier. The existing `extract_json_from_response` only searched for ` ```json ` blocks, so any response in a different format caused a `None` result. This triggered the fallback `create_default_response`, which returns `PortfolioManagerOutput(decisions={})` — an empty dict — causing the display layer to print "No trading decisions available".

## Solution

Extended `extract_json_from_response` with three additional extraction strategies, tried in order after the existing ` ```json ` check:

1. **Plain backtick fence** — handles ` ``` ` without the `json` specifier
2. **Full content parse** — tries `json.loads` on the entire response (handles bare JSON responses)
3. **Brace matching** — finds the first top-level `{...}` object in the content (handles JSON embedded in prose)

All new paths wrap `json.loads` in their own `try/except JSONDecodeError`, so a failed attempt cleanly falls through to the next strategy without masking other errors.

## Testing

The fix is purely in the JSON extraction utility and does not touch any agent logic or API integration. It degrades gracefully: if all strategies fail, the existing `None` return and default-factory fallback still apply.

Verified that the four extraction strategies correctly handle:
- ` ```json ... ``` ` (original behavior preserved)
- ` ``` ... ``` ` (plain fence)
- Bare JSON string
- JSON embedded in explanatory text