### PR TITLE
feat: added .env support for AI_HEDGE_FUND_LLM_MODEL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,9 @@ XAI_API_KEY=your-xai-api-key
 # Get your Moonshot API key from https://platform.moonshot.ai/
 # Mainland China users: set MOONSHOT_BASE_URL=https://api.moonshot.cn/v1
 MOONSHOT_API_KEY=your-moonshot-api-key
+
+# Optional non-interactive LLM defaults. Set the provider when using a custom
+# model id that is not listed in hedge_fund/llm/api_models.json.
+# HEDGE_FUND_LLM_MODEL=z-ai/glm-5.2
+# HEDGE_FUND_LLM_PROVIDER=OpenRouter
+# OPENROUTER_API_KEY=your-openrouter-api-key

--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ aihf ~/.hedge-fund/mandates/example.yaml --tickers AAPL,MSFT --backtest
 
 A mandate is the desk — strategies, staff, risk, capital, cadence — and never names tickers; `--tickers` says what to point it at for this run.
 
+Select a registered model with `--model`, or configure non-interactive defaults
+in your shell, project `.env`, or `~/.hedge-fund/.env`:
+
+```bash
+HEDGE_FUND_LLM_MODEL=z-ai/glm-5.2
+HEDGE_FUND_LLM_PROVIDER=OpenRouter
+OPENROUTER_API_KEY=your-openrouter-api-key
+```
+
+An explicit `--model` takes precedence over `HEDGE_FUND_LLM_MODEL`.
+`HEDGE_FUND_LLM_PROVIDER` overrides provider inference and accepts
+case-insensitive display or enum-style names, such as `OpenRouter` or
+`OPENROUTER`.
+
 ## Development
 
 ```bash

--- a/hedge_fund/llm/__init__.py
+++ b/hedge_fund/llm/__init__.py
@@ -16,6 +16,7 @@ from hedge_fund.llm.registry import (
     env_var_for,
     is_supported,
     load_api_models,
+    normalize_provider,
     provider_for,
 )
 from hedge_fund.llm.watch import ThesisStream
@@ -35,6 +36,7 @@ __all__ = [
     "is_supported",
     "load_api_models",
     "make_llm",
+    "normalize_provider",
     "prompt_key",
     "provider_for",
 ]

--- a/hedge_fund/llm/api_models.json
+++ b/hedge_fund/llm/api_models.json
@@ -30,6 +30,11 @@
     "provider": "OpenAI"
   },
   {
+    "display_name": "GLM-5.2",
+    "model_name": "z-ai/glm-5.2",
+    "provider": "OpenRouter"
+  },
+  {
     "display_name": "Kimi K2.6",
     "model_name": "kimi-k2.6",
     "provider": "Kimi"

--- a/hedge_fund/llm/client.py
+++ b/hedge_fund/llm/client.py
@@ -21,6 +21,7 @@ from hedge_fund.llm.registry import (
     SUPPORTED_PROVIDERS,
     env_var_for,
     is_supported,
+    normalize_provider,
     provider_for,
 )
 
@@ -91,12 +92,13 @@ def make_llm(
 ) -> ChatLLM:
     """Build the client for a model id, routed by the registry's provider.
 
-    The id comes from the caller, else HEDGE_FUND_LLM_MODEL, else DEFAULT_MODEL — the
-    same seam the TUI's picker writes to. Raises with the name of the missing
-    environment variable, because that is the only thing the user can act on.
+    The id comes from the caller, else HEDGE_FUND_LLM_MODEL, else DEFAULT_MODEL.
+    HEDGE_FUND_LLM_PROVIDER overrides registry-based provider inference, which
+    allows unlisted model ids to use an explicitly selected transport.
     """
     model = model or os.environ.get("HEDGE_FUND_LLM_MODEL") or DEFAULT_MODEL
-    provider = provider_for(model)
+    provider_override = os.environ.get("HEDGE_FUND_LLM_PROVIDER")
+    provider = normalize_provider(provider_override) if provider_override else provider_for(model)
     if provider is None:
         # Unlisted ids still work: a model newer than the registry should not
         # need a code change. Anthropic is the default transport.
@@ -117,6 +119,15 @@ def make_llm(
         from langchain_openai import ChatOpenAI
         chat = ChatOpenAI(model=model, api_key=api_key, timeout=timeout,
                           max_retries=1, base_url=os.getenv("OPENAI_API_BASE"))
+    elif provider == "OpenRouter":
+        from langchain_openai import ChatOpenAI
+        chat = ChatOpenAI(
+            model=model,
+            api_key=api_key,
+            timeout=timeout,
+            max_retries=1,
+            base_url="https://openrouter.ai/api/v1",
+        )
     elif provider == "DeepSeek":
         from langchain_deepseek import ChatDeepSeek
         chat = ChatDeepSeek(model=model, api_key=api_key, timeout=timeout,

--- a/hedge_fund/llm/registry.py
+++ b/hedge_fund/llm/registry.py
@@ -20,6 +20,7 @@ API_MODELS_PATH = Path(__file__).resolve().parent / "api_models.json"
 PROVIDER_ENV_VARS = {
     "Anthropic": "ANTHROPIC_API_KEY",
     "OpenAI": "OPENAI_API_KEY",
+    "OpenRouter": "OPENROUTER_API_KEY",
     "xAI": "XAI_API_KEY",
     "DeepSeek": "DEEPSEEK_API_KEY",
     "Google": "GOOGLE_API_KEY",
@@ -54,6 +55,19 @@ def provider_for(model_id: str) -> str | None:
     a hand-exported HEDGE_FUND_LLM_MODEL should not be second-guessed."""
     return next((prov for _, mid, prov in load_api_models() if mid == model_id),
                 None)
+
+
+def normalize_provider(provider: str) -> str:
+    """Normalize display or enum-style provider names from the environment."""
+    normalized = "".join(char for char in provider if char.isalnum()).casefold()
+    for canonical in PROVIDER_ENV_VARS:
+        candidate = "".join(char for char in canonical if char.isalnum()).casefold()
+        if normalized == candidate:
+            return canonical
+    raise ValueError(
+        f"Unsupported HEDGE_FUND_LLM_PROVIDER {provider!r}. "
+        f"Supported: {', '.join(sorted(SUPPORTED_PROVIDERS))}."
+    )
 
 
 def env_var_for(provider: str) -> str | None:

--- a/hedge_fund/llm/test_client.py
+++ b/hedge_fund/llm/test_client.py
@@ -65,12 +65,12 @@ def test_unlisted_model_falls_back_to_anthropic(keyed):
 
 
 @pytest.mark.parametrize("provider", ["OpenRouter", "openrouter", "OPENROUTER"])
-def test_provider_env_overrides_registry_for_custom_model(provider, monkeypatch, keyed):
+def test_provider_env_overrides_registry(provider, monkeypatch, keyed):
     monkeypatch.setenv("HEDGE_FUND_LLM_PROVIDER", provider)
 
-    llm = make_llm("z-ai/glm-5.2")
+    llm = make_llm("gpt-5.5")
 
-    assert llm.model == "z-ai/glm-5.2"
+    assert llm.model == "gpt-5.5"
     assert str(llm._chat.openai_api_base).rstrip("/") == "https://openrouter.ai/api/v1"
 
 

--- a/hedge_fund/llm/test_client.py
+++ b/hedge_fund/llm/test_client.py
@@ -25,6 +25,7 @@ def keyed(monkeypatch):
     for env_var in PROVIDER_ENV_VARS.values():
         monkeypatch.setenv(env_var, "test-key-not-real")
     monkeypatch.delenv("HEDGE_FUND_LLM_MODEL", raising=False)
+    monkeypatch.delenv("HEDGE_FUND_LLM_PROVIDER", raising=False)
     monkeypatch.delenv("OPENAI_API_BASE", raising=False)
 
 
@@ -61,6 +62,23 @@ def test_unlisted_model_falls_back_to_anthropic(keyed):
     code change first."""
     llm = make_llm("claude-something-unreleased")
     assert llm.model == "claude-something-unreleased"
+
+
+@pytest.mark.parametrize("provider", ["OpenRouter", "openrouter", "OPENROUTER"])
+def test_provider_env_overrides_registry_for_custom_model(provider, monkeypatch, keyed):
+    monkeypatch.setenv("HEDGE_FUND_LLM_PROVIDER", provider)
+
+    llm = make_llm("z-ai/glm-5.2")
+
+    assert llm.model == "z-ai/glm-5.2"
+    assert str(llm._chat.openai_api_base).rstrip("/") == "https://openrouter.ai/api/v1"
+
+
+def test_invalid_provider_env_lists_supported_values(monkeypatch, keyed):
+    monkeypatch.setenv("HEDGE_FUND_LLM_PROVIDER", "not-a-provider")
+
+    with pytest.raises(ValueError, match="Unsupported HEDGE_FUND_LLM_PROVIDER"):
+        make_llm("custom-model")
 
 
 def test_kimi_accepts_moonshot_key(monkeypatch):

--- a/hedge_fund/test_run.py
+++ b/hedge_fund/test_run.py
@@ -1,0 +1,14 @@
+import sys
+
+from hedge_fund import run
+from hedge_fund.tui.app import HedgeFundApp
+
+
+def test_cli_model_overrides_env_default(monkeypatch):
+    monkeypatch.setenv("HEDGE_FUND_LLM_MODEL", "claude-sonnet-5")
+    monkeypatch.setattr(sys, "argv", ["aihf", "--model", "gpt-5"])
+    monkeypatch.setattr(HedgeFundApp, "run", lambda self: None)
+
+    run.main()
+
+    assert run.os.environ["HEDGE_FUND_LLM_MODEL"] == "gpt-5"

--- a/hedge_fund/test_run.py
+++ b/hedge_fund/test_run.py
@@ -6,9 +6,11 @@ from hedge_fund.tui.app import HedgeFundApp
 
 def test_cli_model_overrides_env_default(monkeypatch):
     monkeypatch.setenv("HEDGE_FUND_LLM_MODEL", "claude-sonnet-5")
-    monkeypatch.setattr(sys, "argv", ["aihf", "--model", "gpt-5"])
+    monkeypatch.setenv("HEDGE_FUND_LLM_PROVIDER", "OpenRouter")
+    monkeypatch.setattr(sys, "argv", ["aihf", "--model", "gpt-5.5"])
     monkeypatch.setattr(HedgeFundApp, "run", lambda self: None)
 
     run.main()
 
-    assert run.os.environ["HEDGE_FUND_LLM_MODEL"] == "gpt-5"
+    assert run.os.environ["HEDGE_FUND_LLM_MODEL"] == "gpt-5.5"
+    assert run.os.environ["HEDGE_FUND_LLM_PROVIDER"] == "OpenRouter"


### PR DESCRIPTION
## Summary

Adds non-interactive LLM model and provider configuration using the environment-variable naming adopted by the current upstream architecture:

```env
HEDGE_FUND_LLM_MODEL=z-ai/glm-5.2
HEDGE_FUND_LLM_PROVIDER=OpenRouter
OPENROUTER_API_KEY=your-openrouter-api-key
```

## Changes

- Adds `HEDGE_FUND_LLM_PROVIDER` as an explicit override for registry-based provider inference.
- Preserves CLI precedence: an explicit `--model` overrides `HEDGE_FUND_LLM_MODEL`.
- Normalizes provider values case-insensitively, accepting display and enum-style names such as `OpenRouter`, `openrouter`, and `OPENROUTER`.
- Adds OpenRouter client routing through its OpenAI-compatible API endpoint.
- Registers `z-ai/glm-5.2` so OpenRouter is available through the model registry and TUI.
- Documents model and provider defaults in the README and `.env.example`.
- Adds regression coverage for:
  - CLI model precedence
  - Explicit provider overrides
  - Provider normalization
  - Invalid provider values
  - OpenRouter client construction

## Precedence

1. Explicit `--model`
2. `HEDGE_FUND_LLM_MODEL`
3. Built-in default model

When `HEDGE_FUND_LLM_PROVIDER` is set, it overrides provider inference from the model registry. This allows custom or unlisted model IDs to be routed through a specific provider.

## Testing

```text
181 passed, 38 skipped
```