### PR TITLE
Add Jean-Marie Eveillard LLM investor agent

### DIFF
--- a/v2/signals/__init__.py
+++ b/v2/signals/__init__.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 from v2.signals.base import AlphaModel, QuantModel
 from v2.signals.buffett import BuffettAgent
+from v2.signals.eveillard import EveillardAgent
 from v2.signals.llm_agent import LLMAgent
 from v2.signals.pead import PEADModel
 
 ALPHA_MODEL_REGISTRY: dict[str, type[AlphaModel]] = {
     "pead": PEADModel,
     "buffett": BuffettAgent,
+    "eveillard": EveillardAgent,
 }
 
 __all__ = [
@@ -21,6 +23,7 @@ __all__ = [
     "QuantModel",
     "LLMAgent",
     "BuffettAgent",
+    "EveillardAgent",
     "PEADModel",
     "ALPHA_MODEL_REGISTRY",
 ]

--- a/v2/signals/eveillard.py
+++ b/v2/signals/eveillard.py
@@ -1,0 +1,68 @@
+"""Jean-Marie Eveillard agent — a patient, absolute-return value investor.
+
+A stylized approximation of Jean-Marie Eveillard's public investment
+philosophy (see VISION.md: these personas are not the actual individuals and
+not endorsements). Eveillard ran First Eagle's global value funds for decades
+with a famously conservative, margin-of-safety approach — he cared about not
+losing money first, judged businesses on their own merit rather than against a
+benchmark, and was willing to look wrong for years while waiting for value to
+be recognized ("I would rather lose half my shareholders than lose half my
+shareholders' money").
+
+The persona is ONLY a system prompt — all machinery lives in LLMAgent; all
+data comes from the point-in-time FundamentalsSnapshot.
+"""
+
+from __future__ import annotations
+
+from v2.signals.llm_agent import LLMAgent
+
+
+class EveillardAgent(LLMAgent):
+    """Reasons over fundamentals in Jean-Marie Eveillard's voice."""
+
+    @property
+    def name(self) -> str:
+        return "eveillard"
+
+    def get_system_prompt(self) -> str:
+        return """You are Jean-Marie Eveillard, a patient global value investor
+who prizes capital preservation above all. You judge a business on its own
+merit, in absolute terms — never relative to an index. You are comfortable
+being out of step with the crowd and waiting years for value to be recognized.
+
+Work through your checklist:
+1. Margin of safety — is the price (market cap, P/E) clearly below what the
+   business is worth? You demand a discount, not a fair price; overpaying for
+   quality still loses money.
+2. Business quality — durable returns on equity, stable or widening margins,
+   and book value that compounds steadily over time.
+3. Balance-sheet resilience — low debt (debt/equity), a healthy current ratio,
+   and consistent free cash flow. A fragile balance sheet is disqualifying no
+   matter how cheap the stock.
+4. Downside first — what can go wrong, and how much would you lose if it did?
+   You weigh the permanent-loss case before the upside case.
+5. Patience — would you be content to own this quietly for years, ignoring the
+   quotation, while the thesis plays out?
+
+Signal rules:
+- bullish: a sound, resilient business trading at a genuine discount to its
+  intrinsic worth — a real margin of safety.
+- bearish: an overvalued business, a fragile balance sheet, or deteriorating
+  fundamentals where the downside is real.
+- neutral: a decent business at a full price, or evidence too mixed to insist
+  on a margin of safety.
+
+Confidence scale (0-100): 90-100 exceptional conviction with a wide margin of
+safety and strong evidence; 70-89 solid conviction; 40-69 mixed; 10-39 weak or
+speculative.
+
+Hard rules:
+- Reason ONLY from the data provided. Do not use any knowledge of what happened
+  after the as-of date. Do not invent numbers.
+- If the data is insufficient to judge, say so and go neutral. When in doubt,
+  protect capital.
+
+Respond with JSON only, in exactly this schema:
+{"signal": "bullish" | "bearish" | "neutral", "confidence": <0-100>,
+ "reasoning": "<your thesis in Eveillard's voice, 2-4 sentences>"}"""

--- a/v2/signals/test_eveillard.py
+++ b/v2/signals/test_eveillard.py
@@ -1,0 +1,89 @@
+"""EveillardAgent tests — fake LLM and data client, no network.
+
+Mirrors the BuffettAgent test approach: the LLMAgent machinery is already
+covered in test_llm_agents.py, so here we assert only what is specific to this
+persona — its name, that it plugs into the shared value-folding contract, and
+that its system prompt actually carries Eveillard's philosophy.
+"""
+
+import json
+
+import pytest
+
+from v2.data.models import FinancialMetrics
+from v2.llm import PromptCache
+from v2.models import Signal
+from v2.signals import ALPHA_MODEL_REGISTRY, EveillardAgent
+
+
+class FakeLLM:
+    """Canned-response LLM; counts calls."""
+
+    model = "fake-model"
+
+    def __init__(self, response=""):
+        self._response = response
+        self.calls = 0
+
+    def complete(self, system, user):
+        self.calls += 1
+        return self._response
+
+
+class MockDataClient:
+    def __init__(self, metrics=None):
+        self._metrics = metrics or []
+
+    def get_financial_metrics(self, ticker, end_date, period="ttm", limit=10):
+        return self._metrics
+
+    def get_company_facts(self, ticker):
+        return None
+
+
+def _history(n=8):
+    quarters = ["2024-12-31", "2024-09-30", "2024-06-30", "2024-03-31",
+                "2023-12-31", "2023-09-30", "2023-06-30", "2023-03-31"]
+    return [
+        FinancialMetrics(
+            ticker="TEST", report_period=q, period="ttm", filing_date=q,
+            return_on_equity=0.2, gross_margin=0.4, book_value_per_share=10.0,
+            market_cap=1e9,
+        )
+        for q in quarters[:n]
+    ]
+
+
+def _agent(tmp_path, llm):
+    return EveillardAgent(llm=llm, cache=PromptCache(tmp_path / "llm"))
+
+
+def test_registered_in_registry():
+    assert ALPHA_MODEL_REGISTRY["eveillard"] is EveillardAgent
+
+
+def test_name():
+    assert EveillardAgent(llm=FakeLLM(), cache=None).name == "eveillard"
+
+
+def test_system_prompt_is_eveillard():
+    prompt = EveillardAgent(llm=FakeLLM(), cache=None).get_system_prompt()
+    assert "Eveillard" in prompt
+    assert "margin of safety" in prompt.lower()
+
+
+@pytest.mark.parametrize("signal,confidence,expected", [
+    ("bullish", 80, 0.8),
+    ("bearish", 60, -0.6),
+    ("neutral", 90, 0.0),
+])
+def test_value_folding(tmp_path, signal, confidence, expected):
+    response = json.dumps({"signal": signal, "confidence": confidence, "reasoning": "r"})
+    agent = _agent(tmp_path, FakeLLM(response))
+
+    sig = agent.predict("TEST", "2025-01-15", MockDataClient(metrics=_history()))
+
+    assert isinstance(sig, Signal)
+    assert sig.model_name == "eveillard"
+    assert sig.value == pytest.approx(expected)
+    assert sig.metadata["abstained"] is False


### PR DESCRIPTION
Adds an **EveillardAgent** persona to the v2 alpha-model roster — a stylized approximation of Jean-Marie Eveillard's public value philosophy (First Eagle Global): margin of safety, capital preservation, **absolute** (not benchmark-relative) return, and long patience.

Per `ROADMAP.md`, adding an analyst is the main contribution surface. This fills an open *Your agent here* slot — no French value investor persona existed among the listed agents (Buffett, Munger, Graham, Lynch, Druckenmiller, …).

## What it does
Eveillard reasons over the shared point-in-time `FundamentalsSnapshot` exactly like the existing `BuffettAgent` — the persona is only a `name` + `get_system_prompt()`; all machinery stays in `LLMAgent`. His checklist (margin of safety, business quality, balance-sheet resilience, downside-first, patience) maps cleanly onto the snapshot metrics (P/E, ROE, margins, debt/equity, BVPS CAGR, FCF/share).

## Changes
- `v2/signals/eveillard.py` — the persona (name + system prompt), subclassing `LLMAgent`
- `v2/signals/__init__.py` — register in `ALPHA_MODEL_REGISTRY`, add to exports
- `v2/signals/test_eveillard.py` — registry / name / prompt / value-folding tests (fakes, no network)

## Notes
- Stylized approximation of a public investment philosophy, not the individual and not an endorsement (consistent with `VISION.md`).
- Plugs into the CLI automatically: `python -m v2.analyze AAPL --agent eveillard`.
- All 33 `v2/signals` tests pass locally.

Opened as draft — happy to adjust the persona prompt or add a demo entry if useful.