### PR TITLE
feat: add optional Adanos sentiment data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Get your Financial Datasets API key from https://financialdatasets.ai/
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 
+# Optional: enrich the sentiment analyst with social, news, and prediction-market sentiment
+# Get your Adanos API key from https://adanos.org/register
+ADANOS_API_KEY=your-adanos-api-key
+
 # For running LLMs hosted by openai (GPT 5, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ OPENAI_API_KEY=your-openai-api-key
 
 # For getting financial data to power the hedge fund
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+
+# Optional: enrich the sentiment analyst with Adanos market sentiment
+ADANOS_API_KEY=your-adanos-api-key
 ```
 
 **Important**: You must set at least one LLM API key (e.g. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, or `DEEPSEEK_API_KEY`) for the hedge fund to work. 

--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -1,11 +1,14 @@
-from langchain_core.messages import HumanMessage
-from src.graph.state import AgentState, show_agent_reasoning
-from src.utils.progress import progress
-import pandas as pd
-import numpy as np
 import json
+import os
+
+from langchain_core.messages import HumanMessage
+import numpy as np
+import pandas as pd
+
+from src.graph.state import AgentState, show_agent_reasoning
+from src.tools.api import get_adanos_market_sentiment, get_insider_trades, get_company_news
 from src.utils.api_key import get_api_key_from_state
-from src.tools.api import get_insider_trades, get_company_news
+from src.utils.progress import progress
 
 
 ##### Sentiment Agent #####
@@ -13,8 +16,10 @@ def sentiment_analyst_agent(state: AgentState, agent_id: str = "sentiment_analys
     """Analyzes market sentiment and generates trading signals for multiple tickers."""
     data = state.get("data", {})
     end_date = data.get("end_date")
+    start_date = data.get("start_date")
     tickers = data.get("tickers")
     api_key = get_api_key_from_state(state, "FINANCIAL_DATASETS_API_KEY")
+    adanos_api_key = get_api_key_from_state(state, "ADANOS_API_KEY") or os.environ.get("ADANOS_API_KEY")
     # Initialize sentiment analysis for each ticker
     sentiment_analysis = {}
 
@@ -44,20 +49,36 @@ def sentiment_analyst_agent(state: AgentState, agent_id: str = "sentiment_analys
         sentiment = pd.Series([n.sentiment for n in company_news]).dropna()
         news_signals = np.where(sentiment == "negative", "bearish", 
                               np.where(sentiment == "positive", "bullish", "neutral")).tolist()
+
+        adanos_sentiment = []
+        adanos_signals = []
+        if adanos_api_key:
+            progress.update_status(agent_id, ticker, "Fetching Adanos market sentiment")
+            adanos_sentiment = get_adanos_market_sentiment(
+                ticker=ticker,
+                start_date=start_date,
+                end_date=end_date,
+                api_key=adanos_api_key,
+            )
+            adanos_scores = pd.Series([source.sentiment_score for source in adanos_sentiment]).dropna()
+            adanos_signals = np.where(adanos_scores < -0.1, "bearish", np.where(adanos_scores > 0.1, "bullish", "neutral")).tolist()
         
         progress.update_status(agent_id, ticker, "Combining signals")
         # Combine signals from both sources with weights
         insider_weight = 0.3
         news_weight = 0.7
+        adanos_weight = 1.0
         
         # Calculate weighted signal counts
         bullish_signals = (
             insider_signals.count("bullish") * insider_weight +
-            news_signals.count("bullish") * news_weight
+            news_signals.count("bullish") * news_weight +
+            adanos_signals.count("bullish") * adanos_weight
         )
         bearish_signals = (
             insider_signals.count("bearish") * insider_weight +
-            news_signals.count("bearish") * news_weight
+            news_signals.count("bearish") * news_weight +
+            adanos_signals.count("bearish") * adanos_weight
         )
 
         if bullish_signals > bearish_signals:
@@ -68,7 +89,7 @@ def sentiment_analyst_agent(state: AgentState, agent_id: str = "sentiment_analys
             overall_signal = "neutral"
 
         # Calculate confidence level based on the weighted proportion
-        total_weighted_signals = len(insider_signals) * insider_weight + len(news_signals) * news_weight
+        total_weighted_signals = len(insider_signals) * insider_weight + len(news_signals) * news_weight + len(adanos_signals) * adanos_weight
         confidence = 0  # Default confidence when there are no signals
         if total_weighted_signals > 0:
             confidence = round((max(bullish_signals, bearish_signals) / total_weighted_signals) * 100, 2)
@@ -108,6 +129,20 @@ def sentiment_analyst_agent(state: AgentState, agent_id: str = "sentiment_analys
                 "signal_determination": f"{'Bullish' if bullish_signals > bearish_signals else 'Bearish' if bearish_signals > bullish_signals else 'Neutral'} based on weighted signal comparison"
             }
         }
+        if adanos_sentiment:
+            adanos_sentiment_scores = [source.sentiment_score for source in adanos_sentiment if source.sentiment_score is not None]
+            reasoning["adanos_market_sentiment"] = {
+                "signal": "bullish" if adanos_signals.count("bullish") > adanos_signals.count("bearish") else "bearish" if adanos_signals.count("bearish") > adanos_signals.count("bullish") else "neutral",
+                "confidence": round(abs(sum(adanos_sentiment_scores) / len(adanos_sentiment_scores)) * 100) if adanos_sentiment_scores else 0,
+                "metrics": {
+                    "source_count": len(adanos_sentiment),
+                    "bullish_sources": adanos_signals.count("bullish"),
+                    "bearish_sources": adanos_signals.count("bearish"),
+                    "neutral_sources": adanos_signals.count("neutral"),
+                    "weight": adanos_weight,
+                    "sources": [source.model_dump() for source in adanos_sentiment],
+                },
+            }
 
         sentiment_analysis[ticker] = {
             "signal": overall_signal,

--- a/src/data/cache.py
+++ b/src/data/cache.py
@@ -7,6 +7,7 @@ class Cache:
         self._line_items_cache: dict[str, list[dict[str, any]]] = {}
         self._insider_trades_cache: dict[str, list[dict[str, any]]] = {}
         self._company_news_cache: dict[str, list[dict[str, any]]] = {}
+        self._adanos_sentiment_cache: dict[str, list[dict[str, any]]] = {}
 
     def _merge_data(self, existing: list[dict] | None, new_data: list[dict], key_field: str) -> list[dict]:
         """Merge existing and new data, avoiding duplicates based on a key field."""
@@ -60,6 +61,14 @@ class Cache:
     def set_company_news(self, ticker: str, data: list[dict[str, any]]):
         """Append new company news to cache."""
         self._company_news_cache[ticker] = self._merge_data(self._company_news_cache.get(ticker), data, key_field="date")
+
+    def get_adanos_sentiment(self, key: str) -> list[dict[str, any]] | None:
+        """Get cached Adanos sentiment if available."""
+        return self._adanos_sentiment_cache.get(key)
+
+    def set_adanos_sentiment(self, key: str, data: list[dict[str, any]]):
+        """Set cached Adanos sentiment for an exact ticker/date window."""
+        self._adanos_sentiment_cache[key] = data
 
 
 # Global cache instance

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -113,6 +113,17 @@ class CompanyNewsResponse(BaseModel):
     news: list[CompanyNews]
 
 
+class AdanosSentiment(BaseModel):
+    source: str
+    found: bool = False
+    buzz_score: float | None = None
+    sentiment_score: float | None = None
+    bullish_pct: int | None = None
+    bearish_pct: int | None = None
+    trend: str | None = None
+    activity_count: int | None = None
+
+
 class CompanyFacts(BaseModel):
     ticker: str
     name: str

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -4,11 +4,13 @@ import os
 import pandas as pd
 import requests
 import time
+from urllib.parse import quote, urlencode
 
 logger = logging.getLogger(__name__)
 
 from src.data.cache import get_cache
 from src.data.models import (
+    AdanosSentiment,
     CompanyNews,
     CompanyNewsResponse,
     FinancialMetrics,
@@ -24,6 +26,16 @@ from src.data.models import (
 
 # Global cache instance
 _cache = get_cache()
+
+ADANOS_BASE_URL = "https://api.adanos.org"
+ADANOS_STOCK_SOURCES = {
+    "reddit": "/reddit/stocks/v1/stock/{ticker}",
+    "x": "/x/stocks/v1/stock/{ticker}",
+    "news": "/news/stocks/v1/stock/{ticker}",
+    "polymarket": "/polymarket/stocks/v1/stock/{ticker}",
+}
+ADANOS_SOURCE_TIMEOUT_SECONDS = 5
+ADANOS_TOTAL_TIMEOUT_SECONDS = 12
 
 
 def _make_api_request(url: str, headers: dict, method: str = "GET", json_data: dict = None, max_retries: int = 3) -> requests.Response:
@@ -58,6 +70,94 @@ def _make_api_request(url: str, headers: dict, method: str = "GET", json_data: d
         
         # Return the response (whether success, other errors, or final 429)
         return response
+
+
+def _extract_adanos_activity_count(source: str, data: dict) -> int | None:
+    if source == "polymarket":
+        return data.get("trade_count")
+    return data.get("mentions")
+
+
+def _build_adanos_url(source: str, ticker: str, start_date: str | None, end_date: str | None) -> str:
+    path = ADANOS_STOCK_SOURCES[source].format(ticker=quote(ticker, safe=""))
+    params = {}
+    if start_date:
+        params["from"] = start_date
+    if end_date:
+        params["to"] = end_date
+    query = urlencode(params)
+    return f"{ADANOS_BASE_URL}{path}?{query}" if query else f"{ADANOS_BASE_URL}{path}"
+
+
+def get_adanos_market_sentiment(
+    ticker: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    api_key: str = None,
+) -> list[AdanosSentiment]:
+    """Fetch optional Adanos market sentiment by stock ticker.
+
+    Returns an empty list when ADANOS_API_KEY is not configured or when the
+    upstream service has no usable data, keeping the sentiment agent fail-open.
+    """
+    adanos_api_key = api_key or os.environ.get("ADANOS_API_KEY")
+    if not adanos_api_key:
+        return []
+
+    cache_key = f"{ticker}_{start_date or 'none'}_{end_date or 'none'}"
+    cached_data = _cache.get_adanos_sentiment(cache_key)
+    if cached_data is not None:
+        return [AdanosSentiment(**item) for item in cached_data]
+
+    headers = {"X-API-Key": adanos_api_key}
+    source_results: list[AdanosSentiment] = []
+    all_sources_successful = True
+    started_at = time.monotonic()
+
+    for source in ADANOS_STOCK_SOURCES:
+        remaining_seconds = ADANOS_TOTAL_TIMEOUT_SECONDS - (time.monotonic() - started_at)
+        if remaining_seconds <= 0:
+            all_sources_successful = False
+            break
+
+        url = _build_adanos_url(source, ticker, start_date, end_date)
+        try:
+            response = requests.get(url, headers=headers, timeout=min(ADANOS_SOURCE_TIMEOUT_SECONDS, remaining_seconds))
+            if response.status_code == 404:
+                continue
+            if response.status_code != 200:
+                all_sources_successful = False
+                continue
+            data = response.json()
+
+            if not isinstance(data, dict):
+                all_sources_successful = False
+                continue
+
+            if not data.get("found", False):
+                continue
+
+            source_results.append(
+                AdanosSentiment(
+                    source=source,
+                    found=True,
+                    buzz_score=data.get("buzz_score"),
+                    sentiment_score=data.get("sentiment_score"),
+                    bullish_pct=data.get("bullish_pct"),
+                    bearish_pct=data.get("bearish_pct"),
+                    trend=data.get("trend"),
+                    activity_count=_extract_adanos_activity_count(source, data),
+                )
+            )
+        except Exception as e:
+            all_sources_successful = False
+            logger.warning("Failed to fetch Adanos %s sentiment for %s: %s", source, ticker, e)
+            continue
+
+    if all_sources_successful:
+        _cache.set_adanos_sentiment(cache_key, [source.model_dump() for source in source_results])
+
+    return source_results
 
 
 def get_prices(ticker: str, start_date: str, end_date: str, api_key: str = None) -> list[Price]:

--- a/tests/test_adanos_sentiment.py
+++ b/tests/test_adanos_sentiment.py
@@ -1,0 +1,246 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from src.agents.sentiment import sentiment_analyst_agent
+from src.data.models import AdanosSentiment
+from src.tools.api import get_adanos_market_sentiment
+
+
+def _response(status_code: int, payload: dict | None = None):
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = payload or {}
+    return response
+
+
+@patch("src.tools.api.requests.get")
+@patch("src.tools.api._cache")
+def test_get_adanos_market_sentiment_fetches_available_sources(mock_cache, mock_get):
+    mock_cache.get_adanos_sentiment.return_value = None
+    mock_get.side_effect = [
+        _response(
+            200,
+            {
+                "found": True,
+                "buzz_score": 72.5,
+                "sentiment_score": 0.42,
+                "bullish_pct": 61,
+                "bearish_pct": 18,
+                "trend": "rising",
+                "mentions": 120,
+            },
+        ),
+        _response(200, {"found": False}),
+        _response(500),
+        _response(
+            200,
+            {
+                "found": True,
+                "buzz_score": 48.0,
+                "sentiment_score": -0.25,
+                "bullish_pct": 30,
+                "bearish_pct": 55,
+                "trend": "falling",
+                "trade_count": 12,
+            },
+        ),
+    ]
+
+    results = get_adanos_market_sentiment("TSLA", "2026-05-01", "2026-05-07", api_key="test-key")
+
+    assert [result.source for result in results] == ["reddit", "polymarket"]
+    assert results[0].activity_count == 120
+    assert results[1].activity_count == 12
+    assert mock_get.call_count == 4
+    first_url = mock_get.call_args_list[0].args[0]
+    assert first_url == "https://api.adanos.org/reddit/stocks/v1/stock/TSLA?from=2026-05-01&to=2026-05-07"
+    assert mock_get.call_args_list[0].kwargs["headers"] == {"X-API-Key": "test-key"}
+    assert mock_get.call_args_list[0].kwargs["timeout"] == 5
+    mock_cache.set_adanos_sentiment.assert_not_called()
+
+
+@patch("src.tools.api.requests.get")
+@patch("src.tools.api._cache")
+def test_get_adanos_market_sentiment_caches_complete_source_fetch(mock_cache, mock_get):
+    mock_cache.get_adanos_sentiment.return_value = None
+    mock_get.side_effect = [
+        _response(
+            200,
+            {
+                "found": True,
+                "buzz_score": 72.5,
+                "sentiment_score": 0.42,
+                "bullish_pct": 61,
+                "bearish_pct": 18,
+                "trend": "rising",
+                "mentions": 120,
+            },
+        ),
+        _response(200, {"found": False}),
+        _response(200, {"found": False}),
+        _response(200, {"found": False}),
+    ]
+
+    results = get_adanos_market_sentiment("TSLA", "2026-05-01", "2026-05-07", api_key="test-key")
+
+    assert [result.source for result in results] == ["reddit"]
+    mock_cache.set_adanos_sentiment.assert_called_once()
+
+
+@patch("src.tools.api.requests.get")
+@patch("src.tools.api._cache")
+def test_get_adanos_market_sentiment_caches_404_no_data_sources(mock_cache, mock_get):
+    mock_cache.get_adanos_sentiment.return_value = None
+    mock_get.side_effect = [
+        _response(
+            200,
+            {
+                "found": True,
+                "buzz_score": 72.5,
+                "sentiment_score": 0.42,
+                "bullish_pct": 61,
+                "bearish_pct": 18,
+                "trend": "rising",
+                "mentions": 120,
+            },
+        ),
+        _response(404),
+        _response(404),
+        _response(404),
+    ]
+
+    results = get_adanos_market_sentiment("TSLA", "2026-05-01", "2026-05-07", api_key="test-key")
+
+    assert [result.source for result in results] == ["reddit"]
+    mock_cache.set_adanos_sentiment.assert_called_once()
+
+
+@patch("src.tools.api.requests.get")
+@patch("src.tools.api._cache")
+def test_get_adanos_market_sentiment_encodes_ticker_path_segment(mock_cache, mock_get):
+    mock_cache.get_adanos_sentiment.return_value = None
+    mock_get.side_effect = [_response(404), _response(404), _response(404), _response(404)]
+
+    get_adanos_market_sentiment("BRK/B", "2026-05-01", "2026-05-07", api_key="test-key")
+
+    first_url = mock_get.call_args_list[0].args[0]
+    assert first_url == "https://api.adanos.org/reddit/stocks/v1/stock/BRK%2FB?from=2026-05-01&to=2026-05-07"
+
+
+@patch("src.tools.api.requests.get")
+@patch("src.tools.api._cache")
+def test_get_adanos_market_sentiment_skips_malformed_source_payloads(mock_cache, mock_get):
+    mock_cache.get_adanos_sentiment.return_value = None
+    mock_get.side_effect = [
+        _response(200, ["not", "an", "object"]),
+        _response(
+            200,
+            {
+                "found": True,
+                "buzz_score": {"bad": "shape"},
+                "sentiment_score": 0.2,
+            },
+        ),
+        _response(200, {"found": False}),
+        _response(200, {"found": False}),
+    ]
+
+    assert get_adanos_market_sentiment("TSLA", "2026-05-01", "2026-05-07", api_key="test-key") == []
+    mock_cache.set_adanos_sentiment.assert_not_called()
+
+
+@patch("src.tools.api.requests.get")
+@patch("src.tools.api._cache")
+def test_get_adanos_market_sentiment_uses_cache(mock_cache, mock_get):
+    mock_cache.get_adanos_sentiment.return_value = [
+        {
+            "source": "reddit",
+            "found": True,
+            "buzz_score": 72.5,
+            "sentiment_score": 0.42,
+            "bullish_pct": 61,
+            "bearish_pct": 18,
+            "trend": "rising",
+            "activity_count": 120,
+        }
+    ]
+
+    results = get_adanos_market_sentiment("TSLA", "2026-05-01", "2026-05-07", api_key="test-key")
+
+    assert [result.source for result in results] == ["reddit"]
+    assert results[0].sentiment_score == 0.42
+    mock_get.assert_not_called()
+    mock_cache.set_adanos_sentiment.assert_not_called()
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("src.tools.api.requests.get")
+def test_get_adanos_market_sentiment_skips_without_api_key(mock_get):
+    assert get_adanos_market_sentiment("TSLA") == []
+    mock_get.assert_not_called()
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("src.agents.sentiment.get_adanos_market_sentiment")
+@patch("src.agents.sentiment.get_company_news")
+@patch("src.agents.sentiment.get_insider_trades")
+def test_sentiment_agent_keeps_adanos_optional(mock_insider_trades, mock_company_news, mock_adanos):
+    mock_insider_trades.return_value = []
+    mock_company_news.return_value = []
+
+    state = {
+        "messages": [],
+        "data": {
+            "tickers": ["TSLA"],
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-07",
+            "analyst_signals": {},
+        },
+        "metadata": {"show_reasoning": False},
+    }
+
+    sentiment_analyst_agent(state)
+
+    mock_adanos.assert_not_called()
+    reasoning = state["data"]["analyst_signals"]["sentiment_analyst_agent"]["TSLA"]["reasoning"]
+    assert "adanos_market_sentiment" not in reasoning
+
+
+@patch("src.agents.sentiment.get_adanos_market_sentiment")
+@patch("src.agents.sentiment.get_company_news")
+@patch("src.agents.sentiment.get_insider_trades")
+def test_sentiment_agent_uses_adanos_market_sentiment(mock_insider_trades, mock_company_news, mock_adanos):
+    mock_insider_trades.return_value = []
+    mock_company_news.return_value = []
+    mock_adanos.return_value = [
+        AdanosSentiment(source="reddit", found=True, buzz_score=80.0, sentiment_score=0.6, bullish_pct=70, bearish_pct=10, trend="rising", activity_count=42),
+        AdanosSentiment(source="x", found=True, buzz_score=55.0, sentiment_score=0.2, bullish_pct=55, bearish_pct=20, trend="stable", activity_count=18),
+    ]
+    request = SimpleNamespace(api_keys={"ADANOS_API_KEY": "test-adanos-key"})
+    state = {
+        "messages": [],
+        "data": {
+            "tickers": ["TSLA"],
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-07",
+            "analyst_signals": {},
+        },
+        "metadata": {"show_reasoning": False, "request": request},
+    }
+
+    result = sentiment_analyst_agent(state)
+    sentiment_payload = json.loads(result["messages"][0].content)["TSLA"]
+
+    mock_adanos.assert_called_once_with(
+        ticker="TSLA",
+        start_date="2026-05-01",
+        end_date="2026-05-07",
+        api_key="test-adanos-key",
+    )
+    assert sentiment_payload["signal"] == "bullish"
+    assert sentiment_payload["confidence"] == 100.0
+    adanos_reasoning = sentiment_payload["reasoning"]["adanos_market_sentiment"]
+    assert adanos_reasoning["signal"] == "bullish"
+    assert adanos_reasoning["metrics"]["source_count"] == 2
+    assert adanos_reasoning["metrics"]["sources"][0]["source"] == "reddit"


### PR DESCRIPTION
## Summary

- add an optional Adanos market sentiment fetcher for Reddit, X, News, and Polymarket stock sentiment
- enrich the existing sentiment analyst when `ADANOS_API_KEY` is configured
- keep the current sentiment behavior unchanged when Adanos is not configured or returns no usable data
- document the optional environment variable and cover the integration with tests

## Verification

- `python -m pytest tests/test_adanos_sentiment.py tests/test_api_rate_limiting.py -q`
- `python -m pytest tests/ -q`
- `git diff --check`
- `python3 -m py_compile src/tools/api.py src/agents/sentiment.py src/data/models.py tests/test_adanos_sentiment.py`
