### PR TITLE
fix: align default LLM model with registry

### DIFF
--- a/app/backend/models/schemas.py
+++ b/app/backend/models/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional, Dict, Any
-from src.llm.models import ModelProvider
+from src.llm.models import DEFAULT_MODEL_NAME, ModelProvider
 from enum import Enum
 from app.backend.services.graph import extract_base_agent_key
 
@@ -63,7 +63,7 @@ class BaseHedgeFundRequest(BaseModel):
     graph_nodes: List[GraphNode]
     graph_edges: List[GraphEdge]
     agent_models: Optional[List[AgentModelConfig]] = None
-    model_name: Optional[str] = "gpt-4.1"
+    model_name: Optional[str] = DEFAULT_MODEL_NAME
     model_provider: Optional[ModelProvider] = ModelProvider.OPENAI
     margin_requirement: float = 0.0
     portfolio_positions: Optional[List[PortfolioPosition]] = None

--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -14,6 +14,7 @@ from src.tools.api import (
 )
 from app.backend.services.graph import run_graph_async, parse_hedge_fund_response
 from app.backend.services.portfolio import create_portfolio
+from src.llm.models import DEFAULT_MODEL_NAME
 
 class BacktestService:
     """
@@ -29,7 +30,7 @@ class BacktestService:
         start_date: str,
         end_date: str,
         initial_capital: float,
-        model_name: str = "gpt-4.1",
+        model_name: str = DEFAULT_MODEL_NAME,
         model_provider: str = "OpenAI",
         request: dict = {},
     ):

--- a/app/frontend/src/data/models.ts
+++ b/app/frontend/src/data/models.ts
@@ -28,12 +28,12 @@ export const getModels = async (): Promise<LanguageModel[]> => {
 };
 
 /**
- * Get the default model (GPT-4.1) from the models list
+ * Get the default model from the models list
  */
 export const getDefaultModel = async (): Promise<LanguageModel | null> => {
   try {
     const models = await getModels();
-    return models.find(model => model.model_name === "gpt-4.1") || models[0] || null;
+    return models.find(model => model.model_name === "gpt-5.5") || models[0] || null;
   } catch (error) {
     console.error('Failed to get default model:', error);
     return null;

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -105,6 +105,9 @@ ollama_models_json_path = current_dir / "ollama_models.json"
 # Load available models from JSON
 AVAILABLE_MODELS = load_models_from_json(str(models_json_path))
 
+# Keep fallback defaults aligned with the checked-in model registry.
+DEFAULT_MODEL_NAME = "gpt-5.5"
+
 # Load Ollama models from JSON
 OLLAMA_MODELS = load_models_from_json(str(ollama_models_json_path))
 

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ import questionary
 from src.agents.portfolio_manager import portfolio_management_agent
 from src.agents.risk_manager import risk_management_agent
 from src.graph.state import AgentState
+from src.llm.models import DEFAULT_MODEL_NAME
 from src.utils.display import print_trading_output
 from src.utils.analysts import ANALYST_ORDER, get_analyst_nodes
 from src.utils.progress import progress
@@ -50,7 +51,7 @@ def run_hedge_fund(
     portfolio: dict,
     show_reasoning: bool = False,
     selected_analysts: list[str] = [],
-    model_name: str = "gpt-4.1",
+    model_name: str = DEFAULT_MODEL_NAME,
     model_provider: str = "OpenAI",
 ):
     # Start progress tracking

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -2,7 +2,7 @@
 
 import json
 from pydantic import BaseModel
-from src.llm.models import get_model, get_model_info
+from src.llm.models import DEFAULT_MODEL_NAME, get_model, get_model_info
 from src.utils.progress import progress
 from src.graph.state import AgentState
 
@@ -35,7 +35,7 @@ def call_llm(
         model_name, model_provider = get_agent_model_config(state, agent_name)
     else:
         # Use system defaults when no state or agent_name is provided
-        model_name = "gpt-4.1"
+        model_name = DEFAULT_MODEL_NAME
         model_provider = "OPENAI"
 
     # Extract API keys from state if available
@@ -175,7 +175,7 @@ def get_agent_model_config(state, agent_name):
             return model_name, model_provider.value if hasattr(model_provider, 'value') else str(model_provider)
     
     # Fall back to global configuration (system defaults)
-    model_name = state.get("metadata", {}).get("model_name") or "gpt-4.1"
+    model_name = state.get("metadata", {}).get("model_name") or DEFAULT_MODEL_NAME
     model_provider = state.get("metadata", {}).get("model_provider") or "OPENAI"
     
     # Convert enum to string if necessary

--- a/tests/test_llm_default_model.py
+++ b/tests/test_llm_default_model.py
@@ -1,0 +1,75 @@
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MODEL_NAME = "gpt-5.5"
+
+
+def _parse(path: str) -> ast.Module:
+    return ast.parse((ROOT / path).read_text())
+
+
+def test_default_model_is_registered() -> None:
+    models = json.loads((ROOT / "src/llm/api_models.json").read_text())
+    registered_model_names = {model["model_name"] for model in models}
+
+    assert DEFAULT_MODEL_NAME in registered_model_names
+
+
+def test_python_defaults_use_registered_default_constant() -> None:
+    models_tree = _parse("src/llm/models.py")
+    default_assignments = [
+        node
+        for node in models_tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "DEFAULT_MODEL_NAME" for target in node.targets)
+    ]
+    assert default_assignments
+    assert isinstance(default_assignments[0].value, ast.Constant)
+    assert default_assignments[0].value.value == DEFAULT_MODEL_NAME
+
+    schemas_tree = _parse("app/backend/models/schemas.py")
+    request_class = next(
+        node
+        for node in schemas_tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "BaseHedgeFundRequest"
+    )
+    model_name_field = next(
+        node
+        for node in request_class.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "model_name"
+    )
+    assert isinstance(model_name_field.value, ast.Name)
+    assert model_name_field.value.id == "DEFAULT_MODEL_NAME"
+
+    llm_tree = _parse("src/utils/llm.py")
+    fallback_assignments = [
+        node
+        for node in ast.walk(llm_tree)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "model_name" for target in node.targets)
+        and any(isinstance(child, ast.Name) and child.id == "DEFAULT_MODEL_NAME" for child in ast.walk(node.value))
+    ]
+    assert len(fallback_assignments) >= 2
+
+
+def test_frontend_default_model_matches_registry_default() -> None:
+    frontend_models = (ROOT / "app/frontend/src/data/models.ts").read_text()
+
+    assert f'model.model_name === "{DEFAULT_MODEL_NAME}"' in frontend_models
+    assert 'model.model_name === "gpt-4.1"' not in frontend_models
+
+
+def test_no_python_runtime_default_references_removed_model() -> None:
+    checked_files = [
+        ROOT / "src/main.py",
+        ROOT / "src/utils/llm.py",
+        ROOT / "app/backend/models/schemas.py",
+        ROOT / "app/backend/services/backtest_service.py",
+    ]
+
+    for path in checked_files:
+        assert "gpt-4.1" not in path.read_text(), path


### PR DESCRIPTION
## Summary
- add a shared `DEFAULT_MODEL_NAME` for the checked-in API model registry
- replace stale `gpt-4.1` defaults in backend request schemas, backtesting service, CLI run path, and `call_llm` fallback with the registered default
- update the frontend default selector and add a regression test so runtime defaults cannot drift away from `api_models.json`

## Notes
This intentionally does not change the `OPENAI`/`OpenAI` provider fallback because that is already covered by #511.

## Tests
- `python3 -m pytest tests/test_llm_default_model.py -q`
- `git diff --check origin/main...HEAD`
