### PR TITLE
test: skip live FD smoke tests without API key

### DIFF
--- a/v2/data/test_client.py
+++ b/v2/data/test_client.py
@@ -1,5 +1,6 @@
 """Week 1 data exploration — pull and inspect FD data for 5 tickers."""
 
+import os
 import pytest
 
 from v2.data import FDClient
@@ -7,6 +8,11 @@ from v2.data import FDClient
 TICKERS = ["AAPL", "MSFT", "NVDA", "JPM", "XOM"]
 PRICE_START = "2024-01-01"
 PRICE_END = "2026-04-15"
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("FINANCIAL_DATASETS_API_KEY"),
+    reason="live Financial Datasets smoke tests require FINANCIAL_DATASETS_API_KEY",
+)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- skip the live Financial Datasets smoke tests when `FINANCIAL_DATASETS_API_KEY` is not configured
- keep the existing `v2/data/test_client.py` smoke coverage available for contributors who opt in with credentials

## Why
`v2/data/test_client.py` is collected by default by pytest, but it exercises the live Financial Datasets API through `FDClient`. Without an API key, a normal local or CI pytest run can depend on external service behavior instead of staying offline-safe.

## Tests
- `python3 -m pytest -q v2/data/test_client.py`
- `python3 -m pytest --collect-only -q v2/data/test_client.py`