### PR TITLE
feat: add Tencent Cloud LLM providers and multi-language output support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,18 @@ FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-openai-api-key
 
+# For running LLMs via Tencent Cloud Coding Plan (OpenAI-compatible)
+# Get your Coding Plan API key (format: sk-sp-xxxx) from https://console.cloud.tencent.com/tokenhub/codingplan
+# Supported models: tc-code-latest, hunyuan-2.0-instruct, hunyuan-2.0-thinking, minimax-m2.5, kimi-k2.5, glm-5
+TENCENT_CODING_API_KEY=your-tencent-coding-api-key
+TENCENT_CODING_BASE_URL=https://api.lkeap.cloud.tencent.com/coding/v3
+
+# For running LLMs via Tencent TokenHub MaaS (OpenAI-compatible)
+# Get your API key from https://console.cloud.tencent.com/tokenhub
+# Supported models: deepseek-v4-pro, deepseek-v4-flash, glm-5.1, minimax-m2.7, hunyuan-2.0-instruct, kimi-k2.6
+TENCENT_MAAS_API_KEY=your-tencent-maas-api-key
+TENCENT_MAAS_BASE_URL=https://tokenhub.tencentmaas.com/v1
+
 # For running LLMs hosted by anthropic (claude-4-sonnet, claude-4.1-opus, etc.)
 # Get your Anthropic API key from https://anthropic.com/
 ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -2,15 +2,23 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import logging
 import asyncio
+import os
+from pathlib import Path
+from dotenv import load_dotenv
 
-from app.backend.routes import api_router
-from app.backend.database.connection import engine
-from app.backend.database.models import Base
-from app.backend.services.ollama_service import ollama_service
-
-# Configure logging
+# Explicitly load .env from the project root (two levels above app/backend/)
+_env_path = Path(__file__).parent.parent.parent / ".env"
+load_dotenv(_env_path, override=True)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.info(f"Loading .env from: {_env_path} (exists={_env_path.exists()})")
+logger.info(f"TENCENT_MAAS_API_KEY loaded: {bool(os.getenv('TENCENT_MAAS_API_KEY'))}")
+
+from app.backend.routes import api_router
+from app.backend.database.connection import engine, SessionLocal
+from app.backend.database.models import Base
+from app.backend.services.ollama_service import ollama_service
+from app.backend.services.api_key_service import ApiKeyService
 
 app = FastAPI(title="AI Hedge Fund API", description="Backend API for AI Hedge Fund", version="0.1.0")
 
@@ -31,7 +39,16 @@ app.include_router(api_router)
 
 @app.on_event("startup")
 async def startup_event():
-    """Startup event to check Ollama availability."""
+    """Startup event: sync .env API keys to DB, then check Ollama availability."""
+    # Sync .env API key values into the database on first start
+    try:
+        db = SessionLocal()
+        ApiKeyService(db).sync_env_to_db()
+        db.close()
+        logger.info("✓ API keys synced from .env to database")
+    except Exception as e:
+        logger.warning(f"Could not sync API keys from .env: {e}")
+
     try:
         logger.info("Checking Ollama availability...")
         status = await ollama_service.check_ollama_status()

--- a/app/backend/models/schemas.py
+++ b/app/backend/models/schemas.py
@@ -68,6 +68,7 @@ class BaseHedgeFundRequest(BaseModel):
     margin_requirement: float = 0.0
     portfolio_positions: Optional[List[PortfolioPosition]] = None
     api_keys: Optional[Dict[str, str]] = None
+    language: Optional[str] = "English"
 
     def get_agent_ids(self) -> List[str]:
         """Extract agent IDs from graph structure"""

--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -85,7 +85,8 @@ async def run(request_data: HedgeFundRequest, request: Request, db: Session = De
                         end_date=request_data.end_date,
                         model_name=request_data.model_name,
                         model_provider=model_provider,
-                        request=request_data,  # Pass the full request for agent-specific model access
+                        request=request_data,
+                        language=request_data.language or "English",
                     )
                 )
                 
@@ -202,7 +203,8 @@ async def backtest(request_data: BacktestRequest, request: Request, db: Session 
             initial_capital=request_data.initial_capital,
             model_name=request_data.model_name,
             model_provider=model_provider,
-            request=request_data,  # Pass the full request for agent-specific model access
+            request=request_data,
+            language=request_data.language or "English",
         )
 
         # Function to detect client disconnection

--- a/app/backend/services/api_key_service.py
+++ b/app/backend/services/api_key_service.py
@@ -1,23 +1,95 @@
+import os
 from sqlalchemy.orm import Session
 from typing import Dict, Optional
 from app.backend.repositories.api_key_repository import ApiKeyRepository
 
 
