### PR TITLE
fix: accept ticker CLI alias

### DIFF
--- a/src/backtesting/cli.py
+++ b/src/backtesting/cli.py
@@ -17,7 +17,7 @@ from src.utils.ollama import ensure_ollama_and_model
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run backtesting engine (modular)")
-    parser.add_argument("--tickers", type=str, required=False, help="Comma-separated tickers")
+    parser.add_argument("--tickers", "--ticker", dest="tickers", type=str, required=False, help="Comma-separated tickers")
     parser.add_argument(
         "--end-date",
         type=str,

--- a/src/cli/input.py
+++ b/src/cli/input.py
@@ -22,6 +22,8 @@ def add_common_args(
 ) -> argparse.ArgumentParser:
     parser.add_argument(
         "--tickers",
+        "--ticker",
+        dest="tickers",
         type=str,
         required=require_tickers,
         help="Comma-separated list of stock ticker symbols (e.g., AAPL,MSFT,GOOGL)",

--- a/tests/test_cli_ticker_alias.py
+++ b/tests/test_cli_ticker_alias.py
@@ -1,0 +1,48 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _add_argument_calls(path: str):
+    tree = ast.parse((ROOT / path).read_text())
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "add_argument"
+    ]
+
+
+def _string_args(call: ast.Call) -> set[str]:
+    return {arg.value for arg in call.args if isinstance(arg, ast.Constant) and isinstance(arg.value, str)}
+
+
+def _keyword_value(call: ast.Call, name: str) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+            return keyword.value.value
+    return None
+
+
+def test_shared_cli_accepts_documented_ticker_alias() -> None:
+    ticker_calls = [
+        call
+        for call in _add_argument_calls("src/cli/input.py")
+        if {"--tickers", "--ticker"}.issubset(_string_args(call))
+    ]
+
+    assert ticker_calls
+    assert _keyword_value(ticker_calls[0], "dest") == "tickers"
+
+
+def test_backtesting_cli_accepts_documented_ticker_alias() -> None:
+    ticker_calls = [
+        call
+        for call in _add_argument_calls("src/backtesting/cli.py")
+        if {"--tickers", "--ticker"}.issubset(_string_args(call))
+    ]
+
+    assert ticker_calls
+    assert _keyword_value(ticker_calls[0], "dest") == "tickers"


### PR DESCRIPTION
## Summary
- accept `--ticker` as an alias for the existing `--tickers` argument in both CLI parsers
- keep the parsed destination as `args.tickers`, so existing code paths keep working
- add a regression test for the documented alias contract

## Why
README, Docker Compose, and the Docker wrapper scripts currently document/invoke `--ticker`, but the Python parsers only accepted `--tickers`. That makes the documented quickstart path fail at argparse before the app can run.

## Tests
- `python3 -m pytest tests/test_cli_ticker_alias.py -q`
- `git diff --check origin/main...HEAD`
