### PR TITLE
fix: preserve earnings filing metadata

### DIFF
--- a/tests/test_v2_fd_client_earnings.py
+++ b/tests/test_v2_fd_client_earnings.py
@@ -1,0 +1,34 @@
+from v2.data.client import FDClient
+
+
+def test_get_earnings_preserves_filing_metadata(monkeypatch):
+    payload = [
+        {
+            "ticker": "AAPL",
+            "report_period": "2025-09-27",
+            "source_type": "10-K",
+            "filing_date": "2025-10-31",
+            "filing_datetime": "2025-10-31T06:01:26Z",
+            "filing_window": "after_market_close",
+            "fiscal_period": "FY",
+            "currency": "USD",
+            "filing_url": "https://www.sec.gov/Archives/example.htm",
+            "accession_number": "0000320193-25-000079",
+            "quarterly": {"revenue": 102466000000, "earnings_per_share": 1.85},
+        }
+    ]
+
+    client = FDClient(api_key="test")
+    monkeypatch.setattr(client, "_get", lambda *args, **kwargs: payload)
+
+    earnings = client.get_earnings("AAPL")
+
+    assert earnings is not None
+    assert earnings.source_type == "10-K"
+    assert earnings.filing_date == "2025-10-31"
+    assert earnings.filing_datetime == "2025-10-31T06:01:26Z"
+    assert earnings.filing_window == "after_market_close"
+    assert earnings.filing_url == "https://www.sec.gov/Archives/example.htm"
+    assert earnings.accession_number == "0000320193-25-000079"
+    assert earnings.quarterly is not None
+    assert earnings.quarterly.revenue == 102466000000

--- a/v2/data/models.py
+++ b/v2/data/models.py
@@ -214,14 +214,26 @@ class EarningsData(BaseModel):
 
 
 class Earnings(BaseModel):
-    """Earnings data from /earnings (single-ticker, latest-period mode)."""
+    """Latest earnings filing data from /earnings.
+
+    The endpoint returns filing metadata along with the quarterly and annual
+    earnings payloads.  Keep the metadata on the latest-period convenience
+    model so callers do not lose the filing context when using
+    ``FDClient.get_earnings()``.
+    """
 
     model_config = _IGNORE
 
     ticker: str
     report_period: str
+    source_type: str | None = None
+    filing_date: str | None = None
+    filing_datetime: str | None = None
+    filing_window: str | None = None
     fiscal_period: str | None = None
     currency: str | None = None
+    filing_url: str | None = None
+    accession_number: str | None = None
     quarterly: EarningsData | None = None
     annual: EarningsData | None = None
 


### PR DESCRIPTION
## Summary

- Preserve filing metadata on the latest earnings model returned by `FDClient.get_earnings()`.
- Add optional fields for `source_type`, filing dates/window, SEC filing URL, and accession number.
- Add a focused regression test proving the convenience latest-earnings path keeps the filing context while parsing the quarterly payload.

## Tests

- `python3 -m pytest -q tests/test_v2_fd_client_earnings.py`
- `python3 -m py_compile v2/data/models.py v2/data/client.py`
- `git diff --check`