+# Known API key providers: env var name → human-readable description
+_ENV_KEY_REGISTRY: Dict[str, str] = {
+    "FINANCIAL_DATASETS_API_KEY": "Financial Datasets API",
+    "OPENAI_API_KEY":             "OpenAI API",
+    "ANTHROPIC_API_KEY":          "Anthropic API",
+    "DEEPSEEK_API_KEY":           "DeepSeek API",
+    "GROQ_API_KEY":               "Groq API",
+    "GOOGLE_API_KEY":             "Google API",
+    "XAI_API_KEY":                "xAI API",
+    "MOONSHOT_API_KEY":           "Moonshot (Kimi) API",
+    "GIGACHAT_API_KEY":           "GigaChat API",
+    "OPENROUTER_API_KEY":         "OpenRouter API",
+    "AZURE_OPENAI_API_KEY":       "Azure OpenAI API",
+    "TENCENT_CODING_API_KEY":     "Tencent Coding Plan API",
+    "TENCENT_MAAS_API_KEY":       "Tencent TokenHub MaaS API",
+}
+
+# Placeholder prefixes — values starting with these are not real keys
+_PLACEHOLDER_PREFIXES = ("your-", "sk-your-", "sk-sp-your-")
+
+
+def _is_placeholder(value: str) -> bool:
+    """Return True if the value looks like a placeholder rather than a real key."""
+    v = value.strip().lower()
+    return any(v.startswith(p) for p in _PLACEHOLDER_PREFIXES)
+
+
 class ApiKeyService:
     """Simple service to load API keys for requests"""
-    
+
     def __init__(self, db: Session):
         self.repository = ApiKeyRepository(db)
-    
+
+    # ------------------------------------------------------------------
+    # Startup helper
+    # ------------------------------------------------------------------
+
+    def sync_env_to_db(self) -> None:
+        """
+        One-time sync: write env-var values into the database for any
+        provider that has a real (non-placeholder) value in the environment
+        but no existing record in the database.
+
+        DB values are never overwritten — if a user already saved a key
+        via the UI it takes priority.
+        """
+        for env_var, description in _ENV_KEY_REGISTRY.items():
+            value = os.getenv(env_var, "")
+            if not value or _is_placeholder(value):
+                continue
+            # Only create if the DB doesn't have this provider yet
+            existing = self.repository.get_api_key_by_provider(env_var)
+            if existing is None:
+                self.repository.create_or_update_api_key(
+                    provider=env_var,
+                    key_value=value,
+                    description=description,
+                    is_active=True,
+                )
+
+    # ------------------------------------------------------------------
+    # Runtime helpers
+    # ------------------------------------------------------------------
+
     def get_api_keys_dict(self) -> Dict[str, str]:
         """
-        Load all active API keys from database and return as a dictionary
-        suitable for injecting into requests
+        Return all active API keys as a dict {provider: key_value}.
+        DB values take priority; env vars fill in anything the DB doesn't have.
         """
-        api_keys = self.repository.get_all_api_keys(include_inactive=False)
-        return {key.provider: key.key_value for key in api_keys}
-    
+        db_keys = {key.provider: key.key_value
+                   for key in self.repository.get_all_api_keys(include_inactive=False)}
+
+        # Merge with env vars for providers not yet in DB
+        for env_var in _ENV_KEY_REGISTRY:
+            if env_var not in db_keys:
+                value = os.getenv(env_var, "")
+                if value and not _is_placeholder(value):
+                    db_keys[env_var] = value
+
+        return db_keys
+
     def get_api_key(self, provider: str) -> Optional[str]:
-        """Get a specific API key by provider"""
-        api_key = self.repository.get_api_key_by_provider(provider)
-        return api_key.key_value if api_key else None 
+        """Get a specific API key — DB first, then env var fallback."""
+        db_key = self.repository.get_api_key_by_provider(provider)
+        if db_key:
+            return db_key.key_value
+        # Fallback to env var
+        value = os.getenv(provider, "")
+        return value if value and not _is_placeholder(value) else None

--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -32,6 +32,7 @@ class BacktestService:
         model_name: str = "gpt-4.1",
         model_provider: str = "OpenAI",
         request: dict = {},
