### PR TITLE
feat(consensus): wire consensus aggregation into LangGraph workflow (#586, phase 2)

### DIFF
--- a/src/agents/consensus_manager.py
+++ b/src/agents/consensus_manager.py
@@ -1,0 +1,119 @@
+"""Consensus Manager Agent — aggregates multi-agent signals into a consensus view.
+
+Sits between risk_manager and portfolio_manager in the LangGraph workflow.
+No LLM calls — purely deterministic computation on top of existing analyst signals.
+"""
+
+import json
+
+from langchain_core.messages import HumanMessage
+
+from src.graph.state import AgentState, show_agent_reasoning
+from src.consensus.aggregation import build_consensus_result
+from src.consensus.models import AgentContribution, ConsensusResult
+from src.utils.progress import progress
+
+
+# Default equal weights for all agents
+DEFAULT_AGENT_WEIGHTS: dict[str, float] = {}
+
+
+def consensus_manager_agent(state: AgentState, agent_id: str = "consensus_manager"):
+    """Aggregate analyst signals into a consensus view per ticker.
+
+    This agent:
+    1. Collects all analyst signals from state["data"]["analyst_signals"]
+    2. Groups them by ticker
+    3. Computes consensus using the configured strategy
+    4. Stores the consensus result back into state
+    5. Flags outlier agents and disagreement levels
+
+    The portfolio manager can then use state["data"]["consensus"] to make
+    more informed decisions.
+    """
+    data = state["data"]
+    tickers = data["tickers"]
+    analyst_signals = data["analyst_signals"]
+
+    # Strategy from metadata (default: weighted)
+    consensus_strategy = state.get("metadata", {}).get("consensus_strategy", "weighted")
+
+    progress.update_status(agent_id, None, "Aggregating analyst signals")
+
+    # Collect contributions per ticker
+    contributions_by_ticker: dict[str, list[AgentContribution]] = {
+        t: [] for t in tickers
+    }
+
+    for agent_name, signals in analyst_signals.items():
+        # Skip risk management and portfolio management agents
+        if agent_name.startswith("risk_management_agent") or agent_name.startswith(
+            "portfolio_manager"
+        ):
+            continue
+
+        for ticker in tickers:
+            ticker_data = signals.get(ticker, {})
+            signal_val = ticker_data.get("signal")
+            confidence_val = ticker_data.get("confidence")
+
+            if signal_val is not None and confidence_val is not None:
+                contributions_by_ticker[ticker].append(
+                    AgentContribution(
+                        agent_name=agent_name,
+                        signal=str(signal_val),
+                        confidence=float(confidence_val),
+                        reasoning=str(ticker_data.get("reasoning", "")),
+                    )
+                )
+
+    # Build consensus
+    result = build_consensus_result(
+        signals_by_ticker=contributions_by_ticker,
+        strategy=consensus_strategy,
+        weights=DEFAULT_AGENT_WEIGHTS,
+    )
+
+    # Store consensus result in state for portfolio manager to use
+    consensus_data = {}
+    for ticker, cs in result.signals.items():
+        consensus_data[ticker] = {
+            "signal": cs.signal,
+            "score": cs.score,
+            "confidence": cs.confidence,
+            "agreement": cs.agreement,
+            "outliers": cs.outliers,
+            "contributions_count": len(cs.contributions),
+        }
+
+    state["data"]["consensus"] = consensus_data
+
+    progress.update_status(agent_id, None, "Consensus built")
+
+    # Create message for the graph
+    message = HumanMessage(
+        content=json.dumps(consensus_data),
+        name=agent_id,
+    )
+
+    # Show reasoning if requested
+    if state["metadata"].get("show_reasoning"):
+        display_data = {
+            ticker: {
+                "signal": cs.signal,
+                "score": cs.score,
+                "confidence": cs.confidence,
+                "agreement": cs.agreement,
+                "outliers": cs.outliers,
+                "agents": len(cs.contributions),
+            }
+            for ticker, cs in result.signals.items()
+        }
+        show_agent_reasoning(display_data, "Consensus Manager")
+
+    progress.update_status(agent_id, None, "Done")
+
+    return {
+        "messages": state["messages"] + [message],
+        "data": state["data"],
+    }

--- a/src/cli/input.py
+++ b/src/cli/input.py
@@ -223,6 +223,8 @@ class CLIInputs:
     margin_requirement: float
     show_reasoning: bool = False
     show_agent_graph: bool = False
+    use_consensus: bool = False
+    consensus_strategy: str = "weighted"
     raw_args: Optional[argparse.Namespace] = None
 
 
@@ -262,6 +264,20 @@ def parse_cli_inputs(
     if include_graph_flag:
         parser.add_argument("--show-agent-graph", action="store_true", help="Show the agent graph")
 
+    parser.add_argument(
+        "--consensus",
+        action="store_true",
+        dest="use_consensus",
+        help="Enable consensus aggregation of analyst signals before final decision",
+    )
+    parser.add_argument(
+        "--consensus-strategy",
+        type=str,
+        default="weighted",
+        choices=["weighted", "majority", "mean"],
+        help="Consensus strategy: weighted (default), majority, or mean",
+    )
+
     args = parser.parse_args()
 
     # Normalize parsed values
@@ -284,6 +300,8 @@ def parse_cli_inputs(
         margin_requirement=getattr(args, "margin_requirement", 0.0),
         show_reasoning=getattr(args, "show_reasoning", False),
         show_agent_graph=getattr(args, "show_agent_graph", False),
+        use_consensus=getattr(args, "use_consensus", False),
+        consensus_strategy=getattr(args, "consensus_strategy", "weighted"),
         raw_args=args,
     )
 

--- a/src/consensus/__init__.py
+++ b/src/consensus/__init__.py
@@ -1,0 +1,25 @@
+"""Consensus aggregation module for multi-agent trading signals.
+
+Phase 2: Wired into the LangGraph workflow between risk_manager and portfolio_manager.
+Builds on Issue #586 and complements tony-ku's Phase 1 models (#595).
+"""
+
+from src.consensus.models import (
+    ConsensusSignal,
+    AgentContribution,
+    ConsensusResult,
+)
+from src.consensus.aggregation import (
+    aggregate_signals,
+    compute_agreement,
+    detect_outliers,
+)
+
+__all__ = [
+    "ConsensusSignal",
+    "AgentContribution",
+    "ConsensusResult",
+    "aggregate_signals",
+    "compute_agreement",
+    "detect_outliers",
+]

--- a/src/consensus/aggregation.py
+++ b/src/consensus/aggregation.py
@@ -1,0 +1,262 @@
+"""Deterministic consensus aggregation strategies for multi-agent signals.
+
+No LLM calls — pure computation. Three strategies supported:
+- weighted: signal × confidence weighted average
+- majority: count-based voting (bullish/bearish/neutral)
+- mean: simple arithmetic mean of numeric signal values
+"""
+
+from collections import Counter
+from typing import Optional
+
+from src.consensus.models import (
+    AgentContribution,
+    ConsensusSignal,
+    ConsensusResult,
+)
+
+# Thresholds
+NEUTRAL_DEADBAND: float = 0.2  # Scores in (-0.2, +0.2) are treated as neutral
+OUTLIER_STDDEV_MULTIPLIER: float = 1.5  # Signals beyond this many stddevs from mean are outliers
+
+
+def _signal_to_numeric(signal: str) -> float:
+    """Convert signal string to numeric value."""
+    signal_lower = signal.lower()
+    if signal_lower == "bullish":
+        return 1.0
+    elif signal_lower == "bearish":
+        return -1.0
+    else:
+        return 0.0
+
+
+def _numeric_to_signal(score: float) -> str:
+    """Convert numeric score back to signal string."""
+    if score > NEUTRAL_DEADBAND:
+        return "bullish"
+    elif score < -NEUTRAL_DEADBAND:
+        return "bearish"
+    return "neutral"
+
+
+def aggregate_signals(
+    contributions: list[AgentContribution],
+    strategy: str = "weighted",
+    weights: Optional[dict[str, float]] = None,
+) -> ConsensusSignal:
+    """Aggregate multiple agent signals into a single consensus.
+
+    Args:
+        contributions: List of agent contributions (signal + confidence + reasoning)
+        strategy: Aggregation strategy — 'weighted', 'majority', or 'mean'
+        weights: Optional per-agent weight multipliers (default 1.0 for all)
+
+    Returns:
+        ConsensusSignal with composite score, confidence, agreement, and outliers.
+    """
+    if not contributions:
+        raise ValueError("At least one agent contribution is required")
+
+    if weights is None:
+        weights = {}
+
+    # Compute composite score based on strategy
+    if strategy == "majority":
+        score = _aggregate_majority(contributions, weights)
+    elif strategy == "mean":
+        score = _aggregate_mean(contributions)
+    else:  # weighted (default)
+        score = _aggregate_weighted(contributions, weights)
+
+    # Compute agreement score
+    agreement = compute_agreement(contributions, strategy, weights)
+
+    # Adjust confidence: base confidence × agreement penalty
+    raw_confidence = sum(c.confidence for c in contributions) / len(contributions)
+    adjusted_confidence = raw_confidence * agreement
+
+    # Detect outliers
+    outliers = detect_outliers(contributions, strategy, weights)
+
+    return ConsensusSignal(
+        ticker="",  # Will be set by caller
+        signal=_numeric_to_signal(score),
+        score=round(score, 4),
+        confidence=round(adjusted_confidence, 2),
+        agreement=round(agreement, 4),
+        contributions=contributions,
+        outliers=outliers,
+        strategy=strategy,
+    )
+
+
+def _aggregate_weighted(
+    contributions: list[AgentContribution],
+    weights: dict[str, float],
+) -> float:
+    """Weighted average: score = Σ(w_i × signal_i × confidence_i) / Σ(w_i × confidence_i)."""
+    total_weight = 0.0
+    weighted_sum = 0.0
+
+    for c in contributions:
+        w = weights.get(c.agent_name, 1.0)
+        signal_val = _signal_to_numeric(c.signal)
+        effective_weight = w * (c.confidence / 100.0)
+        weighted_sum += signal_val * effective_weight
+        total_weight += effective_weight
+
+    if total_weight == 0:
+        return 0.0
+
+    return weighted_sum / total_weight
+
+
+def _aggregate_majority(
+    contributions: list[AgentContribution],
+    weights: dict[str, float],
+) -> float:
+    """Majority vote: pick the signal category with the most weighted votes."""
+    counter: Counter = Counter()
+
+    for c in contributions:
+        w = weights.get(c.agent_name, 1.0)
+        counter[c.signal.lower()] += w
+
+    winner = counter.most_common(1)[0][0]
+    total = sum(counter.values())
+    winner_share = counter[winner] / total if total > 0 else 0.0
+
+    # Scale the score by the winner's share to reflect conviction
+    numeric = _signal_to_numeric(winner)
+    return numeric * winner_share
+
+
+def _aggregate_mean(contributions: list[AgentContribution]) -> float:
+    """Simple arithmetic mean of numeric signal values."""
+    if not contributions:
+        return 0.0
+    return sum(_signal_to_numeric(c.signal) for c in contributions) / len(contributions)
+
+
+def compute_agreement(
+    contributions: list[AgentContribution],
+    strategy: str = "weighted",
+    weights: Optional[dict[str, float]] = None,
+) -> float:
+    """Compute how much the agents agree (0 = total disagreement, 1 = unanimous).
+
+    For 'majority' strategy: share of votes for the winning camp.
+    For other strategies: 1 - (stddev / max possible stddev).
+    """
+    if len(contributions) <= 1:
+        return 1.0
+
+    if weights is None:
+        weights = {}
+
+    if strategy == "majority":
+        counter: Counter = Counter()
+        for c in contributions:
+            w = weights.get(c.agent_name, 1.0)
+            counter[c.signal.lower()] += w
+        total = sum(counter.values())
+        winner_count = counter.most_common(1)[0][1]
+        return winner_count / total if total > 0 else 0.0
+
+    # For weighted and mean: use stddev-based agreement
+    numeric_signals = [_signal_to_numeric(c.signal) for c in contributions]
+    mean_val = sum(numeric_signals) / len(numeric_signals)
+    variance = sum((s - mean_val) ** 2 for s in numeric_signals) / len(numeric_signals)
+    stddev = variance ** 0.5
+
+    # Max possible stddev when half are +1 and half are -1
+    max_stddev = 1.0
+    agreement = 1.0 - (stddev / max_stddev)
+    return max(0.0, min(1.0, agreement))
+
+
+def detect_outliers(
+    contributions: list[AgentContribution],
+    strategy: str = "weighted",
+    weights: Optional[dict[str, float]] = None,
+) -> list[str]:
+    """Detect agents whose signals deviate significantly from the group consensus.
+
+    Uses standard deviation from mean signal as the outlier criterion.
+    Returns agent names of detected outliers.
+    """
+    if len(contributions) < 3:
+        # Need at least 3 agents to meaningfully detect outliers
+        return []
+
+    if weights is None:
+        weights = {}
+
+    numeric_signals = [_signal_to_numeric(c.signal) for c in contributions]
+    mean_val = sum(numeric_signals) / len(numeric_signals)
+    variance = sum((s - mean_val) ** 2 for s in numeric_signals) / len(numeric_signals)
+    stddev = variance ** 0.5
+
+    if stddev == 0:
+        return []  # Perfect agreement, no outliers
+
+    outliers = []
+    for c in contributions:
+        deviation = abs(_signal_to_numeric(c.signal) - mean_val)
+        if deviation > OUTLIER_STDDEV_MULTIPLIER * stddev:
+            outliers.append(c.agent_name)
+
+    return outliers
+
+
+def build_consensus_result(
+    signals_by_ticker: dict[str, list[AgentContribution]],
+    strategy: str = "weighted",
+    weights: Optional[dict[str, float]] = None,
+) -> ConsensusResult:
+    """Build a full ConsensusResult from per-ticker agent contributions.
+
+    Args:
+        signals_by_ticker: Dictionary of ticker → list of agent contributions
+        strategy: Aggregation strategy
+        weights: Optional per-agent weights
+
+    Returns:
+        ConsensusResult with consensus signals for all tickers.
+    """
+    consensus_signals: dict[str, ConsensusSignal] = {}
+
+    for ticker, contributions in signals_by_ticker.items():
+        if not contributions:
+            # No signals at all — create a neutral consensus
+            consensus_signals[ticker] = ConsensusSignal(
+                ticker=ticker,
+                signal="neutral",
+                score=0.0,
+                confidence=0.0,
+                agreement=0.0,
+                strategy=strategy,
+            )
+            continue
+
+        signal = aggregate_signals(contributions, strategy, weights)
+        signal.ticker = ticker
+        consensus_signals[ticker] = signal
+
+    # Build summary
+    summary_parts = []
+    for ticker, cs in consensus_signals.items():
+        outlier_str = ""
+        if cs.outliers:
+            outlier_str = f" (outliers: {', '.join(cs.outliers)})"
+        summary_parts.append(
+            f"{ticker}: {cs.signal.upper()} "
+            f"(score={cs.score:+.3f}, conf={cs.confidence:.0f}, "
+            f"agree={cs.agreement:.0%}){outlier_str}"
+        )
+
+    return ConsensusResult(
+        signals=consensus_signals,
+        summary=" | ".join(summary_parts) if summary_parts else "No signals",
+    )

--- a/src/consensus/models.py
+++ b/src/consensus/models.py
@@ -1,0 +1,52 @@
+"""Data models for consensus aggregation of multi-agent trading signals."""
+
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class AgentContribution(BaseModel):
+    """A single agent's contribution to the consensus."""
+    agent_name: str = Field(description="Agent identifier, e.g. 'warren_buffett_agent'")
+    signal: str = Field(description="Signal value: 'bullish', 'bearish', or 'neutral'")
+    confidence: float = Field(description="Confidence score 0-100")
+    reasoning: str = Field(default="", description="Agent's reasoning for this signal")
+
+
+class ConsensusSignal(BaseModel):
+    """Aggregated consensus for a single ticker."""
+    ticker: str = Field(description="Stock ticker symbol")
+    signal: str = Field(
+        description="Consensus signal: 'bullish', 'bearish', or 'neutral'"
+    )
+    score: float = Field(
+        description="Composite score in [-1, +1]. Positive=bullish, negative=bearish, near zero=neutral"
+    )
+    confidence: float = Field(
+        description="Aggregated confidence 0-100. Lower when agents disagree."
+    )
+    agreement: float = Field(
+        description="Agreement score 0-1. How much the agents agree with each other."
+    )
+    contributions: list[AgentContribution] = Field(
+        default_factory=list,
+        description="Individual agent contributions that formed this consensus.",
+    )
+    outliers: list[str] = Field(
+        default_factory=list,
+        description="Agent names whose signals deviate significantly from consensus.",
+    )
+    strategy: str = Field(
+        default="weighted",
+        description="Aggregation strategy used: 'weighted', 'majority', or 'mean'.",
+    )
+
+
+class ConsensusResult(BaseModel):
+    """Full consensus output for all tickers."""
+    signals: dict[str, ConsensusSignal] = Field(
+        description="Dictionary of ticker to consensus signal"
+    )
+    summary: str = Field(
+        default="",
+        description="Human-readable summary of the consensus across all tickers",
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from colorama import Fore, Style, init
 import questionary
 from src.agents.portfolio_manager import portfolio_management_agent
 from src.agents.risk_manager import risk_management_agent
+from src.agents.consensus_manager import consensus_manager_agent
 from src.graph.state import AgentState
 from src.utils.display import print_trading_output
 from src.utils.analysts import ANALYST_ORDER, get_analyst_nodes
@@ -52,13 +53,18 @@ def run_hedge_fund(
     selected_analysts: list[str] = [],
     model_name: str = "gpt-4.1",
     model_provider: str = "OpenAI",
+    use_consensus: bool = False,
+    consensus_strategy: str = "weighted",
 ):
     # Start progress tracking
     progress.start()
 
     try:
         # Build workflow (default to all analysts when none provided)
-        workflow = create_workflow(selected_analysts if selected_analysts else None)
+        workflow = create_workflow(
+            selected_analysts if selected_analysts else None,
+            use_consensus=use_consensus,
+        )
         agent = workflow.compile()
 
         final_state = agent.invoke(
@@ -79,6 +85,7 @@ def run_hedge_fund(
                     "show_reasoning": show_reasoning,
                     "model_name": model_name,
                     "model_provider": model_provider,
+                    "consensus_strategy": consensus_strategy,
                 },
             },
         )
@@ -97,8 +104,13 @@ def start(state: AgentState):
     return state
 
 
-def create_workflow(selected_analysts=None):
-    """Create the workflow with selected analysts."""
+def create_workflow(selected_analysts=None, use_consensus: bool = False):
+    """Create the workflow with selected analysts.
+
+    When use_consensus=True, inserts a consensus_manager node between
+    risk_management and portfolio_manager that aggregates all analyst
+    signals into a structured consensus view before the final decision.
+    """
     workflow = StateGraph(AgentState)
     workflow.add_node("start_node", start)
 
@@ -123,7 +135,14 @@ def create_workflow(selected_analysts=None):
         node_name = analyst_nodes[analyst_key][0]
         workflow.add_edge(node_name, "risk_management_agent")
 
-    workflow.add_edge("risk_management_agent", "portfolio_manager")
+    if use_consensus:
+        # Insert consensus manager between risk and portfolio
+        workflow.add_node("consensus_manager", consensus_manager_agent)
+        workflow.add_edge("risk_management_agent", "consensus_manager")
+        workflow.add_edge("consensus_manager", "portfolio_manager")
+    else:
+        workflow.add_edge("risk_management_agent", "portfolio_manager")
+
     workflow.add_edge("portfolio_manager", END)
 
     workflow.set_entry_point("start_node")
@@ -175,5 +194,7 @@ if __name__ == "__main__":
         selected_analysts=inputs.selected_analysts,
         model_name=inputs.model_name,
         model_provider=inputs.model_provider,
+        use_consensus=inputs.use_consensus,
+        consensus_strategy=inputs.consensus_strategy,
     )
     print_trading_output(result)

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,0 +1,315 @@
+"""Tests for the consensus aggregation module."""
+
+import pytest
+
+from src.consensus.models import AgentContribution, ConsensusSignal, ConsensusResult
+from src.consensus.aggregation import (
+    aggregate_signals,
+    compute_agreement,
+    detect_outliers,
+    build_consensus_result,
+    _signal_to_numeric,
+    _numeric_to_signal,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def unanimous_bullish():
+    """All agents agree — bullish."""
+    return [
+        AgentContribution(agent_name="buffett", signal="bullish", confidence=90, reasoning="Great moat"),
+        AgentContribution(agent_name="munger", signal="bullish", confidence=85, reasoning="Fair price"),
+        AgentContribution(agent_name="lynch", signal="bullish", confidence=80, reasoning="Growth story"),
+    ]
+
+
+@pytest.fixture
+def unanimous_bearish():
+    """All agents agree — bearish."""
+    return [
+        AgentContribution(agent_name="buffett", signal="bearish", confidence=70, reasoning="Overvalued"),
+        AgentContribution(agent_name="burry", signal="bearish", confidence=95, reasoning="Bubble"),
+        AgentContribution(agent_name="taleb", signal="bearish", confidence=90, reasoning="Tail risk"),
+    ]
+
+
+@pytest.fixture
+def mixed_signals():
+    """Agents disagree — bullish vs bearish split."""
+    return [
+        AgentContribution(agent_name="wood", signal="bullish", confidence=80, reasoning="Innovation"),
+        AgentContribution(agent_name="buffett", signal="bearish", confidence=75, reasoning="Overvalued"),
+        AgentContribution(agent_name="burry", signal="bearish", confidence=90, reasoning="Crash coming"),
+    ]
+
+
+@pytest.fixture
+def neutral_mixed():
+    """Mix with neutral signals."""
+    return [
+        AgentContribution(agent_name="damodaran", signal="neutral", confidence=60, reasoning="Fairly priced"),
+        AgentContribution(agent_name="munger", signal="bullish", confidence=50, reasoning="OK value"),
+        AgentContribution(agent_name="taleb", signal="neutral", confidence=70, reasoning="Uncertain"),
+    ]
+
+
+# ── signal_to_numeric / numeric_to_signal ──────────────────────────
+
+def test_signal_to_numeric_bullish():
+    assert _signal_to_numeric("bullish") == 1.0
+    assert _signal_to_numeric("BULLISH") == 1.0
+
+
+def test_signal_to_numeric_bearish():
+    assert _signal_to_numeric("bearish") == -1.0
+
+
+def test_signal_to_numeric_neutral():
+    assert _signal_to_numeric("neutral") == 0.0
+    assert _signal_to_numeric("unknown") == 0.0
+
+
+def test_numeric_to_signal():
+    assert _numeric_to_signal(0.8) == "bullish"
+    assert _numeric_to_signal(-0.9) == "bearish"
+    assert _numeric_to_signal(0.0) == "neutral"
+    assert _numeric_to_signal(0.15) == "neutral"  # within deadband
+
+
+# ── aggregate_signals ──────────────────────────────────────────────
+
+class TestAggregateWeighted:
+    """Weighted strategy: signal × confidence weighted average."""
+
+    def test_unanimous_bullish(self, unanimous_bullish):
+        result = aggregate_signals(unanimous_bullish, strategy="weighted")
+        assert result.signal == "bullish"
+        assert result.score > 0.5
+        assert result.agreement > 0.9
+        assert len(result.outliers) == 0
+
+    def test_unanimous_bearish(self, unanimous_bearish):
+        result = aggregate_signals(unanimous_bearish, strategy="weighted")
+        assert result.signal == "bearish"
+        assert result.score < -0.5
+        assert result.agreement > 0.9
+
+    def test_mixed_signals(self, mixed_signals):
+        result = aggregate_signals(mixed_signals, strategy="weighted")
+        # Bearish camp has higher total confidence (75+90 > 80)
+        assert result.signal == "bearish"
+        assert result.score < 0
+        # Disagreement should lower agreement
+        assert result.agreement < 0.6
+
+    def test_neutral_mixed(self, neutral_mixed):
+        result = aggregate_signals(neutral_mixed, strategy="weighted")
+        # With one bullish at low confidence and two neutrals → neutral or slight bullish
+        assert result.signal in ("neutral", "bullish")
+        assert -0.3 < result.score < 0.6
+
+    def test_single_agent(self):
+        contributions = [AgentContribution(agent_name="buffett", signal="bullish", confidence=100)]
+        result = aggregate_signals(contributions, strategy="weighted")
+        assert result.signal == "bullish"
+        assert result.agreement == 1.0  # single agent = full agreement
+
+    def test_empty_contributions_raises(self):
+        with pytest.raises(ValueError, match="At least one agent contribution"):
+            aggregate_signals([], strategy="weighted")
+
+
+class TestAggregateMajority:
+    """Majority vote: pick the signal with most votes."""
+
+    def test_bullish_majority(self):
+        contribs = [
+            AgentContribution(agent_name="a", signal="bullish", confidence=50),
+            AgentContribution(agent_name="b", signal="bullish", confidence=30),
+            AgentContribution(agent_name="c", signal="bearish", confidence=90),
+        ]
+        result = aggregate_signals(contribs, strategy="majority")
+        assert result.signal == "bullish"  # 2/3 bullish
+
+    def test_bearish_majority(self):
+        contribs = [
+            AgentContribution(agent_name="a", signal="bearish", confidence=50),
+            AgentContribution(agent_name="b", signal="bearish", confidence=50),
+            AgentContribution(agent_name="c", signal="bullish", confidence=50),
+            AgentContribution(agent_name="d", signal="neutral", confidence=50),
+        ]
+        result = aggregate_signals(contribs, strategy="majority")
+        assert result.signal == "bearish"
+
+
+class TestAggregateMean:
+    """Simple average of numeric signals."""
+
+    def test_all_bullish(self, unanimous_bullish):
+        result = aggregate_signals(unanimous_bullish, strategy="mean")
+        assert result.signal == "bullish"
+        assert result.score == 1.0
+
+    def test_two_bearish_one_bullish(self):
+        contribs = [
+            AgentContribution(agent_name="a", signal="bearish", confidence=50),
+            AgentContribution(agent_name="b", signal="bearish", confidence=50),
+            AgentContribution(agent_name="c", signal="bullish", confidence=50),
+        ]
+        result = aggregate_signals(contribs, strategy="mean")
+        assert result.signal == "bearish"
+        assert result.score == pytest.approx(-0.3333, abs=0.01)
+
+
+# ── compute_agreement ──────────────────────────────────────────────
+
+def test_agreement_perfect_unanimous(unanimous_bullish):
+    assert compute_agreement(unanimous_bullish) > 0.95
+
+
+def test_agreement_total_disagreement():
+    """Half bullish, half bearish = max disagreement."""
+    contribs = [
+        AgentContribution(agent_name="a", signal="bullish", confidence=50),
+        AgentContribution(agent_name="b", signal="bearish", confidence=50),
+    ]
+    assert compute_agreement(contribs) == 0.0
+
+
+def test_agreement_single_agent():
+    contribs = [AgentContribution(agent_name="a", signal="bullish", confidence=50)]
+    assert compute_agreement(contribs) == 1.0
+
+
+def test_agreement_majority_strategy():
+    contribs = [
+        AgentContribution(agent_name="a", signal="bullish", confidence=50),
+        AgentContribution(agent_name="b", signal="bullish", confidence=50),
+        AgentContribution(agent_name="c", signal="bearish", confidence=50),
+    ]
+    assert compute_agreement(contribs, strategy="majority") == pytest.approx(2 / 3, abs=0.01)
+
+
+# ── detect_outliers ────────────────────────────────────────────────
+
+def test_no_outliers_when_unanimous(unanimous_bullish):
+    assert detect_outliers(unanimous_bullish) == []
+
+
+def test_no_outliers_with_two_agents():
+    """Need at least 3 agents to detect outliers."""
+    contribs = [
+        AgentContribution(agent_name="a", signal="bullish", confidence=50),
+        AgentContribution(agent_name="b", signal="bearish", confidence=50),
+    ]
+    assert detect_outliers(contribs) == []
+
+
+def test_outlier_detected():
+    """One bear among many bulls should be flagged."""
+    contribs = [
+        AgentContribution(agent_name="bull1", signal="bullish", confidence=80),
+        AgentContribution(agent_name="bull2", signal="bullish", confidence=75),
+        AgentContribution(agent_name="bull3", signal="bullish", confidence=70),
+        AgentContribution(agent_name="bear", signal="bearish", confidence=60),
+        AgentContribution(agent_name="bull4", signal="bullish", confidence=65),
+    ]
+    outliers = detect_outliers(contribs)
+    assert "bear" in outliers
+    # All bulls should NOT be outliers
+    for name in ["bull1", "bull2", "bull3", "bull4"]:
+        assert name not in outliers
+
+
+def test_no_outlier_when_balanced(mixed_signals):
+    """With a balanced split, no clear outlier."""
+    outliers = detect_outliers(mixed_signals)
+    assert len(outliers) == 0
+
+
+# ── Agent weights ──────────────────────────────────────────────────
+
+def test_agent_weights():
+    """Custom weights should influence the consensus."""
+    contribs = [
+        AgentContribution(agent_name="buffett", signal="bullish", confidence=40),
+        AgentContribution(agent_name="burry", signal="bearish", confidence=90),
+    ]
+    # Without weights: bearish wins (90 vs 40 → score ≈ -0.38, clearly bearish)
+    no_weight = aggregate_signals(contribs, strategy="weighted")
+    assert no_weight.signal == "bearish"
+    assert no_weight.score < -0.2
+
+    # With Buffett 10x weight: bullish now dominates
+    weighted = aggregate_signals(contribs, strategy="weighted", weights={"buffett": 10.0, "burry": 1.0})
+    assert weighted.signal == "bullish"
+    assert weighted.score > 0.2
+
+
+# ── build_consensus_result ─────────────────────────────────────────
+
+def test_build_consensus_result_multiple_tickers():
+    signals_by_ticker = {
+        "AAPL": [
+            AgentContribution(agent_name="buffett", signal="bullish", confidence=80),
+            AgentContribution(agent_name="munger", signal="bullish", confidence=75),
+        ],
+        "TSLA": [
+            AgentContribution(agent_name="wood", signal="bullish", confidence=90),
+            AgentContribution(agent_name="burry", signal="bearish", confidence=95),
+        ],
+    }
+    result = build_consensus_result(signals_by_ticker, strategy="weighted")
+
+    assert len(result.signals) == 2
+    assert result.signals["AAPL"].signal == "bullish"
+    assert result.signals["AAPL"].agreement > 0.9
+    assert result.signals["AAPL"].confidence > 70
+
+    assert result.signals["TSLA"].agreement < 0.5  # strong disagreement
+
+    assert "AAPL" in result.summary
+    assert "TSLA" in result.summary
+
+
+def test_build_consensus_empty_ticker():
+    result = build_consensus_result({"EMPTY": []})
+    assert result.signals["EMPTY"].signal == "neutral"
+    assert result.signals["EMPTY"].score == 0.0
+    assert result.signals["EMPTY"].confidence == 0.0
+
+
+def test_contributions_preserved():
+    contribs = [
+        AgentContribution(agent_name="buffett", signal="bullish", confidence=80, reasoning="Moat"),
+        AgentContribution(agent_name="munger", signal="bullish", confidence=75, reasoning="Quality"),
+    ]
+    result = aggregate_signals(contribs)
+    assert len(result.contributions) == 2
+    assert result.contributions[0].reasoning == "Moat"
+    assert result.contributions[1].reasoning == "Quality"
+
+
+# ── Edge cases ─────────────────────────────────────────────────────
+
+def test_zero_confidence():
+    """Zero-confidence signals should contribute zero weight."""
+    contribs = [
+        AgentContribution(agent_name="a", signal="bullish", confidence=0),
+        AgentContribution(agent_name="b", signal="bearish", confidence=50),
+    ]
+    result = aggregate_signals(contribs, strategy="weighted")
+    assert result.signal == "bearish"  # only B counts
+
+
+def test_all_zero_confidence():
+    """All zero confidence = neutral."""
+    contribs = [
+        AgentContribution(agent_name="a", signal="bullish", confidence=0),
+        AgentContribution(agent_name="b", signal="bearish", confidence=0),
+    ]
+    result = aggregate_signals(contribs, strategy="weighted")
+    assert result.signal == "neutral"
+    assert result.score == 0.0


### PR DESCRIPTION
## Summary

Phase 2 of the consensus mechanism requested in #586. This PR **wires the consensus aggregation into the actual LangGraph workflow** — building on the aggregation foundation and making it usable end-to-end.

### What's new

| Component | Description |
|-----------|-------------|
| `src/consensus/` | Aggregation layer: 3 strategies (weighted, majority, mean), outlier detection, agreement scoring |
| `src/agents/consensus_manager.py` | LangGraph-compatible agent node — sits between risk and portfolio |
| `src/main.py` | Optional consensus node in workflow toggle |
| `--consensus` flag | CLI flag to enable consensus aggregation |
| `--consensus-strategy` flag | Choose strategy: weighted (default), majority, or mean |
| `tests/test_consensus.py` | 28 unit tests, all passing ✅ |

### Architecture

```
Before:  analysts → risk_manager → portfolio_manager
After:   analysts → risk_manager → [consensus_manager] → portfolio_manager
```

When `--consensus` is enabled:
1. All analyst signals are collected per ticker
2. Consensus manager aggregates them into a single `ConsensusSignal` (score [-1,+1], confidence, agreement)
3. Outlier agents are flagged
4. Consensus data is stored in `state['data']['consensus']` for the portfolio manager
5. No LLM calls — entirely deterministic

### Design decisions

- **Zero LLM cost**: Pure computation, no additional API calls
- **Opt-in**: Backward compatible — default behavior unchanged
- **3 strategies**: `weighted` (signal×confidence), `majority` (voting), `mean` (simple average)
- **Outlier detection**: Agents deviating >1.5σ from mean are flagged
- **Neutral deadband**: Scores in (-0.2, +0.2) → neutral (avoids false positives on weak signals)

### Test results

```
tests/test_consensus.py ........................  28 passed ✅
```

### Usage

```bash
# Default (weighted consensus)
poetry run python src/main.py --ticker AAPL,MSFT --consensus

# Majority vote
poetry run python src/main.py --ticker AAPL --consensus --consensus-strategy majority

# Mean strategy
poetry run python src/main.py --ticker AAPL --consensus --consensus-strategy mean
```

### Related

- Closes #586
- Complements #595 (Phase 1 aggregation library by tony-ku)
- Follow-up possibilities: LLM arbiter for high-disagreement cases, agent performance tracking for adaptive weights