### PR TITLE
fix: include escrowed short margin in portfolio value calculation

### DIFF
--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -206,7 +206,9 @@ class BacktestService:
 
     def calculate_portfolio_value(self, current_prices: Dict[str, float]) -> float:
         """Calculate total portfolio value."""
-        total_value = self.portfolio["cash"]
+        # Margin escrowed for shorts was deducted from cash but is still the
+        # investor's asset, so it must count toward total value.
+        total_value = self.portfolio["cash"] + self.portfolio["margin_used"]
 
         for ticker in self.tickers:
             position = self.portfolio["positions"][ticker]

--- a/src/backtesting/valuation.py
+++ b/src/backtesting/valuation.py
@@ -8,9 +8,11 @@ from .portfolio import Portfolio
 def calculate_portfolio_value(portfolio: Portfolio, current_prices: Mapping[str, float]) -> float:
     """Compute total portfolio value identical to Backtester.calculate_portfolio_value.
 
-    total_value = cash + market value of longs - market value of shorts
+    total_value = cash + escrowed short margin + market value of longs - market value of shorts
     """
-    total_value = portfolio.get_cash()
+    # Margin escrowed for shorts was deducted from cash but is still the
+    # investor's asset, so it must count toward total value.
+    total_value = portfolio.get_cash() + portfolio.get_margin_used()
     positions = portfolio.get_positions()
     for ticker, pos in positions.items():
         price = float(current_prices[ticker])

--- a/tests/backtesting/test_valuation.py
+++ b/tests/backtesting/test_valuation.py
@@ -7,10 +7,26 @@ def test_calculate_portfolio_value(portfolio, prices):
     portfolio.apply_short_open("MSFT", 5, 200.0)
 
     value = calculate_portfolio_value(portfolio, prices)
-    # cash after trades
+    # cash after trades, plus margin escrowed for the short
     snap = portfolio.get_snapshot()
-    expected = snap["cash"] + 10 * 100.0 - 5 * 200.0
+    expected = snap["cash"] + snap["margin_used"] + 10 * 100.0 - 5 * 200.0
     assert value == expected
+
+
+def test_short_open_does_not_change_portfolio_value(portfolio, prices):
+    # Opening a short at the current price moves cash into margin escrow
+    # but creates no gain or loss, so total value must stay unchanged.
+    portfolio.apply_short_open("MSFT", 5, 200.0)
+    value = calculate_portfolio_value(portfolio, prices)
+    assert value == 100_000.0
+
+
+def test_short_open_and_cover_round_trip_restores_value(portfolio, prices):
+    portfolio.apply_short_open("MSFT", 5, 200.0)
+    portfolio.apply_short_cover("MSFT", 5, 200.0)
+    value = calculate_portfolio_value(portfolio, prices)
+    assert value == 100_000.0
+    assert portfolio.get_margin_used() == 0.0
 
 
 def test_compute_exposures(portfolio, prices):


### PR DESCRIPTION
## Summary

`calculate_portfolio_value` computes `cash + long value - short value` but never adds back `margin_used`, the cash moved into margin escrow when shorts are opened. Since `Portfolio.apply_short_open` deducts the margin from cash, the escrowed amount vanishes from the reported portfolio value, so opening a short shows an instant artificial loss equal to the margin requirement even though no price has moved.

Example with `initial_cash = 100,000` and `margin_requirement = 0.5`: shorting 100 shares at $50 escrows $2,500 of margin. Cash becomes 102,500 and reported value becomes `102,500 - 5,000 = 97,500`, a phantom $2,500 loss at an unchanged price. The value is only recovered when the short is covered and the margin is released. This distorts returns, Sharpe, Sortino, and max drawdown for any backtest run with `--margin-requirement > 0`. The default margin requirement is 0.0, which is likely why this went unnoticed.

## Changes

- `src/backtesting/valuation.py`: add `portfolio.get_margin_used()` to the total in `calculate_portfolio_value`
- `app/backend/services/backtest_service.py`: same fix for the web backend's copy of the calculation
- `tests/backtesting/test_valuation.py`: regression tests asserting portfolio value is invariant when a short is opened at the current price and after an open plus cover round trip; updated the existing valuation test to account for escrowed margin

## Testing

- New tests fail on the previous code (`97,500 != 100,000`) and pass with the fix
- `python -m pytest tests -q` passes (67 passed)