### PR TITLE
fix: add request timeout to all LLM provider constructors

### DIFF
--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -124,6 +124,12 @@ LLM_ORDER = [model.to_choice_tuple() for model in AVAILABLE_MODELS]
 OLLAMA_LLM_ORDER = [model.to_choice_tuple() for model in OLLAMA_MODELS]
 
 
+# Per-request timeout for LLM calls, in seconds. Without it a hung provider
+# connection blocks an analysis task forever and the retry loop in call_llm
+# never gets a chance to run (see #618). Override with LLM_REQUEST_TIMEOUT.
+DEFAULT_REQUEST_TIMEOUT_SECONDS = float(os.getenv("LLM_REQUEST_TIMEOUT", "120"))
+
+
 def get_model_info(model_name: str, model_provider: str) -> LLMModel | None:
     """Get model information by model_name"""
     all_models = AVAILABLE_MODELS + OLLAMA_MODELS
@@ -155,7 +161,7 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             # Print error to console
             print(f"API Key Error: Please make sure GROQ_API_KEY is set in your .env file or provided via API keys.")
             raise ValueError("Groq API key not found.  Please make sure GROQ_API_KEY is set in your .env file or provided via API keys.")
-        return ChatGroq(model=model_name, api_key=api_key)
+        return ChatGroq(model=model_name, api_key=api_key, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.OPENAI:
         # Get and validate API key
         api_key = (api_keys or {}).get("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
@@ -164,25 +170,25 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             # Print error to console
             print(f"API Key Error: Please make sure OPENAI_API_KEY is set in your .env file or provided via API keys.")
             raise ValueError("OpenAI API key not found.  Please make sure OPENAI_API_KEY is set in your .env file or provided via API keys.")
-        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.ANTHROPIC:
         api_key = (api_keys or {}).get("ANTHROPIC_API_KEY") or os.getenv("ANTHROPIC_API_KEY")
         if not api_key:
             print(f"API Key Error: Please make sure ANTHROPIC_API_KEY is set in your .env file or provided via API keys.")
             raise ValueError("Anthropic API key not found.  Please make sure ANTHROPIC_API_KEY is set in your .env file or provided via API keys.")
-        return ChatAnthropic(model=model_name, api_key=api_key)
+        return ChatAnthropic(model=model_name, api_key=api_key, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.DEEPSEEK:
         api_key = (api_keys or {}).get("DEEPSEEK_API_KEY") or os.getenv("DEEPSEEK_API_KEY")
         if not api_key:
             print(f"API Key Error: Please make sure DEEPSEEK_API_KEY is set in your .env file or provided via API keys.")
             raise ValueError("DeepSeek API key not found.  Please make sure DEEPSEEK_API_KEY is set in your .env file or provided via API keys.")
-        return ChatDeepSeek(model=model_name, api_key=api_key)
+        return ChatDeepSeek(model=model_name, api_key=api_key, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.GOOGLE:
         api_key = (api_keys or {}).get("GOOGLE_API_KEY") or os.getenv("GOOGLE_API_KEY")
         if not api_key:
             print(f"API Key Error: Please make sure GOOGLE_API_KEY is set in your .env file or provided via API keys.")
             raise ValueError("Google API key not found.  Please make sure GOOGLE_API_KEY is set in your .env file or provided via API keys.")
-        return ChatGoogleGenerativeAI(model=model_name, api_key=api_key)
+        return ChatGoogleGenerativeAI(model=model_name, api_key=api_key, request_timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.OLLAMA:
         # For Ollama, we use a base URL instead of an API key
         # Check if OLLAMA_HOST is set (for Docker on macOS)
@@ -191,6 +197,7 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
         return ChatOllama(
             model=model_name,
             base_url=base_url,
+            client_kwargs={"timeout": DEFAULT_REQUEST_TIMEOUT_SECONDS},
         )
     elif model_provider == ModelProvider.OPENROUTER:
         api_key = (api_keys or {}).get("OPENROUTER_API_KEY") or os.getenv("OPENROUTER_API_KEY")
@@ -206,6 +213,7 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             model=model_name,
             openai_api_key=api_key,
             openai_api_base="https://openrouter.ai/api/v1",
+            timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS,
             model_kwargs={
                 "extra_headers": {
                     "HTTP-Referer": site_url,
@@ -222,23 +230,23 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
         # Kimi exposes an OpenAI-compatible endpoint. Default to the international host;
         # users in mainland China can override via MOONSHOT_BASE_URL=https://api.moonshot.cn/v1.
         base_url = os.getenv("MOONSHOT_BASE_URL") or os.getenv("KIMI_BASE_URL") or "https://api.moonshot.ai/v1"
-        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.XAI:
         api_key = (api_keys or {}).get("XAI_API_KEY") or os.getenv("XAI_API_KEY")
         if not api_key:
             print(f"API Key Error: Please make sure XAI_API_KEY is set in your .env file or provided via API keys.")
             raise ValueError("xAI API key not found. Please make sure XAI_API_KEY is set in your .env file or provided via API keys.")
-        return ChatXAI(model=model_name, api_key=api_key)
+        return ChatXAI(model=model_name, api_key=api_key, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.GIGACHAT:
         if os.getenv("GIGACHAT_USER") or os.getenv("GIGACHAT_PASSWORD"):
-            return GigaChat(model=model_name)
+            return GigaChat(model=model_name, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
         else: 
             api_key = (api_keys or {}).get("GIGACHAT_API_KEY") or os.getenv("GIGACHAT_API_KEY") or os.getenv("GIGACHAT_CREDENTIALS")
             if not api_key:
                 print("API Key Error: Please make sure api_keys is set in your .env file or provided via API keys.")
                 raise ValueError("GigaChat API key not found. Please make sure GIGACHAT_API_KEY is set in your .env file or provided via API keys.")
 
-            return GigaChat(credentials=api_key, model=model_name)
+            return GigaChat(credentials=api_key, model=model_name, timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     elif model_provider == ModelProvider.AZURE_OPENAI:
         # Get and validate API key
         api_key = os.getenv("AZURE_OPENAI_API_KEY")
@@ -258,7 +266,7 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
             # Print error to console
             print(f"Azure Deployment Name Error: Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
             raise ValueError("Azure OpenAI deployment name not found.  Please make sure AZURE_OPENAI_DEPLOYMENT_NAME is set in your .env file.")
-        return AzureChatOpenAI(azure_endpoint=azure_endpoint, azure_deployment=azure_deployment_name, api_key=api_key, api_version="2024-10-21")
+        return AzureChatOpenAI(azure_endpoint=azure_endpoint, azure_deployment=azure_deployment_name, api_key=api_key, api_version="2024-10-21", timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS)
     else:
         raise ValueError(
             f"Unsupported model provider: {model_provider}. "

--- a/tests/test_llm_timeout.py
+++ b/tests/test_llm_timeout.py
@@ -1,0 +1,52 @@
+import pytest
+
+from src.llm.models import (
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ModelProvider,
+    get_model,
+)
+
+# (provider, env vars required by get_model, attribute holding the timeout)
+TIMEOUT_CASES = [
+    (ModelProvider.OPENAI, {"OPENAI_API_KEY": "test"}, "request_timeout"),
+    (ModelProvider.GROQ, {"GROQ_API_KEY": "test"}, "request_timeout"),
+    (ModelProvider.ANTHROPIC, {"ANTHROPIC_API_KEY": "test"}, "default_request_timeout"),
+    (ModelProvider.DEEPSEEK, {"DEEPSEEK_API_KEY": "test"}, "request_timeout"),
+    (ModelProvider.GOOGLE, {"GOOGLE_API_KEY": "test"}, "timeout"),
+    (ModelProvider.OPENROUTER, {"OPENROUTER_API_KEY": "test"}, "request_timeout"),
+    (ModelProvider.KIMI, {"MOONSHOT_API_KEY": "test"}, "request_timeout"),
+    (ModelProvider.XAI, {"XAI_API_KEY": "test"}, "request_timeout"),
+    (ModelProvider.GIGACHAT, {"GIGACHAT_API_KEY": "test"}, "timeout"),
+]
+
+
+@pytest.mark.parametrize("provider,env,attr", TIMEOUT_CASES)
+def test_get_model_sets_request_timeout(provider, env, attr, monkeypatch):
+    """Every provider gets a request timeout so a hung API call cannot block
+    an analysis task forever (the retry loop in call_llm never runs if the
+    first invoke hangs)."""
+    monkeypatch.delenv("GIGACHAT_USER", raising=False)
+    monkeypatch.delenv("GIGACHAT_PASSWORD", raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    model = get_model("test-model", provider)
+
+    assert getattr(model, attr) == DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+
+def test_ollama_client_gets_timeout(monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    model = get_model("test-model", ModelProvider.OLLAMA)
+    assert model.client_kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+
+def test_azure_openai_gets_timeout(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.setenv("AZURE_OPENAI_DEPLOYMENT_NAME", "test-deployment")
+
+    model = get_model("test-model", ModelProvider.AZURE_OPENAI)
+
+    assert model.request_timeout == DEFAULT_REQUEST_TIMEOUT_SECONDS


### PR DESCRIPTION
Fixes #618

None of the provider constructors in `get_model()` set a request timeout, so `llm.invoke()` in `call_llm()` can hang indefinitely when a provider connection stalls. Because the first call never returns, the `max_retries` loop never gets a chance to run, and the analysis task blocks forever instead of degrading to `default_factory`.

This sets a 120-second default on every provider, overridable with the `LLM_REQUEST_TIMEOUT` env var. With a timeout in place, a stalled call now raises, the existing retry loop runs, and the fallback path works as designed.

One detail worth noting: the kwarg isn't uniform across providers, so each was verified against the versions pinned in `pyproject.toml` — `timeout` (alias) for the OpenAI-compatible clients (OpenAI, Azure, OpenRouter, Kimi, xAI, DeepSeek, Groq) and Anthropic, `request_timeout` for `ChatGoogleGenerativeAI` (its field/alias are reversed relative to the others), plain `timeout` for GigaChat, and `client_kwargs={"timeout": ...}` for `ChatOllama` (which has no timeout field — it forwards to the httpx client).

Added `tests/test_llm_timeout.py` asserting the resolved timeout lands on the right attribute for all 12 constructors (11 tests, parametrized). All pass locally.