### PR TITLE
Fix backtest crash when a short wipes out the book

### DIFF
--- a/v2/backtesting/engine.py
+++ b/v2/backtesting/engine.py
@@ -252,7 +252,12 @@ class BacktestEngine:
         last_exit = _parse_date(trades[-1].exit_date)
         calendar_days = (last_exit - first_entry).days
         years = max(calendar_days / 365.25, 0.01)
-        annualized = (1 + total_return_pct) ** (1 / years) - 1
+        # Shorts are unbounded, so the book can be wiped out (equity <= 0).
+        # A non-positive growth factor raised to a fractional power is a
+        # complex number, which breaks the metric. Losing everything is
+        # -100% annualized.
+        growth = 1 + total_return_pct
+        annualized = growth ** (1 / years) - 1 if growth > 0 else -1.0
 
         # Sharpe ratio: average return divided by volatility, scaled to
         # annual terms. Higher = better risk-adjusted performance.

--- a/v2/backtesting/test_backtest.py
+++ b/v2/backtesting/test_backtest.py
@@ -182,6 +182,19 @@ class TestMetrics:
         assert result.metrics.n_long == 2
         assert result.metrics.win_rate == 0.5
 
+    def test_wiped_out_book_annualizes_to_total_loss(self):
+        # A short's loss is unbounded: a full-size short on a stock that
+        # triples loses more than the account, taking equity below zero.
+        # Annualizing a negative growth factor must not blow up.
+        prices = _make_prices(100.0, 20, daily_change=0.25)
+        result = BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
+            FixedAlpha(-1.0), ["MEME"], MockFDClient(prices),
+            prices[0].time[:10], prices[6].time[:10], holding_days=5,
+        )
+        assert result.equity_curve[-1] < 0
+        assert result.metrics.total_return_pct < -1.0
+        assert result.metrics.annualized_return_pct == -1.0
+
 
 # ---------------------------------------------------------------------------
 # Integration — requires API key


### PR DESCRIPTION
A backtest that ends with negative equity crashes instead of reporting metrics:

```
TypeError: type complex doesn't define __round__ method
```

## Cause

A short's loss is unbounded (`return_pct = (entry_price - exit_price) / entry_price`), so `equity += t.pnl` can fall below zero. `_compute_metrics` then annualizes with:

```python
annualized = (1 + total_return_pct) ** (1 / years) - 1
```

When equity is negative, `1 + total_return_pct` is negative. Python evaluates a negative base with a fractional exponent to a **complex** number, which then reaches `round(annualized, 6)` and raises.

## Reproduce

A full-size short (`capital == per_trade`) on a stock that triples during the hold. Equity goes from 10,000 to -10,517, and `run_alpha` raises:

```python
prices = _make_prices(100.0, 20, daily_change=0.25)
BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
    FixedAlpha(-1.0), ["MEME"], MockFDClient(prices),
    prices[0].time[:10], prices[6].time[:10], holding_days=5,
)
```

## Fix

Guard the annualization. A book that ends at or below zero is a total loss, which is -100% annualized:

```python
growth = 1 + total_return_pct
annualized = growth ** (1 / years) - 1 if growth > 0 else -1.0
```

## Scope

Two files, no new dependencies. Adds a regression test that drives the crash through the public `run_alpha` path and asserts the book is wiped out and the metric is -1.0. `pytest v2/ --ignore=v2/event_study` passes (57 passed, 36 skipped).

Note: `v2/backtesting/` is not black-formatted at HEAD, so the test matches the surrounding hand-formatted style rather than reformatting untouched code.