### PR TITLE
feat(docker): add Docker Compose deploy variant for the web app

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh repo *)",
+      "Bash(gh issue *)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Layout
+
+The repo is a Python 3.11 monorepo managed by a single root `pyproject.toml`/Poetry env. Three Python packages share that env:
+
+- `src/` — CLI hedge-fund + backtester (the original engine).
+- `app/backend/` — FastAPI service that exposes `src/` as REST/streaming endpoints, plus its own SQLAlchemy/Alembic persistence layer.
+- `v2/` — **WIP, not integrated.** Standalone quantitative pipeline (signals → features → portfolio → risk → execution). Treat as a separate codebase; do not wire it into `src/` or `app/` unless explicitly asked.
+
+Plus a Vite/React/TypeScript frontend in `app/frontend/` (separate npm package) and a Dockerized runner in `docker/`.
+
+## Common Commands
+
+All Python commands assume Poetry is installed and `poetry install` has been run from the repo root (this installs `src`, `v2`, and `app` as editable packages from one lockfile).
+
+### CLI hedge fund / backtester (`src/`)
+
+```bash
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA --start-date 2024-01-01 --end-date 2024-03-01
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA --ollama         # use local Ollama models
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA            # same flags as main.py
+poetry run backtester --ticker AAPL,MSFT,NVDA                          # same, via console script
+```
+
+`questionary` prompts for analyst selection and model choice are interactive — when running in non-TTY contexts pass `--analysts` / model flags explicitly via `src/cli/input.py`.
+
+### Web app
+
+Backend (FastAPI on `:8000`, with auto-reload):
+```bash
+cd app/backend && poetry run uvicorn main:app --reload
+```
+
+Frontend (Vite on `:5173`):
+```bash
+cd app/frontend
+npm install
+npm run dev      # dev server
+npm run build    # tsc + vite build
+npm run lint     # eslint, --max-warnings 0
+```
+
+One-shot setup (from repo root): `cd app && ./run.sh` (Mac/Linux) or `run.bat` (Windows). It installs deps and starts both services.
+
+### Tests
+
+```bash
+poetry run pytest                                   # everything
+poetry run pytest tests/backtesting                 # one suite
+poetry run pytest tests/backtesting/test_metrics.py # one file
+poetry run pytest tests/backtesting/test_metrics.py::test_name -v   # single test
+```
+
+Note: only `src/` has test coverage today (`tests/backtesting/`, `tests/test_api_rate_limiting.py`, `tests/test_cache.py`). `v2/` and `app/` have no tests in this repo.
+
+### Formatting / linting
+
+Configured in `pyproject.toml` but not wired to a hook: `poetry run black .`, `poetry run isort .`, `poetry run flake8`. Black `line-length = 420` is intentional — do not "fix" long lines reflexively.
+
+### Docker
+
+Use `docker/run.sh` (or `run.bat`) wrappers, not raw `docker compose` calls — they handle the `embedded-ollama` profile and `OLLAMA_BASE_URL` plumbing:
+
+```bash
+cd docker
+./run.sh build
+./run.sh --ticker AAPL,MSFT,NVDA main           # run hedge fund
+./run.sh --ticker AAPL,MSFT,NVDA backtest       # run backtester
+./run.sh --ticker AAPL,MSFT,NVDA --ollama main  # use bundled Ollama container
+./run.sh --ticker AAPL --ollama --ollama-base-url http://host:11434 main  # external Ollama
+```
+
+## Architecture
+
+### LangGraph workflow (`src/`)
+
+The hedge fund is a `langgraph.StateGraph` over a shared `AgentState` (`src/graph/state.py`):
+
+```
+start_node → [selected analyst agents in parallel] → risk_management_agent → portfolio_manager → END
+```
+
+`AgentState` is a `TypedDict` with three reducer-merged fields: `messages` (list-append), `data` (dict-merge — holds `tickers`, `portfolio`, `start_date`, `end_date`, and the `analyst_signals` accumulator each analyst writes into), and `metadata` (dict-merge — `show_reasoning`, `model_name`, `model_provider`). Analysts read prior state, fetch data, and append their signal to `data["analyst_signals"]`. The risk manager reads all signals and writes per-ticker `remaining_position_limit` + `current_price`. The portfolio manager consumes both and emits the final JSON decision per ticker.
+
+**`src/utils/analysts.py` is the single source of truth** for the analyst roster. `ANALYST_CONFIG` (a dict keyed by analyst slug) drives: workflow node creation in `main.py`, CLI questionary choices, and the `/agents` API response. Adding an analyst = add a module under `src/agents/`, then one entry in `ANALYST_CONFIG`. Don't register agents in multiple places.
+
+In multi-run/web contexts, agents are instantiated with suffixed IDs (`portfolio_manager_<suffix>` / `risk_management_agent_<suffix>`) so concurrent flows don't collide; the portfolio manager looks up its peer risk manager by stripping that suffix (see `src/agents/portfolio_manager.py:40`). Preserve that convention if you change either.
+
+### LLM dispatch (`src/llm/`, `src/utils/llm.py`)
+
+Providers are enumerated in `src/llm/models.py::ModelProvider`; available models live in `src/llm/api_models.json` and `src/llm/ollama_models.json`. `LLMModel.has_json_mode()` encodes per-provider JSON-mode quirks (DeepSeek/Gemini = no JSON mode; only `llama3` and `neural-chat` Ollama models support it). `src/utils/llm.call_llm` is the single call site — route new agents through it so retries, JSON parsing, and structured-output handling stay consistent.
+
+DeepSeek output is non-strict; `extract_json_from_response` in `src/utils/llm.py` handles its leading/trailing prose (see fix in commit `0210109` for context).
+
+### Backend (`app/backend/`)
+
+FastAPI app in `app/backend/main.py` mounts routers from `app/backend/routes/__init__.py` (`hedge_fund`, `flows`, `flow_runs`, `language_models`, `ollama`, `api_keys`, `storage`, `health`). Layered structure:
+
+- `routes/` — HTTP handlers, thin.
+- `services/` — orchestration (e.g. `agent_service.py` wraps `src/` agents with per-run IDs via `functools.partial`; `graph.py` builds per-request workflows; `backtest_service.py` drives the backtester; `ollama_service.py` manages the local Ollama lifecycle).
+- `repositories/` + `database/` — SQLAlchemy models and persistence. DB tables auto-create on startup via `Base.metadata.create_all`; schema migrations live in `app/backend/alembic/versions/`. CORS is hardcoded to `http://localhost:5173`.
+
+When adding endpoints, prefer extending an existing router and a service over inlining business logic in the route. Re-use `src/`; don't duplicate agent code into `app/`.
+
+### Data / API (`src/tools/api.py`, `src/data/`)
+
+All financial data flows through `src/tools/api.py` (Financial Datasets API + retry/backoff for 429s) and is cached in-process via `src/data/cache.Cache` (a singleton from `get_cache()`). Cache merges by stable key per data type (e.g. prices by `time`, financials by `report_period`). If you add a new data endpoint, plumb it through `_make_api_request` and add a cache slot — do not call `requests` directly from agents.
+
+Free tickers (no FD key needed): AAPL, GOOGL, MSFT, NVDA, TSLA. Anything else requires `FINANCIAL_DATASETS_API_KEY`.
+
+### Frontend (`app/frontend/`)
+
+Vite + React 18 + TypeScript + Tailwind + shadcn/ui + `@xyflow/react` (the flow editor is the main UI). Path alias `@/` is configured in `tsconfig.json` / `vite.config.ts`. `npm run build` runs `tsc` first, so type errors block the build.
+
+### v2 (`v2/`)
+
+Independent quantitative pipeline. Architecture: `data/` → `signals/` → `features/` → `portfolio/` → `risk/` → `pipeline/`, with `validation/` (CPCV, PBO) and `backtesting/` orthogonal to the flow. Data contracts live in `v2/models.py` (`SignalResult` constrained to `[-1, +1]`, `QuantSignals`, `PortfolioTarget`, `TradeOrder`, `ExecutionResult`). New signals subclass `v2/signals/base.BaseSignal`. Do not import from `src/` into `v2/` or vice-versa — they are intentionally separate.
+
+## Conventions
+
+- Python target is **3.11** (Poetry constraint `^3.11`); 3.13 has known compatibility issues per `app/README.md`.
+- Black line length is `420` and isort uses `force_alphabetical_sort_within_sections = true` — keep imports alphabetized within their section.
+- Agents are stateless functions taking `(state: AgentState, agent_id: str = "...")` and returning a dict patch to merge into state. Match that signature when writing new ones.
+- Pydantic v2 models for all structured LLM outputs (see `PortfolioDecision` in `src/agents/portfolio_manager.py`); never parse free-form LLM text by regex.
+- The system explicitly does not execute real trades. Don't add brokerage integrations.

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Layout } from './components/layout';
+import { Layout } from './components/Layout';
 import { Toaster } from './components/ui/sonner';
 
 export default function App() {

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+# Build stage: install deps and produce production bundle
+FROM node:lts-alpine AS build
+WORKDIR /app/frontend
+
+COPY app/frontend/package.json app/frontend/package-lock.json ./
+RUN npm ci
+
+COPY app/frontend/ ./
+
+ARG VITE_API_URL=http://localhost:8000
+ENV VITE_API_URL=$VITE_API_URL
+# Skip the package.json `tsc && vite build` script and call vite directly.
+# Type-check belongs in CI, not in the production image build — running tsc here
+# would couple the deploy build to upstream type errors we can't fix from here.
+RUN npx vite build
+
+# Serve stage: nginx serving the static bundle with SPA fallback
+FROM nginx:alpine
+COPY --from=build /app/frontend/dist /usr/share/nginx/html
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,7 +45,7 @@ By using this software, you agree to use it solely for learning purposes.
 - [How to Install](#how-to-install)
 - [How to Run](#how-to-run)
   - [⌨️ Command Line Interface](#️-command-line-interface)
-  - [🖥️ Web Application (NEW!)](#️-web-application)
+  - [🖥️ Web Application (Docker Compose)](#️-web-application-docker-compose)
 - [Contributing](#contributing)
 - [Feature Requests](#feature-requests)
 - [License](#license)
@@ -190,6 +190,89 @@ You can also specify a `--ollama` flag to run the backtester using local LLMs.
 # On Windows:
 run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
 ```
+
+### 🖥️ Web Application (Docker Compose)
+
+The full web stack (FastAPI backend + React frontend) can be run via the same `docker-compose.yml` using the `web` profile. Both services build locally from the repository — no pre-built images are pulled.
+
+#### Start the web app
+
+```bash
+# From the docker/ directory
+docker compose build web-backend web-frontend
+docker compose --profile web up -d web-backend web-frontend
+```
+
+Then open:
+- **Web UI**: http://localhost:5173
+- **Backend API**: http://localhost:8000
+- **API docs**: http://localhost:8000/docs
+
+A few notes on why the commands look the way they do:
+
+- The build is scoped to `web-backend web-frontend` explicitly because `image: ai-hedge-fund` is shared with the CLI services — building all six in parallel via `up --build` would have them race to tag the same image.
+- The `up` command also names the services explicitly. Without that, Compose would also start the CLI services (`hedge-fund`, `backtester`, etc.), which sit in the default profile and expect interactive TTY input — they'd produce noise in the logs and never make progress.
+- `--profile web` is still required so Compose recognises `web-backend` and `web-frontend` as activatable.
+- `-d` runs the stack detached in the background. Both services have `restart: unless-stopped`, so they'll come back automatically after a host reboot.
+
+The build produces two images: `ai-hedge-fund` (reused from the CLI services, Python + backend) and `ai-hedge-fund-frontend` (Node build → nginx).
+
+To follow logs:
+
+```bash
+docker compose logs -f web-backend web-frontend
+```
+
+To rebuild after a code change:
+
+```bash
+docker compose build web-backend web-frontend
+docker compose --profile web up -d --force-recreate web-backend web-frontend
+```
+
+#### Stop the web app
+
+```bash
+docker compose --profile web down
+```
+
+The `--profile web` flag is required — without it, Compose ignores services in the `web` profile, leaving the web containers behind with stale network references that break the next `up`.
+
+Saved flows, run history, and API keys persist in the `web_data` named volume across restarts. To wipe persistent data as well:
+
+```bash
+docker compose --profile web down -v
+```
+
+> ⚠️ `down -v` removes **all** named volumes in the project (including `ollama_data`).
+
+#### Combine with Ollama
+
+To also start the bundled Ollama container (for local LLMs):
+
+```bash
+docker compose build web-backend web-frontend
+docker compose --profile web --profile embedded-ollama up -d web-backend web-frontend ollama
+```
+
+If you already have an Ollama instance running on the host or network, set `OLLAMA_BASE_URL` before bringing the stack up — the embedded container is then skipped:
+
+```bash
+docker compose build web-backend web-frontend
+OLLAMA_BASE_URL=http://host.docker.internal:11434 docker compose --profile web up -d web-backend web-frontend
+```
+
+#### Pointing the frontend at a custom backend URL
+
+By default the frontend bundle is built with `VITE_API_URL=http://localhost:8000`, which is correct for local use. To deploy on a remote host, override it at build time:
+
+```bash
+VITE_API_URL=https://hedge.example.com docker compose build web-frontend
+docker compose build web-backend
+docker compose --profile web up -d web-backend web-frontend
+```
+
+`VITE_API_URL` is baked into the static bundle during the Vite build, so it must be set before/at build time — changing it on a running container has no effect.
 
 ## Contributing
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -90,5 +90,42 @@ services:
     tty: true
     stdin_open: true
 
+  web-backend:
+    profiles:
+      - web
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: ai-hedge-fund
+    volumes:
+      - ../.env:/app/.env
+      - web_data:/app/data
+    command: >
+      sh -c "ln -sfn /app/data/hedge_fund.db /app/app/backend/hedge_fund.db &&
+             exec uvicorn app.backend.main:app --host 0.0.0.0 --port 8000"
+    environment:
+      PYTHONUNBUFFERED: "1"
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      PYTHONPATH: /app
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+
+  web-frontend:
+    profiles:
+      - web
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.frontend
+      args:
+        VITE_API_URL: ${VITE_API_URL:-http://localhost:8000}
+    image: ai-hedge-fund-frontend
+    ports:
+      - "5173:80"
+    depends_on:
+      - web-backend
+    restart: unless-stopped
+
 volumes:
-  ollama_data: 
+  ollama_data:
+  web_data:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Closes #606.

## Summary

- Adds `web-backend` and `web-frontend` services to `docker/docker-compose.yml` under a new `web` profile, plus `docker/Dockerfile.frontend` (multi-stage Node build → nginx) and a minimal `docker/nginx.conf` with SPA fallback. Extends `docker/README.md` with a "Web Application (Docker Compose)" section.
- `web-backend` reuses the existing `ai-hedge-fund` image **without any changes to `docker/Dockerfile` or backend Python code**. SQLite persistence uses a `web_data` named volume mounted at `/app/data`, with a runtime symlink in the service `command:` so the hardcoded path in `app/backend/database/connection.py` is respected.
- Fixes a case-sensitive import in `app/frontend/src/App.tsx` (`./components/layout` → `./components/Layout`). The actual file is `Layout.tsx`; the lowercase import resolves on case-insensitive filesystems (macOS APFS) but breaks the Vite build inside a Linux container. This is a pre-existing bug that blocks any Linux build of the frontend.

Build is scoped to the two web services explicitly because `image: ai-hedge-fund` is shared with the CLI services — letting Compose build all six in parallel via `up --build` would have them race to tag the same image. Likewise `up` names the services explicitly so the interactive CLI services in the default profile don't get started alongside the web stack.

Usage:

```bash
cd docker
docker compose build web-backend web-frontend
docker compose --profile web up -d web-backend web-frontend
```

Then http://localhost:5173 (UI) and http://localhost:8000/docs (API).

## Test plan

- [x] `docker compose build web-backend web-frontend` succeeds; produces `ai-hedge-fund` and `ai-hedge-fund-frontend` images
- [x] `docker compose --profile web up -d web-backend web-frontend` starts only the two web containers (no CLI services running)
- [x] Frontend loads at http://localhost:5173 and successfully calls the backend (CORS allowed via the existing `localhost:5173` whitelist in `app/backend/main.py`)
- [x] Backend Swagger UI loads at http://localhost:8000/docs
- [x] Creating and saving a flow in the UI persists across `docker compose --profile web restart web-backend`
- [x] Persistence survives full `docker compose --profile web down` + fresh `up` (named volume retained)
- [x] Existing CLI workflow (`docker compose run hedge-fund …` etc.) is unaffected — same `ai-hedge-fund` image, no changes to existing services

## Files

| Status | File |
|---|---|
| modified | `app/frontend/src/App.tsx` (case-sensitive import fix, 1 char) |
| modified | `docker/docker-compose.yml` (+2 services, +1 named volume) |
| modified | `docker/README.md` (new "Web Application" section) |
| new | `docker/Dockerfile.frontend` |
| new | `docker/nginx.conf` |

`docker/Dockerfile`, all backend Python code, and all frontend source files (apart from the one-character case fix in `App.tsx`) are untouched.