+        language: str = "English",
     ):
         """
         Initialize the backtest service.
@@ -55,6 +56,7 @@ class BacktestService:
         self.model_name = model_name
         self.model_provider = model_provider
         self.request = request
+        self.language = language
         self.portfolio_values = []
 
     def execute_trade(self, ticker: str, action: str, quantity: float, current_price: float) -> int:
@@ -373,6 +375,7 @@ class BacktestService:
                     model_name=self.model_name,
                     model_provider=self.model_provider,
                     request=self.request,
+                    language=self.language,
                 )
                 
                 # Parse the decisions from the graph result

--- a/app/backend/services/graph.py
+++ b/app/backend/services/graph.py
@@ -129,12 +129,10 @@ def create_graph(graph_nodes: list, graph_edges: list) -> StateGraph:
     return graph
 
 
-async def run_graph_async(graph, portfolio, tickers, start_date, end_date, model_name, model_provider, request=None):
+async def run_graph_async(graph, portfolio, tickers, start_date, end_date, model_name, model_provider, request=None, language: str = "English"):
     """Async wrapper for run_graph to work with asyncio."""
-    # Use run_in_executor to run the synchronous function in a separate thread
-    # so it doesn't block the event loop
     loop = asyncio.get_running_loop()
-    result = await loop.run_in_executor(None, lambda: run_graph(graph, portfolio, tickers, start_date, end_date, model_name, model_provider, request))  # Use default executor
+    result = await loop.run_in_executor(None, lambda: run_graph(graph, portfolio, tickers, start_date, end_date, model_name, model_provider, request, language))
     return result
 
 
@@ -147,6 +145,7 @@ def run_graph(
     model_name: str,
     model_provider: str,
     request=None,
+    language: str = "English",
 ) -> dict:
     """
     Run the graph with the given portfolio, tickers,
@@ -171,7 +170,8 @@ def run_graph(
                 "show_reasoning": False,
                 "model_name": model_name,
                 "model_provider": model_provider,
-                "request": request,  # Pass the request for agent-specific model access
+                "request": request,
+                "language": language,
             },
         },
     )

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -79,6 +79,20 @@ const LLM_API_KEYS: ApiKey[] = [
     description: 'For GigaChat models (GigaChat-2-Max, etc.)',
     url: 'https://github.com/ai-forever/gigachat',
     placeholder: 'your-gigachat-api-key'
+  },
+  {
+    key: 'TENCENT_CODING_API_KEY',
+    label: 'Tencent Coding Plan API',
+    description: 'For Tencent Coding Plan models (hunyuan-2.0, kimi-k2.5, glm-5, etc.) — key format: sk-sp-xxxx',
+    url: 'https://console.cloud.tencent.com/tokenhub/codingplan',
+    placeholder: 'sk-sp-your-tencent-coding-api-key'
+  },
+  {
+    key: 'TENCENT_MAAS_API_KEY',
+    label: 'Tencent TokenHub MaaS API',
+    description: 'For Tencent MaaS models (deepseek-v4-pro, deepseek-v4-flash, glm-5.1, minimax-m2.7)',
+    url: 'https://console.cloud.tencent.com/tokenhub',
+    placeholder: 'sk-your-tencent-maas-api-key'
   }
 ];
 

--- a/app/frontend/src/nodes/components/portfolio-start-node.tsx
+++ b/app/frontend/src/nodes/components/portfolio-start-node.tsx
@@ -39,6 +39,18 @@ const runModes = [
   { value: 'backtest', label: 'Backtest' },
 ];
 
