### PR TITLE
fix(graph): skip edges from unregistered frontend nodes to prevent compile crash

### DIFF
--- a/app/backend/services/graph.py
+++ b/app/backend/services/graph.py
@@ -40,54 +40,67 @@ def create_graph(graph_nodes: list, graph_edges: list) -> StateGraph:
 
     # Get analyst nodes from the configuration
     analyst_nodes = {key: (f"{key}_agent", config["agent_func"]) for key, config in ANALYST_CONFIG.items()}
-    
+
     # Extract agent IDs from graph structure
     agent_ids = [node.id for node in graph_nodes]
-    agent_ids_set = set(agent_ids)
-    
+
     # Track which nodes are portfolio managers for special handling
     portfolio_manager_nodes = set()
-    
+
+    # Track nodes actually registered with the StateGraph so edges are only
+    # added between nodes that exist.  The frontend may send nodes whose
+    # base key is not in ANALYST_CONFIG (e.g. a visual "stock-analyzer" node);
+    # those are silently skipped during add_node, but their IDs still appear
+    # in agent_ids.  Using agent_ids_set for the edge filter therefore causes
+    # graph.add_edge to reference an unknown node and raises a ValueError.
+    registered_nodes = {"start_node"}
+
     # Add agent nodes
     for unique_agent_id in agent_ids:
         base_agent_key = extract_base_agent_key(unique_agent_id)
-        
+
         # Track portfolio manager nodes for special handling (before ANALYST_CONFIG check)
         if base_agent_key == "portfolio_manager":
             portfolio_manager_nodes.add(unique_agent_id)
             continue
-            
+
         # Skip if the base agent key is not in our analyst configuration
         if base_agent_key not in ANALYST_CONFIG:
             continue
-            
+
         node_name, node_func = analyst_nodes[base_agent_key]
         agent_function = create_agent_function(node_func, unique_agent_id)
         graph.add_node(unique_agent_id, agent_function)
-    
+        registered_nodes.add(unique_agent_id)
+
     # Add portfolio manager nodes and their corresponding risk managers
     risk_manager_nodes = {}  # Map portfolio manager ID to risk manager ID
     for portfolio_manager_id in portfolio_manager_nodes:
         portfolio_manager_function = create_agent_function(portfolio_management_agent, portfolio_manager_id)
         graph.add_node(portfolio_manager_id, portfolio_manager_function)
-        
+        registered_nodes.add(portfolio_manager_id)
+
         # Create unique risk manager for this portfolio manager
         suffix = portfolio_manager_id.split('_')[-1]
         risk_manager_id = f"risk_management_agent_{suffix}"
         risk_manager_nodes[portfolio_manager_id] = risk_manager_id
-        
+
         # Add the risk manager node
         risk_manager_function = create_agent_function(risk_management_agent, risk_manager_id)
         graph.add_node(risk_manager_id, risk_manager_function)
+        registered_nodes.add(risk_manager_id)
 
     # Build connections based on React Flow graph structure
     nodes_with_incoming_edges = set()
     nodes_with_outgoing_edges = set()
     direct_to_portfolio_managers = {}  # Map analyst ID to portfolio manager ID for direct connections
-    
+
     for edge in graph_edges:
