### PR TITLE
fix: bound call_llm invocations

### DIFF
--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -1,10 +1,30 @@
 """Helper functions for LLM"""
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 import json
 from pydantic import BaseModel
 from src.llm.models import get_model, get_model_info
 from src.utils.progress import progress
 from src.graph.state import AgentState
+
+
+DEFAULT_LLM_TIMEOUT_SECONDS = 120
+
+
+def invoke_with_timeout(llm, prompt: any, timeout: float | None):
+    """Invoke an LLM with a bounded wait so retry/fallback logic can run."""
+    if timeout is None or timeout <= 0:
+        return llm.invoke(prompt)
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(llm.invoke, prompt)
+    try:
+        return future.result(timeout=timeout)
+    except FutureTimeoutError as exc:
+        future.cancel()
+        raise TimeoutError(f"LLM call timed out after {timeout} seconds") from exc
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
 
 
 def call_llm(
@@ -14,6 +34,7 @@ def call_llm(
     state: AgentState | None = None,
     max_retries: int = 3,
     default_factory=None,
+    timeout: float | None = DEFAULT_LLM_TIMEOUT_SECONDS,
 ) -> BaseModel:
     """
     Makes an LLM call with retry logic, handling both JSON supported and non-JSON supported models.
@@ -25,6 +46,7 @@ def call_llm(
         state: Optional state object to extract agent-specific model configuration
         max_retries: Maximum number of retries (default: 3)
         default_factory: Optional factory function to create default response on failure
+        timeout: Maximum seconds to wait for each LLM invocation before retrying (default: 120)
 
     Returns:
         An instance of the specified Pydantic model
@@ -58,8 +80,9 @@ def call_llm(
     # Call the LLM with retries
     for attempt in range(max_retries):
         try:
-            # Call the LLM
-            result = llm.invoke(prompt)
+            # Call the LLM with a bounded wait so existing retry/fallback paths
+            # can recover when a provider hangs instead of returning an error.
+            result = invoke_with_timeout(llm, prompt, timeout)
 
             # For non-JSON support models, we need to extract and parse the JSON manually
             if model_info and not model_info.has_json_mode():

--- a/tests/test_llm_timeout.py
+++ b/tests/test_llm_timeout.py
@@ -1,0 +1,100 @@
+import time
+import sys
+import types
+
+from pydantic import BaseModel
+
+
+def install_optional_dependency_stubs():
+    provider_classes = {
+        "langchain_anthropic": ["ChatAnthropic"],
+        "langchain_deepseek": ["ChatDeepSeek"],
+        "langchain_google_genai": ["ChatGoogleGenerativeAI"],
+        "langchain_groq": ["ChatGroq"],
+        "langchain_xai": ["ChatXAI"],
+        "langchain_openai": ["ChatOpenAI", "AzureChatOpenAI"],
+        "langchain_gigachat": ["GigaChat"],
+        "langchain_ollama": ["ChatOllama"],
+    }
+    for module_name, class_names in provider_classes.items():
+        if module_name not in sys.modules:
+            module = types.ModuleType(module_name)
+            for class_name in class_names:
+                setattr(module, class_name, type(class_name, (), {}))
+            sys.modules[module_name] = module
+
+    if "langchain_core" not in sys.modules:
+        sys.modules["langchain_core"] = types.ModuleType("langchain_core")
+    if "langchain_core.messages" not in sys.modules:
+        messages = types.ModuleType("langchain_core.messages")
+        messages.BaseMessage = type("BaseMessage", (), {})
+        sys.modules["langchain_core.messages"] = messages
+
+
+install_optional_dependency_stubs()
+
+from src.utils import llm as llm_utils
+
+
+class DummyResponse(BaseModel):
+    decision: str
+
+
+class FakeModelInfo:
+    def has_json_mode(self):
+        return True
+
+
+class FakeLLM:
+    def __init__(self, invoke_func):
+        self.invoke_func = invoke_func
+
+    def with_structured_output(self, *_args, **_kwargs):
+        return self
+
+    def invoke(self, prompt):
+        return self.invoke_func(prompt)
+
+
+def install_fake_model(monkeypatch, invoke_func):
+    monkeypatch.setattr(llm_utils, "get_model_info", lambda *_args, **_kwargs: FakeModelInfo())
+    monkeypatch.setattr(llm_utils, "get_model", lambda *_args, **_kwargs: FakeLLM(invoke_func))
+
+
+def test_call_llm_retries_after_timeout(monkeypatch):
+    calls = 0
+
+    def invoke(_prompt):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            time.sleep(0.05)
+            return DummyResponse(decision="late")
+        return DummyResponse(decision="ok")
+
+    install_fake_model(monkeypatch, invoke)
+
+    result = llm_utils.call_llm("prompt", DummyResponse, max_retries=2, timeout=0.01)
+
+    assert result == DummyResponse(decision="ok")
+    assert calls == 2
+
+
+def test_call_llm_uses_default_factory_after_timeout(monkeypatch):
+    def invoke(_prompt):
+        time.sleep(0.05)
+        return DummyResponse(decision="late")
+
+    install_fake_model(monkeypatch, invoke)
+
+    started = time.monotonic()
+    result = llm_utils.call_llm(
+        "prompt",
+        DummyResponse,
+        max_retries=1,
+        timeout=0.01,
+        default_factory=lambda: DummyResponse(decision="fallback"),
+    )
+
+    assert result == DummyResponse(decision="fallback")
+    assert time.monotonic() - started < 0.5


### PR DESCRIPTION
## Summary

- Fixes https://github.com/virattt/ai-hedge-fund/issues/618
- add a configurable per-attempt timeout to `call_llm()`
- route timeout failures through the existing retry and fallback handling instead of letting the first provider call hang indefinitely
- add regression coverage for retry-after-timeout and final `default_factory` fallback

## Testing

- `python3 -m pytest tests/test_llm_timeout.py -q`
- `python3 -m py_compile src/utils/llm.py tests/test_llm_timeout.py`
- `git diff --check origin/main...HEAD`
- conflict-marker scan on changed files
