### PR TITLE
fix(llm): handle LangChain Pydantic content blocks in extract_json_from_response

### DIFF
--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -111,6 +111,8 @@ def extract_json_from_response(content) -> dict | None:
     try:
         # Reasoning models (e.g. Anthropic extended thinking) return content as a
         # list of blocks (thinking + text). Concatenate the text blocks.
+        # LangChain returns these as Pydantic objects (TextBlock / ThinkingBlock),
+        # not plain dicts, so we check both dict and attribute access.
         if isinstance(content, list):
             parts = []
             for block in content:
@@ -118,6 +120,8 @@ def extract_json_from_response(content) -> dict | None:
                     parts.append(block)
                 elif isinstance(block, dict) and block.get("type") == "text":
                     parts.append(block.get("text", ""))
+                elif getattr(block, "type", None) == "text":
+                    parts.append(getattr(block, "text", ""))
             content = "\n".join(parts)
         # 1. Try markdown code block with ```json
         json_start = content.find("```json")


### PR DESCRIPTION
**Describe the bug**

When `claude-fable-5` is selected, every agent silently returns the default error response instead of real analysis.

`extract_json_from_response` iterates content blocks checking `isinstance(block, dict)`, but LangChain's `ChatAnthropic` returns blocks as Pydantic objects (`TextBlock`, `ThinkingBlock`) — not plain dicts. So the text content is silently dropped, `parts` stays empty, and all JSON extraction fails.

**Fix**

Added a `getattr` fallback after the dict branch:

```python
elif getattr(block, "type", None) == "text":
    parts.append(getattr(block, "text", ""))
```

This handles `TextBlock` objects from `langchain-anthropic` without touching the existing `str` and `dict` paths.

**Additional context**

Change is 2 lines in one function — no other behaviour affected.