-        # Only consider edges between agent nodes (not from stock tickers)
-        if edge.source in agent_ids_set and edge.target in agent_ids_set:
+        # Only wire edges between nodes that were actually added to the graph.
+        # Frontend payloads may include visual-only nodes (e.g. stock-analyzer)
+        # whose base keys are not in ANALYST_CONFIG; those nodes are skipped
+        # above, so referencing them in add_edge would raise "Unknown node".
+        if edge.source in registered_nodes and edge.target in registered_nodes:
             source_base_key = extract_base_agent_key(edge.source)
             target_base_key = extract_base_agent_key(edge.target)
             

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,151 @@
+"""Regression tests for create_graph edge-wiring correctness (bug #635).
+
+Uses importlib to load graph.py directly so we don't need the full project
+installed; project-internal modules (src.*, app.*) are stubbed via sys.modules
+before the load; third-party packages (langgraph, langchain_core) are the real
+installed versions.
+"""
+
+import sys
+import types
+import importlib.util
+from types import SimpleNamespace
+from pathlib import Path
+from typing import TypedDict
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub project-internal modules ONLY (NOT langgraph / langchain_core).
+# They must be registered before graph.py is executed.
+# ---------------------------------------------------------------------------
+
+def _pkg(path: str):
+    mod = types.ModuleType(path)
+    mod.__path__ = []
+    mod.__package__ = path
+    sys.modules[path] = mod
+    return mod
+
+
+def _mod(path: str, **attrs):
+    mod = types.ModuleType(path)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[path] = mod
+    return mod
+
+
+for _p in ("src", "src.agents", "src.utils", "src.graph",
+           "app", "app.backend", "app.backend.services"):
+    _pkg(_p)
+
+_mod("src.agents.portfolio_manager",
+     portfolio_management_agent=MagicMock(name="pm_agent"))
+_mod("src.agents.risk_manager",
+     risk_management_agent=MagicMock(name="rm_agent"))
+_mod("src.main", start=MagicMock(name="start"))
+class _AgentState(TypedDict):
+    messages: list
+
+_mod("src.graph.state", AgentState=_AgentState)
+_mod("src.utils.analysts", ANALYST_CONFIG={})
+_mod("app.backend.services.agent_service",
+     create_agent_function=MagicMock(
+         side_effect=lambda fn, nid: MagicMock(name=f"agent_{nid}")))
+
+# Now import the real langgraph (langchain_core is a real installed dep).
+from langgraph.graph import StateGraph  # noqa: E402
+
+# Load graph.py directly without going through the package machinery.
+_GRAPH_FILE = (
+    Path(__file__).parent.parent / "app" / "backend" / "services" / "graph.py"
+)
+_spec = importlib.util.spec_from_file_location("_graph_under_test", _GRAPH_FILE)
+_graph_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_graph_mod)
+create_graph = _graph_mod.create_graph
+
+
+# ---------------------------------------------------------------------------
+# Minimal ANALYST_CONFIG for tests
+# ---------------------------------------------------------------------------
+
+TEST_CONFIG = {
+    "warren_buffett": {"agent_func": MagicMock()},
+    "fundamentals_analyst": {"agent_func": MagicMock()},
+    "portfolio_manager": {"agent_func": MagicMock()},
+}
+
+
+def _node(nid: str): return SimpleNamespace(id=nid)
+def _edge(src: str, tgt: str): return SimpleNamespace(source=src, target=tgt)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCreateGraphUnknownNode:
+    """Regression tests for the unknown-node edge crash (GitHub issue #635)."""
+
+    def test_edge_from_unknown_frontend_node_does_not_raise(self):
+        """
+        A React Flow 'stock-analyzer' visual node is not in ANALYST_CONFIG, so
+        create_graph skips it during add_node().  Before the fix its ID was
+        still forwarded to add_edge(), raising:
+
+            ValueError: Found edge starting at unknown node 'stock-analyzer-node_t4jxmp'
+
+        After the fix, only edges between *registered* nodes are wired.
+        """
+        analyst_id = "warren_buffett_abc123"
+        pm_id      = "portfolio_manager_xyz999"
+        unknown_id = "stock-analyzer-node_t4jxmp"
+
+        nodes = [_node(analyst_id), _node(pm_id), _node(unknown_id)]
+        edges = [
+            _edge(unknown_id, analyst_id),   # was triggering the crash
+            _edge(analyst_id, pm_id),
+        ]
+
+        with patch.object(_graph_mod, "ANALYST_CONFIG", TEST_CONFIG):
+            graph = create_graph(nodes, edges)
+            # compile() is where langgraph validates edge connectivity;
+            # it raises ValueError if any edge references an unknown node.
+            graph.compile()  # must not raise
+
+        assert isinstance(graph, StateGraph)
+
+    def test_edge_to_unknown_frontend_node_does_not_raise(self):
+        """Edges where the *target* is unregistered are also dropped cleanly."""
+        analyst_id = "fundamentals_analyst_aaa111"
+        pm_id      = "portfolio_manager_bbb222"
+        unknown_id = "stock-analyzer-node_ccc333"
+
+        nodes = [_node(analyst_id), _node(pm_id), _node(unknown_id)]
+        edges = [
+            _edge(analyst_id, unknown_id),   # target not registered
+            _edge(analyst_id, pm_id),
+        ]
+
+        with patch.object(_graph_mod, "ANALYST_CONFIG", TEST_CONFIG):
+            graph = create_graph(nodes, edges)
+            graph.compile()  # must not raise
+
+        assert isinstance(graph, StateGraph)
+
+    def test_all_valid_nodes_graph_unchanged(self):
+        """Sanity: a graph with only ANALYST_CONFIG nodes still compiles correctly."""
+        analyst_id = "warren_buffett_abc123"
+        pm_id      = "portfolio_manager_xyz999"
+
+        nodes = [_node(analyst_id), _node(pm_id)]
+        edges = [_edge(analyst_id, pm_id)]
+
+        with patch.object(_graph_mod, "ANALYST_CONFIG", TEST_CONFIG):
+            graph = create_graph(nodes, edges)
+            graph.compile()  # must not raise
+
+        assert isinstance(graph, StateGraph)


### PR DESCRIPTION
## Description

`create_graph()` crashes when the React Flow payload contains a visual node whose
base key is **not** in `ANALYST_CONFIG` (e.g. the generic `stock-analyzer` node the
frontend appends).

Such nodes are correctly skipped during the `add_node()` phase, but their IDs still
appeared in `agent_ids_set`, which was then used as the edge filter:

```python
# Before
if edge.source in agent_ids_set and edge.target in agent_ids_set:
    ...
    graph.add_edge(edge.source, edge.target)   # unknown node crashes at compile()
```

`langgraph` raises at `graph.compile()` time (called implicitly by `graph.invoke()`):

```
ValueError: Found edge starting at unknown node 'stock-analyzer-node_t4jxmp'
```

### Root cause (from issue #635)

> Found edge starting at unknown node 'stock-analyzer-node_t4jxmp'

The stock-analyzer node is sent by the frontend React Flow graph but is not a member
of `ANALYST_CONFIG`, so it is skipped in the add-node loop. Its ID remains in
`agent_ids_set`, so when an edge touches it the else-branch calls `add_edge` against
an unregistered node.

### Fix

Track which nodes were **actually added** to the StateGraph in a `registered_nodes`
set. Use that set as the gate for edge wiring instead of `agent_ids_set`. Edges
whose source or target was not registered are silently skipped.

Closes #635

## Changes Made

- `app/backend/services/graph.py`: replace `agent_ids_set` edge filter with
  `registered_nodes` (tracks nodes passed to `graph.add_node()`).
- `tests/test_graph.py`: new regression tests — 2 fail on the original code,
  all 3 pass after the fix.

## Testing

```
.venv/bin/pytest tests/test_graph.py -v
# 3 passed (fails-before / passes-after verified)
```

Prepared with AI assistance (Claude Code). Every change reviewed and understood line-by-line.