+const SUPPORTED_LANGUAGES = [
+  { value: 'English', label: 'English' },
+  { value: 'Chinese', label: '中文 (Chinese)' },
+  { value: 'Japanese', label: '日本語 (Japanese)' },
+  { value: 'Korean', label: '한국어 (Korean)' },
+  { value: 'French', label: 'Français (French)' },
+  { value: 'German', label: 'Deutsch (German)' },
+  { value: 'Spanish', label: 'Español (Spanish)' },
+  { value: 'Portuguese', label: 'Português (Portuguese)' },
+  { value: 'Russian', label: 'Русский (Russian)' },
+];
+
 export function PortfolioStartNode({
   data,
   selected,
@@ -58,7 +70,9 @@ export function PortfolioStartNode({
   const [runMode, setRunMode] = useNodeState(id, 'runMode', 'single');
   const [startDate, setStartDate] = useNodeState(id, 'startDate', threeMonthsAgo.toISOString().split('T')[0]);
   const [endDate, setEndDate] = useNodeState(id, 'endDate', today.toISOString().split('T')[0]);
+  const [language, setLanguage] = useNodeState(id, 'language', 'English');
   const [open, setOpen] = useState(false);
+  const [languageOpen, setLanguageOpen] = useState(false);
   
   const { currentFlowId } = useFlowContext();
   const nodeContext = useNodeContext();
@@ -229,6 +243,7 @@ export function PortfolioStartNode({
         model_provider: undefined,
         // Pass portfolio positions to backend
         portfolio_positions: portfolioPositions,
+        language,
       });
     } else {
       // Use the regular hedge fund API for single run
@@ -251,6 +266,7 @@ export function PortfolioStartNode({
         initial_cash: parseFloat(initialCash) || 100000,
         // Pass portfolio positions to backend
         portfolio_positions: portfolioPositions,
+        language,
       });
     }
   };
@@ -358,6 +374,51 @@ export function PortfolioStartNode({
                     Add Position
                   </Button>
                 </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="text-subtitle text-primary flex items-center gap-1">
+                  Output Language
+                </div>
+                <Popover open={languageOpen} onOpenChange={setLanguageOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={languageOpen}
+                      className="w-full justify-between h-10 px-3 py-2 bg-node border border-border hover:bg-accent"
+                    >
+                      <span className="text-subtitle">
+                        {SUPPORTED_LANGUAGES.find((l) => l.value === language)?.label || 'English'}
+                      </span>
+                      <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0 bg-node border border-border shadow-lg">
+                    <Command className="bg-node">
+                      <CommandList className="bg-node">
+                        <CommandEmpty>No language found.</CommandEmpty>
+                        <CommandGroup>
+                          {SUPPORTED_LANGUAGES.map((lang) => (
+                            <CommandItem
+                              key={lang.value}
+                              value={lang.value}
+                              className={cn(
+                                "cursor-pointer bg-node hover:bg-accent",
+                                language === lang.value
+                              )}
+                              onSelect={(currentValue) => {
+                                setLanguage(currentValue);
+                                setLanguageOpen(false);
+                              }}
+                            >
+                              {lang.label}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
               </div>
               <div className="flex flex-col gap-2">
                 <div className="text-subtitle text-primary flex items-center gap-1">

--- a/app/frontend/src/services/types.ts
+++ b/app/frontend/src/services/types.ts
@@ -40,9 +40,11 @@ export interface BaseHedgeFundRequest {
   graph_edges: GraphEdge[];
   agent_models?: AgentModelConfig[];
   model_name?: string;
-  model_provider?: ModelProvider;
+  model_provider?: string;  // accept any provider string, not just the limited enum
   margin_requirement?: number;
   portfolio_positions?: PortfolioPosition[];
+  api_keys?: Record<string, string>;
+  language?: string;
 }
 
 export interface HedgeFundRequest extends BaseHedgeFundRequest {

--- a/src/cli/input.py
+++ b/src/cli/input.py
@@ -9,8 +9,21 @@ from src.utils.analysts import ANALYST_ORDER
 from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider, find_model_by_name
 from src.utils.ollama import ensure_ollama_and_model
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
+
+
+SUPPORTED_LANGUAGES = [
+    ("English", "English"),
+    ("中文 (Chinese)", "Chinese"),
+    ("日本語 (Japanese)", "Japanese"),
+    ("한국어 (Korean)", "Korean"),
+    ("Français (French)", "French"),
+    ("Deutsch (German)", "German"),
+    ("Español (Spanish)", "Spanish"),
+    ("Português (Portuguese)", "Portuguese"),
+    ("Русский (Russian)", "Russian"),
+]
 
 
 def add_common_args(
@@ -41,6 +54,13 @@ def add_common_args(
     if include_ollama:
         parser.add_argument("--ollama", action="store_true", help="Use Ollama for local LLM inference")
     parser.add_argument("--model", type=str, required=False, help="Model name to use (e.g., gpt-4o)")
+    parser.add_argument(
+        "--language",
+        type=str,
+        required=False,
+        default=None,
+        help="Output language for LLM responses (e.g., English, Chinese, Japanese)",
+    )
     return parser
 
 
@@ -187,6 +207,33 @@ def select_model(use_ollama: bool, model_flag: str | None = None) -> tuple[str, 
     return model_name, model_provider or ""
 
 
+def select_language(language_flag: str | None = None) -> str:
+    if language_flag:
+        print(f"\nOutput language: {Fore.CYAN}{language_flag}{Style.RESET_ALL}\n")
+        return language_flag
+
+    choice = questionary.select(
+        "Select output language:",
+        choices=[questionary.Choice(display, value=value) for display, value in SUPPORTED_LANGUAGES],
+        default="English",
+        style=questionary.Style(
+            [
+                ("selected", "fg:green bold"),
+                ("pointer", "fg:green bold"),
+                ("highlighted", "fg:green"),
+                ("answer", "fg:green bold"),
+            ]
+        ),
+    ).ask()
+
+    if not choice:
+        print("\n\nInterrupt received. Exiting...")
+        sys.exit(0)
+
+    print(f"\nOutput language: {Fore.CYAN}{choice}{Style.RESET_ALL}\n")
+    return choice
+
+
 def resolve_dates(start_date: str | None, end_date: str | None, *, default_months_back: int | None = None) -> tuple[str, str]:
     if start_date:
         try:
@@ -219,6 +266,7 @@ class CLIInputs:
     end_date: str
     initial_cash: float
     margin_requirement: float
+    language: str = "English"
     show_reasoning: bool = False
     show_agent_graph: bool = False
     raw_args: Optional[argparse.Namespace] = None
@@ -269,6 +317,7 @@ def parse_cli_inputs(
         "analysts": getattr(args, "analysts", None),
     })
     model_name, model_provider = select_model(getattr(args, "ollama", False), getattr(args, "model", None))
+    language = select_language(getattr(args, "language", None))
     start_date, end_date = resolve_dates(getattr(args, "start_date", None), getattr(args, "end_date", None), default_months_back=default_months_back)
 
     return CLIInputs(
@@ -280,6 +329,7 @@ def parse_cli_inputs(
         end_date=end_date,
         initial_cash=getattr(args, "initial_cash", 100000.0),
         margin_requirement=getattr(args, "margin_requirement", 0.0),
+        language=language,
         show_reasoning=getattr(args, "show_reasoning", False),
         show_agent_graph=getattr(args, "show_agent_graph", False),
         raw_args=args,

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -5,19 +5,9 @@
     "provider": "xAI"
   },
   {
-    "display_name": "DeepSeek V4 Pro",
-    "model_name": "deepseek-v4-pro",
-    "provider": "DeepSeek"
-  },
-  {
     "display_name": "GPT-5.5",
     "model_name": "gpt-5.5",
     "provider": "OpenAI"
-  },
-  {
-    "display_name": "Kimi K2.6",
-    "model_name": "kimi-k2.6",
-    "provider": "Kimi"
   },
   {
     "display_name": "Claude Opus 4.7",
@@ -28,5 +18,105 @@
     "display_name": "Gemini 3.1 Pro",
     "model_name": "gemini-3.1-pro-preview",
     "provider": "Google"
+  },
+  {
+    "display_name": "Tencent Auto (tc-code-latest)",
+    "model_name": "tc-code-latest",
+    "provider": "TencentCodingPlan"
+  },
+  {
+    "display_name": "Tencent HY 2.0 Instruct",
+    "model_name": "hunyuan-2.0-instruct",
+    "provider": "TencentCodingPlan"
+  },
+  {
+    "display_name": "Tencent HY 2.0 Think",
+    "model_name": "hunyuan-2.0-thinking",
+    "provider": "TencentCodingPlan"
+  },
+  {
+    "display_name": "MiniMax M2.5 (TencentCodingPlan)",
+    "model_name": "minimax-m2.5",
+    "provider": "TencentCodingPlan"
+  },
+  {
+    "display_name": "Kimi K2.5 (TencentCodingPlan)",
+    "model_name": "kimi-k2.5",
+    "provider": "TencentCodingPlan"
+  },
+  {
+    "display_name": "GLM-5 (TencentCodingPlan)",
+    "model_name": "glm-5",
+    "provider": "TencentCodingPlan"
+  },
+  {
+    "display_name": "DeepSeek V4 Pro (TencentMaas)",
+    "model_name": "deepseek-v4-pro",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "DeepSeek V4 Flash (TencentMaas)",
+    "model_name": "deepseek-v4-flash",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "DeepSeek V3.2 (TencentMaas)",
+    "model_name": "deepseek-v3.2",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "DeepSeek V3.1 Terminus (TencentMaas)",
+    "model_name": "deepseek-v3.1-terminus",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "DeepSeek R1-0528 (TencentMaas)",
+    "model_name": "deepseek-r1-0528",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "HY 3 Preview (TencentMaas)",
+    "model_name": "hy3-preview",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "HY 2.0 Instruct (TencentMaas)",
+    "model_name": "hunyuan-2.0-instruct-20251111",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "HY 2.0 Think (TencentMaas)",
+    "model_name": "hunyuan-2.0-thinking-20251109",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "Kimi K2.6 (TencentMaas)",
+    "model_name": "kimi-k2.6",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "Kimi K2.5 (TencentMaas)",
+    "model_name": "kimi-k2.5",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "GLM-5.1 (TencentMaas)",
+    "model_name": "glm-5.1",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "GLM-5 Turbo (TencentMaas)",
+    "model_name": "glm-5-turbo",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "MiniMax M2.7 (TencentMaas)",
+    "model_name": "minimax-m2.7",
+    "provider": "TencentMaas"
+  },
+  {
+    "display_name": "MiniMax M2.5 (TencentMaas)",
+    "model_name": "minimax-m2.5",
+    "provider": "TencentMaas"
   }
 ]

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -31,6 +31,8 @@ class ModelProvider(str, Enum):
     GIGACHAT = "GigaChat"
     AZURE_OPENAI = "Azure OpenAI"
     XAI = "xAI"
+    TENCENT_CODING_PLAN = "TencentCodingPlan"
+    TENCENT_MAAS = "TencentMaas"
 
 
 class LLMModel(BaseModel):
@@ -50,6 +52,11 @@ class LLMModel(BaseModel):
 
     def has_json_mode(self) -> bool:
         """Check if the model supports JSON mode"""
+        # TencentMaaS / TencentCodingPlan use full OpenAI-compatible protocol
+        # — they support JSON mode regardless of the underlying model name.
+        if self.provider in (ModelProvider.TENCENT_MAAS, ModelProvider.TENCENT_CODING_PLAN):
+            return True
+        # The official DeepSeek API and Gemini don't reliably support JSON mode
         if self.is_deepseek() or self.is_gemini():
             return False
         # Only certain Ollama models support JSON mode
@@ -61,8 +68,8 @@ class LLMModel(BaseModel):
         return True
 
     def is_deepseek(self) -> bool:
-        """Check if the model is a DeepSeek model"""
-        return self.model_name.startswith("deepseek")
+        """Check if the model is a DeepSeek model (official DeepSeek API)"""
+        return self.model_name.startswith("deepseek") and self.provider == ModelProvider.DEEPSEEK
 
     def is_kimi(self) -> bool:
         """Check if the model is a Kimi (Moonshot) model"""
@@ -75,6 +82,14 @@ class LLMModel(BaseModel):
     def is_ollama(self) -> bool:
         """Check if the model is an Ollama model"""
         return self.provider == ModelProvider.OLLAMA
+
+    def is_tencent_coding_plan(self) -> bool:
+        """Check if the model is a Tencent Coding Plan model"""
+        return self.provider == ModelProvider.TENCENT_CODING_PLAN
+
+    def is_tencent_maas(self) -> bool:
+        """Check if the model is a Tencent TokenHub MaaS model"""
+        return self.provider == ModelProvider.TENCENT_MAAS
 
 
 # Load models from JSON file
@@ -250,6 +265,20 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             print(f"Azure Deployment Name Error: Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
             raise ValueError("Azure OpenAI deployment name not found.  Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
         return AzureChatOpenAI(azure_endpoint=azure_endpoint, azure_deployment=azure_deployment_name, api_key=api_key, api_version="2024-10-21")
+    elif model_provider == ModelProvider.TENCENT_CODING_PLAN:
+        api_key = (api_keys or {}).get("TENCENT_CODING_API_KEY") or os.getenv("TENCENT_CODING_API_KEY")
+        if not api_key:
+            print(f"API Key Error: Please make sure TENCENT_CODING_API_KEY is set in your .env file or provided via API keys.")
+            raise ValueError("Tencent Coding Plan API key not found. Please make sure TENCENT_CODING_API_KEY is set in your .env file.")
+        base_url = os.getenv("TENCENT_CODING_BASE_URL", "https://api.lkeap.cloud.tencent.com/coding/v3")
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)
+    elif model_provider == ModelProvider.TENCENT_MAAS:
+        api_key = (api_keys or {}).get("TENCENT_MAAS_API_KEY") or os.getenv("TENCENT_MAAS_API_KEY")
+        if not api_key:
+            print(f"API Key Error: Please make sure TENCENT_MAAS_API_KEY is set in your .env file or provided via API keys.")
+            raise ValueError("Tencent TokenHub MaaS API key not found. Please make sure TENCENT_MAAS_API_KEY is set in your .env file.")
+        base_url = os.getenv("TENCENT_MAAS_BASE_URL", "https://tokenhub.tencentmaas.com/v1")
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)
     else:
         raise ValueError(
             f"Unsupported model provider: {model_provider}. "

--- a/src/main.py
+++ b/src/main.py
@@ -52,6 +52,7 @@ def run_hedge_fund(
     selected_analysts: list[str] = [],
     model_name: str = "gpt-4.1",
     model_provider: str = "OpenAI",
+    language: str = "English",
 ):
     # Start progress tracking
     progress.start()
@@ -79,6 +80,7 @@ def run_hedge_fund(
                     "show_reasoning": show_reasoning,
                     "model_name": model_name,
                     "model_provider": model_provider,
+                    "language": language,
                 },
             },
         )
@@ -175,5 +177,6 @@ if __name__ == "__main__":
         selected_analysts=inputs.selected_analysts,
         model_name=inputs.model_name,
         model_provider=inputs.model_provider,
+        language=inputs.language,
     )
     print_trading_output(result)

--- a/src/utils/display.py
+++ b/src/utils/display.py
@@ -3,6 +3,61 @@ from tabulate import tabulate
 from .analysts import ANALYST_ORDER
 import os
 import json
+import unicodedata
+import tabulate as _tabulate_module
+
+# Enable wide-character (CJK) support in tabulate so table borders align correctly
+try:
+    _tabulate_module.WIDE_CHARS_MODE = True
+except AttributeError:
+    pass
+
+
+def _display_width(s: str) -> int:
+    """Return the visual terminal column-width of a string.
+
+    CJK 全角字符（W / F 类型）占 2 列，其余占 1 列。
+    ANSI 转义序列（colorama 颜色）不占宽度，直接跳过。
+    """
+    # Strip ANSI escape codes before measuring
+    import re
+    plain = re.sub(r'\x1b\[[0-9;]*m', '', s)
+    width = 0
+    for ch in plain:
+        eaw = unicodedata.east_asian_width(ch)
+        width += 2 if eaw in ('W', 'F') else 1
+    return width
+
+
+def _wrap_text(text: str, max_width: int = 60) -> str:
+    """Wrap text to *max_width* terminal columns, CJK-aware.
+
+    Preserves existing newlines (paragraph breaks) and handles
+    mixed CJK / ASCII content correctly.
+    """
+    result_lines = []
+    for paragraph in text.split('\n'):
+        words = paragraph.split()
+        if not words:
+            result_lines.append('')
+            continue
+        current_line = ''
+        current_width = 0
+        for word in words:
+            word_width = _display_width(word)
+            if current_width == 0:
+                current_line = word
+                current_width = word_width
+            elif current_width + 1 + word_width <= max_width:
+                current_line += ' ' + word
+                current_width += 1 + word_width
+            else:
+                result_lines.append(current_line)
+                current_line = word
+                current_width = word_width
+        if current_line:
+            result_lines.append(current_line)
+    return '\n'.join(result_lines)
 
 
 def sort_agent_signals(signals):
@@ -67,24 +122,7 @@ def print_trading_output(result: dict) -> None:
                     # Convert any other type to string
                     reasoning_str = str(reasoning)
                 
-                # Wrap long reasoning text to make it more readable
-                wrapped_reasoning = ""
-                current_line = ""
-                # Use a fixed width of 60 characters to match the table column width
-                max_line_length = 60
-                for word in reasoning_str.split():
-                    if len(current_line) + len(word) + 1 > max_line_length:
-                        wrapped_reasoning += current_line + "\n"
-                        current_line = word
-                    else:
-                        if current_line:
-                            current_line += " " + word
-                        else:
-                            current_line = word
-                if current_line:
-                    wrapped_reasoning += current_line
-                
-                reasoning_str = wrapped_reasoning
+                reasoning_str = _wrap_text(reasoning_str)
 
             table_data.append(
                 [
@@ -120,23 +158,7 @@ def print_trading_output(result: dict) -> None:
 
         # Get reasoning and format it
         reasoning = decision.get("reasoning", "")
-        # Wrap long reasoning text to make it more readable
-        wrapped_reasoning = ""
-        if reasoning:
-            current_line = ""
-            # Use a fixed width of 60 characters to match the table column width
-            max_line_length = 60
-            for word in reasoning.split():
-                if len(current_line) + len(word) + 1 > max_line_length:
-                    wrapped_reasoning += current_line + "\n"
-                    current_line = word
-                else:
-                    if current_line:
-                        current_line += " " + word
-                    else:
-                        current_line = word
-            if current_line:
-                wrapped_reasoning += current_line
+        wrapped_reasoning = _wrap_text(reasoning) if reasoning else ""
 
         decision_data = [
             ["Action", f"{action_color}{action}{Style.RESET_ALL}"],
@@ -233,25 +255,8 @@ def print_trading_output(result: dict) -> None:
             # Convert any other type to string
             reasoning_str = str(portfolio_manager_reasoning)
             
-        # Wrap long reasoning text to make it more readable
-        wrapped_reasoning = ""
-        current_line = ""
-        # Use a fixed width of 60 characters to match the table column width
-        max_line_length = 60
-        for word in reasoning_str.split():
-            if len(current_line) + len(word) + 1 > max_line_length:
-                wrapped_reasoning += current_line + "\n"
-                current_line = word
-            else:
-                if current_line:
-                    current_line += " " + word
-                else:
-                    current_line = word
-        if current_line:
-            wrapped_reasoning += current_line
-            
         print(f"\n{Fore.WHITE}{Style.BRIGHT}Portfolio Strategy:{Style.RESET_ALL}")
-        print(f"{Fore.CYAN}{wrapped_reasoning}{Style.RESET_ALL}")
+        print(f"{Fore.CYAN}{_wrap_text(reasoning_str)}{Style.RESET_ALL}")
 
 
 def print_backtest_results(table_rows: list) -> None:

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -2,9 +2,40 @@
 
 import json
 from pydantic import BaseModel
+from langchain_core.messages import SystemMessage
 from src.llm.models import get_model, get_model_info
 from src.utils.progress import progress
 from src.graph.state import AgentState
+
+
+def inject_language_into_prompt(prompt, language: str):
+    """
+    Append a language instruction to the system message in a LangChain PromptValue.
+    Returns the modified message list, or the original prompt unchanged if language
+    is English / empty (the default) or if the prompt cannot be parsed.
+    """
+    if not language or language.lower() == "english":
+        return prompt
+
+    lang_note = (
+        f"\n\nIMPORTANT: You MUST respond entirely in {language}. "
+        f"All analysis, reasoning, and output text must be written in {language}."
+    )
+    try:
+        messages = prompt.to_messages()
+        result = []
+        injected = False
+        for msg in messages:
+            if msg.type == "system" and not injected:
+                result.append(SystemMessage(content=msg.content + lang_note))
+                injected = True
+            else:
+                result.append(msg)
+        if not injected:
+            result.insert(0, SystemMessage(content=lang_note.strip()))
+        return result
+    except Exception:
+        return prompt
 
 
 def call_llm(
@@ -48,6 +79,10 @@ def call_llm(
     model_info = get_model_info(model_name, model_provider)
     llm = get_model(model_name, model_provider, api_keys)
 
+    # Inject language instruction into the prompt if a non-English language is selected
+    language = state.get("metadata", {}).get("language", "English") if state else "English"
+    prompt = inject_language_into_prompt(prompt, language)
+
     # For non-JSON support models, we can use structured output
     if not (model_info and not model_info.has_json_mode()):
         llm = llm.with_structured_output(
@@ -70,12 +105,20 @@ def call_llm(
                 return result
 
         except Exception as e:
+            # Truncate long error messages for display (e.g. full HTTP response bodies)
+            error_summary = str(e)
+            if len(error_summary) > 120:
+                error_summary = error_summary[:120] + "..."
+
             if agent_name:
-                progress.update_status(agent_name, None, f"Error - retry {attempt + 1}/{max_retries}")
+                if attempt < max_retries - 1:
+                    progress.update_status(agent_name, None, f"Retry {attempt + 1}/{max_retries}: {error_summary}")
+                else:
+                    progress.update_status(agent_name, None, f"Failed after {max_retries} retries: {error_summary}")
+
+            print(f"[{agent_name or 'LLM'}] Attempt {attempt + 1}/{max_retries} failed: {e}")
 
             if attempt == max_retries - 1:
-                print(f"Error in LLM call after {max_retries} attempts: {e}")
-                # Use default_factory if provided, otherwise create a basic default
                 if default_factory:
                     return default_factory()
                 return create_default_response(pydantic_model)


### PR DESCRIPTION
## Summary

- **Tencent Cloud Coding Plan** (`TencentCodingPlan` provider): OpenAI-compatible integration via `https://api.lkeap.cloud.tencent.com/coding/v3`. Supports `tc-code-latest`, `hunyuan-2.0-instruct`, `hunyuan-2.0-thinking`, `minimax-m2.5`, `kimi-k2.5`, `glm-5`.
- **Tencent TokenHub MaaS** (`TencentMaas` provider): OpenAI-compatible integration via `https://tokenhub.tencentmaas.com/v1`. Supports `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-v3.2`, `hunyuan-2.0-instruct`, `kimi-k2.6`, `glm-5.1`, `minimax-m2.7`, and more.
- **Multi-language LLM output**: CLI `--language` flag + interactive prompt; web UI "Output Language" dropdown on the Portfolio Analyzer node. Language instruction is injected into every agent system prompt at runtime — no per-agent changes required.
- **CJK terminal formatting**: `unicodedata` east-asian-width aware text wrapping and `tabulate.WIDE_CHARS_MODE = True` for correct table alignment when output is Chinese/Japanese/Korean.
- **API key management improvements**: backend `main.py` explicitly loads `.env` from project root; `ApiKeyService` syncs env-var keys to DB on startup and merges DB + env fallbacks; frontend settings page exposes `TENCENT_CODING_API_KEY` and `TENCENT_MAAS_API_KEY`.
- **`has_json_mode()` fix**: TencentMaas DeepSeek models now correctly use JSON mode (only the official `DEEPSEEK` provider opts out).
- **`.env.example` updated** with Tencent Coding Plan and TokenHub MaaS placeholder entries.

## New environment variables

| Variable | Description |
|---|---|
| `TENCENT_CODING_API_KEY` | Tencent Cloud Coding Plan API key (format: `sk-sp-xxxx`) |
| `TENCENT_CODING_BASE_URL` | `https://api.lkeap.cloud.tencent.com/coding/v3` |
| `TENCENT_MAAS_API_KEY` | Tencent TokenHub MaaS API key |
| `TENCENT_MAAS_BASE_URL` | `https://tokenhub.tencentmaas.com/v1` |

## Test plan

- [ ] Run CLI with `--language Chinese` and verify LLM output is in Chinese with correctly aligned terminal tables
- [ ] Run CLI without `--language` flag and verify interactive language prompt appears (default: English)
- [ ] Select a `TencentCodingPlan` model in CLI and confirm successful API call
- [ ] Select a `TencentMaas` model in CLI and confirm successful API call
- [ ] Open web UI, verify "Output Language" dropdown appears on Portfolio Analyzer node
- [ ] Run a single analysis via web UI with Chinese selected and verify output language
- [ ] Check Settings page shows `TENCENT_CODING_API_KEY` and `TENCENT_MAAS_API_KEY` fields

Made with [Cursor](https://cursor.com)