### PR TITLE
Fix short margin accounting

### DIFF
--- a/app/backend/services/backtest_service.py
+++ b/app/backend/services/backtest_service.py
@@ -57,6 +57,16 @@ class BacktestService:
         self.request = request
         self.portfolio_values = []
 
+    def _available_cash(self) -> float:
+        short_sale_proceeds = sum(
+            position["short"] * position["short_cost_basis"]
+            for position in self.portfolio["positions"].values()
+        )
+        return max(
+            0.0,
+            self.portfolio["cash"] - self.portfolio["margin_used"] - short_sale_proceeds,
+        )
+
     def execute_trade(self, ticker: str, action: str, quantity: float, current_price: float) -> int:
         """
         Execute trades with support for both long and short positions.
@@ -70,7 +80,8 @@ class BacktestService:
 
         if action == "buy":
             cost = quantity * current_price
-            if cost <= self.portfolio["cash"]:
+            available_cash = self._available_cash()
+            if cost <= available_cash:
                 # Weighted average cost basis for the new total
                 old_shares = position["long"]
                 old_cost_basis = position["long_cost_basis"]
@@ -87,7 +98,7 @@ class BacktestService:
                 return quantity
             else:
                 # Calculate maximum affordable quantity
-                max_quantity = int(self.portfolio["cash"] / current_price)
+                max_quantity = int(available_cash / current_price)
                 if max_quantity > 0:
                     cost = max_quantity * current_price
                     old_shares = position["long"]
@@ -122,9 +133,7 @@ class BacktestService:
         elif action == "short":
             proceeds = current_price * quantity
             margin_required = proceeds * self.portfolio["margin_requirement"]
-            available_cash = max(
-                0.0, self.portfolio["cash"] - self.portfolio["margin_used"]
-            )
+            available_cash = self._available_cash()
             if margin_required <= available_cash:
                 # Weighted average short cost basis
                 old_short_shares = position["short"]
@@ -142,7 +151,6 @@ class BacktestService:
                 self.portfolio["margin_used"] += margin_required
 
                 self.portfolio["cash"] += proceeds
-                self.portfolio["cash"] -= margin_required
                 return quantity
             else:
                 margin_ratio = self.portfolio["margin_requirement"]
@@ -169,7 +177,6 @@ class BacktestService:
                     self.portfolio["margin_used"] += margin_required
 
                     self.portfolio["cash"] += proceeds
-                    self.portfolio["cash"] -= margin_required
                     return max_quantity
                 return 0
 
@@ -191,7 +198,6 @@ class BacktestService:
                 position["short_margin_used"] -= margin_to_release
                 self.portfolio["margin_used"] -= margin_to_release
 
-                self.portfolio["cash"] += margin_to_release
                 self.portfolio["cash"] -= cover_cost
 
                 self.portfolio["realized_gains"][ticker]["short"] += realized_gain
@@ -536,4 +542,4 @@ class BacktestService:
         # Calculate additional metrics
         performance_df["Daily Return"] = performance_df["Portfolio Value"].pct_change().fillna(0)
         
-        return performance_df 
+        return performance_df

--- a/src/agents/portfolio_manager.py
+++ b/src/agents/portfolio_manager.py
@@ -105,7 +105,11 @@ def compute_allowed_actions(
     positions = portfolio.get("positions", {}) or {}
     margin_requirement = float(portfolio.get("margin_requirement", 0.5))
     margin_used = float(portfolio.get("margin_used", 0.0))
-    equity = float(portfolio.get("equity", cash))
+    short_sale_proceeds = sum(
+        float(position.get("short", 0) or 0) * float(position.get("short_cost_basis", 0.0) or 0.0)
+        for position in positions.values()
+    )
+    available_cash = max(0.0, cash - margin_used - short_sale_proceeds)
 
     for ticker in tickers:
         price = float(current_prices.get(ticker, 0.0))
@@ -123,8 +127,8 @@ def compute_allowed_actions(
         # Long side
         if long_shares > 0:
             actions["sell"] = long_shares
-        if cash > 0 and price > 0:
-            max_buy_cash = int(cash // price)
+        if available_cash > 0 and price > 0:
+            max_buy_cash = int(available_cash // price)
             max_buy = max(0, min(max_qty, max_buy_cash))
             if max_buy > 0:
                 actions["buy"] = max_buy
@@ -137,8 +141,7 @@ def compute_allowed_actions(
                 # If margin requirement is zero or unset, only cap by max_qty
                 max_short = max_qty
             else:
-                available_margin = max(0.0, (equity / margin_requirement) - margin_used)
-                max_short_margin = int(available_margin // price)
+                max_short_margin = int(available_cash // (price * margin_requirement))
                 max_short = max(0, min(max_qty, max_short_margin))
             if max_short > 0:
                 actions["short"] = max_short

--- a/src/backtesting/portfolio.py
+++ b/src/backtesting/portfolio.py
@@ -73,6 +73,17 @@ class Portfolio:
     def get_margin_requirement(self) -> float:
         return float(self._portfolio["margin_requirement"])
 
+    def get_available_cash(self) -> float:
+        """Return cash that is not reserved for existing short positions."""
+        short_sale_proceeds = sum(
+            position["short"] * position["short_cost_basis"]
+            for position in self._portfolio["positions"].values()
+        )
+        return max(
+            0.0,
+            self._portfolio["cash"] - self._portfolio["margin_used"] - short_sale_proceeds,
+        )
+
     def get_positions(self) -> Mapping[str, PositionState]:
         return MappingProxyType(self._portfolio["positions"])  # type: ignore[arg-type]
 
@@ -85,7 +96,8 @@ class Portfolio:
         quantity = int(quantity)
         position = self._portfolio["positions"][ticker]
         cost = quantity * price
-        if cost <= self._portfolio["cash"]:
+        available_cash = self.get_available_cash()
+        if cost <= available_cash:
             old_shares = position["long"]
             old_cost_basis = position["long_cost_basis"]
             total_shares = old_shares + quantity
@@ -96,7 +108,7 @@ class Portfolio:
             position["long"] = old_shares + quantity
             self._portfolio["cash"] -= cost
             return quantity
-        max_quantity = int(self._portfolio["cash"] / price) if price > 0 else 0
+        max_quantity = int(available_cash / price) if price > 0 else 0
         if max_quantity > 0:
             cost = max_quantity * price
             old_shares = position["long"]
@@ -133,9 +145,7 @@ class Portfolio:
         proceeds = price * quantity
         margin_ratio = self._portfolio["margin_requirement"]
         margin_required = proceeds * margin_ratio
-        available_cash = max(
-            0.0, self._portfolio["cash"] - self._portfolio["margin_used"]
-        )
+        available_cash = self.get_available_cash()
         if margin_required <= available_cash:
             old_short_shares = position["short"]
             old_cost_basis = position["short_cost_basis"]
@@ -148,7 +158,6 @@ class Portfolio:
             position["short_margin_used"] += margin_required
             self._portfolio["margin_used"] += margin_required
             self._portfolio["cash"] += proceeds
-            self._portfolio["cash"] -= margin_required
             return quantity
         max_quantity = int(available_cash / (price * margin_ratio)) if margin_ratio > 0 and price > 0 else 0
         if max_quantity > 0:
@@ -165,7 +174,6 @@ class Portfolio:
             position["short_margin_used"] += margin_required
             self._portfolio["margin_used"] += margin_required
             self._portfolio["cash"] += proceeds
-            self._portfolio["cash"] -= margin_required
             return max_quantity
         return 0
 
@@ -185,7 +193,6 @@ class Portfolio:
         position["short"] -= quantity
         position["short_margin_used"] -= margin_to_release
         self._portfolio["margin_used"] -= margin_to_release
-        self._portfolio["cash"] += margin_to_release
         self._portfolio["cash"] -= cover_cost
         self._portfolio["realized_gains"][ticker]["short"] += realized_gain
         if position["short"] == 0:

--- a/tests/backtesting/test_portfolio.py
+++ b/tests/backtesting/test_portfolio.py
@@ -56,8 +56,8 @@ def test_apply_short_open_basic(portfolio: Portfolio) -> None:
     assert pos["short_cost_basis"] == pytest.approx(30.0)
     assert pos["short_margin_used"] == pytest.approx(1_500.0)
     assert snap["margin_used"] == pytest.approx(1_500.0)
-    # Cash increases net by proceeds - margin = 3,000 - 1,500 = 1,500
-    assert snap["cash"] == pytest.approx(101_500.0)
+    # Cash includes short-sale proceeds; margin remains tracked separately.
+    assert snap["cash"] == pytest.approx(103_000.0)
 
 
 def test_apply_short_open_partial_when_insufficient_margin_cash() -> None:
@@ -70,26 +70,35 @@ def test_apply_short_open_partial_when_insufficient_margin_cash() -> None:
     pos = snap["positions"]["AAPL"]
     assert pos["short"] == 4
     assert pos["short_margin_used"] == pytest.approx(200.0)
-    # cash: + proceeds (400) - margin (200) = +200 → 400 total
-    assert snap["cash"] == pytest.approx(400.0)
+    # Cash includes short-sale proceeds; the initial margin is reserved separately.
+    assert snap["cash"] == pytest.approx(600.0)
 
 
-def test_apply_short_open_uses_available_cash_not_total_cash() -> None:
+def test_apply_short_open_does_not_reuse_restricted_short_proceeds() -> None:
     p = Portfolio(tickers=["AAPL"], initial_cash=1_000.0, margin_requirement=0.5)
 
-    # First short consumes all free margin but increases total cash with proceeds.
+    # The first short leaves $500 available for additional initial margin.
     first = p.apply_short_open("AAPL", 10, 100.0)
     assert first == 10
 
-    # Available cash should still be 1,000 (cash 1,500 - margin_used 500),
-    # so max additional quantity at $100 with 50% margin is 20 shares.
+    # Existing short proceeds and collateral stay restricted, leaving room for
+    # only 10 additional shares at the same price and margin requirement.
     second = p.apply_short_open("AAPL", 30, 100.0)
-    assert second == 20
+    assert second == 10
 
     snap = p.get_snapshot()
     pos = snap["positions"]["AAPL"]
-    assert pos["short"] == 30
-    assert snap["margin_used"] == pytest.approx(1_500.0)
+    assert pos["short"] == 20
+    assert snap["margin_used"] == pytest.approx(1_000.0)
+    assert p.get_available_cash() == pytest.approx(0.0)
+
+
+def test_apply_long_buy_does_not_spend_restricted_short_proceeds() -> None:
+    p = Portfolio(tickers=["AAPL"], initial_cash=1_000.0, margin_requirement=0.5)
+    p.apply_short_open("AAPL", 10, 100.0)
+
+    assert p.apply_long_buy("AAPL", 20, 100.0) == 5
+    assert p.get_available_cash() == pytest.approx(0.0)
 
 
 def test_apply_short_cover_realized_gain_and_margin_release(portfolio: Portfolio) -> None:
@@ -105,8 +114,8 @@ def test_apply_short_cover_realized_gain_and_margin_release(portfolio: Portfolio
     # Proportional margin released: 40/100 of pre short_margin_used
     released = (40 / 100.0) * pre_margin_used
     assert pos["short_margin_used"] == pytest.approx(pre_margin_used - released)
-    # Cash delta = +released - cover_cost(40*40=1600)
-    expected_cash = pre["cash"] + released - 1_600.0
+    # Covering spends cash; released collateral remains tracked in margin_used.
+    expected_cash = pre["cash"] - 1_600.0
     assert snap["cash"] == pytest.approx(expected_cash)
 
 

--- a/tests/backtesting/test_valuation.py
+++ b/tests/backtesting/test_valuation.py
@@ -7,10 +7,18 @@ def test_calculate_portfolio_value(portfolio, prices):
     portfolio.apply_short_open("MSFT", 5, 200.0)
 
     value = calculate_portfolio_value(portfolio, prices)
-    # cash after trades
-    snap = portfolio.get_snapshot()
-    expected = snap["cash"] + 10 * 100.0 - 5 * 200.0
-    assert value == expected
+    assert value == 100_000.0
+
+
+def test_short_open_preserves_equity_and_marks_to_market() -> None:
+    from src.backtesting.portfolio import Portfolio
+
+    portfolio = Portfolio(tickers=["AAPL"], initial_cash=1_000.0, margin_requirement=0.5)
+    portfolio.apply_short_open("AAPL", 10, 100.0)
+
+    assert calculate_portfolio_value(portfolio, {"AAPL": 100.0}) == 1_000.0
+    assert calculate_portfolio_value(portfolio, {"AAPL": 110.0}) == 900.0
+    assert calculate_portfolio_value(portfolio, {"AAPL": 90.0}) == 1_100.0
 
 
 def test_compute_exposures(portfolio, prices):

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -1,0 +1,19 @@
+from app.backend.services.backtest_service import BacktestService
+from app.backend.services.portfolio import create_portfolio
+
+
+def test_short_open_preserves_web_backtest_equity_and_buying_power() -> None:
+    service = BacktestService(
+        graph=None,
+        portfolio=create_portfolio(1_000.0, 0.5, ["AAPL"]),
+        tickers=["AAPL"],
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+        initial_capital=1_000.0,
+    )
+
+    assert service.execute_trade("AAPL", "short", 10, 100.0) == 10
+    assert service.calculate_portfolio_value({"AAPL": 100.0}) == 1_000.0
+    assert service.calculate_portfolio_value({"AAPL": 110.0}) == 900.0
+    assert service.execute_trade("AAPL", "short", 30, 100.0) == 10
+    assert service._available_cash() == 0.0

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1,0 +1,23 @@
+from src.agents.portfolio_manager import compute_allowed_actions
+
+
+def test_allowed_actions_exclude_restricted_short_proceeds() -> None:
+    portfolio = {
+        "cash": 2_000.0,
+        "margin_requirement": 0.5,
+        "margin_used": 500.0,
+        "positions": {
+            "AAPL": {
+                "long": 0,
+                "short": 10,
+                "short_cost_basis": 100.0,
+            }
+        },
+    }
+
+    actions = compute_allowed_actions(
+        ["AAPL"], {"AAPL": 100.0}, {"AAPL": 100}, portfolio,
+    )
+
+    assert actions["AAPL"]["buy"] == 5
+    assert actions["AAPL"]["short"] == 10


### PR DESCRIPTION
## Summary

- Preserve account equity when opening and covering short positions.
- Reserve short-sale proceeds and collateral from later buy and short capacity.
- Apply the same accounting model to the CLI backtester, web backtester, and portfolio-manager limits.

## Root cause

Opening a short removed initial margin from cash while net liquidation value also removed the short liability. That created an immediate false loss equal to the margin. The remaining calculation also let short-sale proceeds fund additional positions beyond the available collateral.

## Validation

- Full suite: 139 passed, 38 skipped.
- Added core, web-backtest, and portfolio-manager regressions for entry equity, mark-to-market PnL, and restricted buying power.
