### PR TITLE
Add Momentum alpha model (12-1 time-series momentum)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ the engine. Two flavors:
 |-------|--------|
 | Post-Earnings Announcement Drift (PEAD) | ✅ |
 | Market-regime detection (HMM / regime-switching) | ⬜ |
-| Momentum | ⬜ |
+| Momentum | ✅ |
 | Mean reversion | ⬜ |
 | Value / quality factors | ⬜ |
 | Statistical arbitrage | ⬜ |

--- a/v2/signals/__init__.py
+++ b/v2/signals/__init__.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 from v2.signals.base import AlphaModel, QuantModel
 from v2.signals.buffett import BuffettAgent
 from v2.signals.llm_agent import LLMAgent
+from v2.signals.momentum import MomentumModel
 from v2.signals.pead import PEADModel
 
 ALPHA_MODEL_REGISTRY: dict[str, type[AlphaModel]] = {
     "pead": PEADModel,
+    "momentum": MomentumModel,
     "buffett": BuffettAgent,
 }
 
@@ -21,6 +23,7 @@ __all__ = [
     "QuantModel",
     "LLMAgent",
     "BuffettAgent",
+    "MomentumModel",
     "PEADModel",
     "ALPHA_MODEL_REGISTRY",
 ]

--- a/v2/signals/momentum.py
+++ b/v2/signals/momentum.py
@@ -1,0 +1,103 @@
+"""Momentum alpha model — time-series (12-1) price momentum.
+
+Go long stocks that have risen over roughly the past year and short those
+that have fallen, while **skipping the most recent month** to sidestep the
+well-documented short-term reversal effect. This "12-1" window (twelve months
+of history, excluding the last one) is the canonical momentum specification
+from Jegadeesh & Titman (1993) and Asness, Moskowitz & Pedersen (2013).
+
+Momentum is the trend counterpart to a mean-reversion model and complements
+the event-driven PEAD signal: PEAD reacts to a discrete earnings surprise,
+momentum rides the persistent drift in the price itself.
+
+Pure Python math over prices — same AlphaModel interface as every other
+signal. It only forms a *view* (conviction in [-1, +1]); the backtest harness
+and portfolio construction decide timing and sizing.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from v2.data.protocol import DataClient
+from v2.models import Signal
+from v2.signals.base import QuantModel
+
+_TRADING_DAYS_PER_MONTH = 21
+
+
+class MomentumModel(QuantModel):
+    """Time-series (12-1) momentum: trailing return excluding the last month.
+
+    ``predict(ticker, date)`` measures the return from ``lookback_months`` ago
+    up to ``skip_months`` ago and maps it to a conviction in [-1, +1] via a
+    scaled ``tanh``. Returns 0.0 (no view) when there is not enough
+    point-in-time price history to form the window.
+    """
+
+    def __init__(
+        self,
+        *,
+        lookback_months: int = 12,
+        skip_months: int = 1,
+        scale: float = 3.0,
+    ) -> None:
+        if lookback_months <= 0:
+            raise ValueError(f"lookback_months must be positive, got {lookback_months}")
+        if skip_months < 0:
+            raise ValueError(f"skip_months must be >= 0, got {skip_months}")
+        if skip_months >= lookback_months:
+            raise ValueError(f"skip_months ({skip_months}) must be < lookback_months ({lookback_months})")
+        self._lookback_months = lookback_months
+        self._skip_months = skip_months
+        self._scale = scale
+
+    @property
+    def name(self) -> str:
+        return "momentum"
+
+    def predict(self, ticker: str, date: str, data_client: DataClient) -> Signal:
+        # Point-in-time: fetch only prices up to `date` (end_date=date, no
+        # lookahead). Pad the start generously so calendar-vs-trading-day gaps
+        # (weekends, holidays) still leave enough bars for the lookback window.
+        start = (_parse_date(date) - timedelta(days=self._lookback_months * 31 + 45)).isoformat()
+        prices = data_client.get_prices(ticker, start, date)
+
+        # Sort defensively — providers do not all return bars in order — and
+        # drop non-positive closes (bad ticks) before indexing.
+        closes = [p.close for p in sorted(prices, key=lambda p: p.time) if p.close > 0]
+
+        skip = self._skip_months * _TRADING_DAYS_PER_MONTH
+        lookback = self._lookback_months * _TRADING_DAYS_PER_MONTH
+        if len(closes) <= lookback:
+            return self._neutral(ticker, date)
+
+        # 12-1 window: price `skip` bars ago relative to price `lookback` bars ago.
+        start_price = closes[-lookback - 1]
+        end_price = closes[-1] if skip == 0 else closes[-skip - 1]
+        if start_price <= 0:
+            return self._neutral(ticker, date)
+
+        trailing_return = end_price / start_price - 1.0
+        value = self._sigmoid(trailing_return, scale=self._scale)
+
+        return Signal(
+            model_name=self.name,
+            ticker=ticker,
+            date=date,
+            value=value,
+            reasoning=f"{self._lookback_months}-{self._skip_months} momentum = {trailing_return:+.1%} -> conviction {value:+.2f}",
+            components={"trailing_return": trailing_return},
+            metadata={
+                "lookback_months": self._lookback_months,
+                "skip_months": self._skip_months,
+                "n_bars": len(closes),
+            },
+        )
+
+    def _neutral(self, ticker: str, date: str) -> Signal:
+        return Signal(model_name=self.name, ticker=ticker, date=date, value=0.0)
+
+
+def _parse_date(s: str) -> date:
+    return datetime.strptime(s[:10], "%Y-%m-%d").date()

--- a/v2/signals/test_momentum.py
+++ b/v2/signals/test_momentum.py
@@ -1,0 +1,125 @@
+"""Tests for the Momentum alpha model (12-1 time-series momentum)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from v2.data.models import Price
+from v2.models import Signal
+from v2.signals import MomentumModel
+from v2.signals.base import AlphaModel, QuantModel
+
+
+class MockPriceClient:
+    """Returns canned daily bars, filtered point-in-time by [start, end]."""
+
+    def __init__(self, prices: list[Price]) -> None:
+        self._prices = prices
+        self.last_end_date: str | None = None
+
+    def get_prices(self, ticker, start_date, end_date, **kwargs) -> list[Price]:
+        self.last_end_date = end_date
+        return [p for p in self._prices if start_date <= p.time[:10] <= end_date]
+
+
+def _series(end_date: str, closes: list[float]) -> list[Price]:
+    """Build one daily bar per calendar day, oldest first, ending at end_date."""
+    end = datetime.strptime(end_date, "%Y-%m-%d").date()
+    n = len(closes)
+    return [
+        Price(
+            open=c,
+            high=c,
+            low=c,
+            close=c,
+            volume=0,
+            time=(end - timedelta(days=(n - 1 - i))).isoformat(),
+        )
+        for i, c in enumerate(closes)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Interface
+# ---------------------------------------------------------------------------
+
+
+class TestInterface:
+    def test_is_quant_model(self):
+        assert issubclass(MomentumModel, QuantModel)
+        assert issubclass(MomentumModel, AlphaModel)
+
+    def test_name(self):
+        assert MomentumModel().name == "momentum"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"lookback_months": 0},
+            {"skip_months": -1},
+            {"lookback_months": 3, "skip_months": 3},
+            {"lookback_months": 3, "skip_months": 5},
+        ],
+    )
+    def test_invalid_params_rejected(self, kwargs):
+        with pytest.raises(ValueError):
+            MomentumModel(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# predict
+# ---------------------------------------------------------------------------
+
+
+class TestMomentumPredict:
+    def test_uptrend_is_long(self):
+        # 300 rising daily closes -> positive 12-1 return -> bullish conviction.
+        closes = [100.0 * (1.001**i) for i in range(300)]
+        client = MockPriceClient(_series("2025-06-30", closes))
+        sig = client_predict(client, "2025-06-30")
+        assert isinstance(sig, Signal)
+        assert sig.model_name == "momentum"
+        assert sig.value > 0.0
+        assert sig.components["trailing_return"] > 0.0
+
+    def test_downtrend_is_short(self):
+        closes = [100.0 * (0.999**i) for i in range(300)]
+        client = MockPriceClient(_series("2025-06-30", closes))
+        sig = client_predict(client, "2025-06-30")
+        assert sig.value < 0.0
+        assert sig.components["trailing_return"] < 0.0
+
+    def test_insufficient_history_is_neutral(self):
+        # Fewer bars than the lookback window -> no view.
+        closes = [100.0 + i for i in range(100)]
+        client = MockPriceClient(_series("2025-06-30", closes))
+        sig = client_predict(client, "2025-06-30")
+        assert sig.value == 0.0
+
+    def test_last_month_is_skipped(self):
+        # Rise for the first 279 bars, then crash hard over the final ~month.
+        # The 12-1 window ends one month before `date`, so it must ignore the
+        # crash and still read the up-move -> bullish.
+        closes = [100.0 * (1.002**i) for i in range(279)]
+        closes += [closes[-1] * (0.90**k) for k in range(1, 22)]  # -10%/day for 21 days
+        client = MockPriceClient(_series("2025-06-30", closes))
+        sig = client_predict(client, "2025-06-30")
+        assert sig.value > 0.0, "signal should reflect the 12-1 window, not the skipped last month"
+
+    def test_point_in_time_ignores_future_bars(self):
+        # Rising history up to `date`, then a crash on later dates. A
+        # point-in-time model must not see the post-date bars.
+        closes = [100.0 * (1.001**i) for i in range(300)]
+        history = _series("2025-06-30", closes)
+        future = _series("2025-08-15", [50.0 * (0.9**k) for k in range(46)])  # after date
+        client = MockPriceClient(history + future)
+
+        sig = client_predict(client, "2025-06-30")
+        assert client.last_end_date == "2025-06-30"
+        assert sig.value > 0.0  # unaffected by the future crash
+
+
+def client_predict(client: MockPriceClient, date: str) -> Signal:
+    return MomentumModel().predict("TEST", date, client)


### PR DESCRIPTION
Adds the Momentum analyst from the roadmap (Analysts > Quantitative models).

## What

A pure-math `QuantModel` (same interface as PEAD) that measures trailing price return over the past ~12 months while skipping the most recent month to avoid short-term reversal (the canonical 12-1 momentum of Jegadeesh & Titman 1993), and maps it to a conviction in [-1, +1] via scaled tanh.

- Point-in-time by construction: fetches only prices up to the as-of date, no lookahead.
- Returns 0.0 (no view) when there is not enough history.
- Registers as `"momentum"`, so `python -m v2.analyze TICKER --agent momentum` works with no other changes.

## Scope

Four files, no new dependencies, no packaging or lock changes:

- `v2/signals/momentum.py` new model
- `v2/signals/test_momentum.py` unit tests (uptrend/downtrend/neutral, param validation, last-month skip, point-in-time correctness)
- `v2/signals/__init__.py` register in `ALPHA_MODEL_REGISTRY`
- `ROADMAP.md` flip the Momentum row to shipped

## Tests

`pytest v2/ --ignore=v2/event_study` passes (67 passed, 36 skipped). black/isort/ruff clean on the changed files.