### PR TITLE
fix: handle empty price list in prices_to_df

### DIFF
--- a/src/agents/nassim_taleb.py
+++ b/src/agents/nassim_taleb.py
@@ -45,7 +45,7 @@ def nassim_taleb_agent(state: AgentState, agent_id: str = "nassim_taleb_agent"):
     for ticker in tickers:
         progress.update_status(agent_id, ticker, "Fetching price data")
         prices = get_prices(ticker, start_date, end_date, api_key=api_key)
-        prices_df = prices_to_df(prices) if prices else pd.DataFrame()
+        prices_df = prices_to_df(prices)
 
         progress.update_status(agent_id, ticker, "Fetching financial metrics")
         metrics = get_financial_metrics(ticker, end_date, period="ttm", limit=10, api_key=api_key)

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -350,6 +350,13 @@ def get_market_cap(
 
 def prices_to_df(prices: list[Price]) -> pd.DataFrame:
     """Convert prices to a DataFrame."""
+    if not prices:
+        # Return an empty frame with the expected schema so callers can safely
+        # rely on the columns/index instead of hitting a KeyError on "time".
+        empty = pd.DataFrame(columns=["open", "close", "high", "low", "volume", "time"])
+        empty.index = pd.DatetimeIndex([], name="Date")
+        return empty
+
     df = pd.DataFrame([p.model_dump() for p in prices])
     df["Date"] = pd.to_datetime(df["time"])
     df.set_index("Date", inplace=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from src.data.models import Price
+from src.tools.api import prices_to_df
+
+EXPECTED_COLUMNS = ["open", "close", "high", "low", "volume", "time"]
+
+
+class TestPricesToDf:
+    """Test prices_to_df DataFrame conversion."""
+
+    def test_converts_prices_to_dataframe(self):
+        prices = [
+            Price(open=1.0, close=2.0, high=3.0, low=0.5, volume=100, time="2024-01-01"),
+            Price(open=2.0, close=3.0, high=4.0, low=1.5, volume=200, time="2024-01-02"),
+        ]
+        df = prices_to_df(prices)
+        assert list(df.columns) == EXPECTED_COLUMNS
+        assert df.index.name == "Date"
+        assert len(df) == 2
+        # Index should be sorted ascending by date
+        assert df.index.is_monotonic_increasing
+
+    def test_empty_prices_returns_empty_dataframe(self):
+        """An empty price list (e.g. API failure or no data) must not raise."""
+        df = prices_to_df([])
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+        assert list(df.columns) == EXPECTED_COLUMNS
+        assert df.index.name == "Date"
+        assert isinstance(df.index, pd.DatetimeIndex)


### PR DESCRIPTION
get_prices() returns an empty list whenever the data API fails or has no data for the requested range. Passing that empty list to prices_to_df() built an empty DataFrame with no columns, so `df["time"]` raised `KeyError: 'time'`, crashing risk_manager, technicals, and the backtester's get_price_data() path.

nassim_taleb already worked around this at the call site with `prices_to_df(prices) if prices else pd.DataFrame()`. Fix it at the source instead: return an empty DataFrame with the expected columns and a DatetimeIndex named "Date" when there are no prices, then simplify the nassim_taleb call site to match the other agents.

Adds tests for both the populated and empty cases.