### PR TITLE
docs: sync agent lists with Growth and News Sentiment analysts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ This system employs several agents working together:
 15. Sentiment Agent - Analyzes market sentiment and generates trading signals
 16. Fundamentals Agent - Analyzes fundamental data and generates trading signals
 17. Technicals Agent - Analyzes technical indicators and generates trading signals
-18. Risk Manager - Calculates risk metrics and sets position limits
-19. Portfolio Manager - Makes final trading decisions and generates orders
+18. Growth Analyst - Analyzes growth trends and valuation to identify growth opportunities
+19. News Sentiment Analyst - Analyzes company news sentiment to generate trading signals
+20. Risk Manager - Calculates risk metrics and sets position limits
+21. Portfolio Manager - Makes final trading decisions and generates orders
 
 <img width="1042" alt="Screenshot 2025-03-22 at 6 19 07 PM" src="https://github.com/user-attachments/assets/cbae3dcf-b571-490d-b0ad-3f0f035ac0d4" />
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,17 +11,20 @@ This system employs several agents working together:
 5. Charlie Munger Agent - Warren Buffett's partner, only buys wonderful businesses at fair prices
 6. Michael Burry Agent - The Big Short contrarian who hunts for deep value
 7. Mohnish Pabrai Agent - The Dhandho investor, who looks for doubles at low risk
-8. Peter Lynch Agent - Practical investor who seeks "ten-baggers" in everyday businesses
-9. Phil Fisher Agent - Meticulous growth investor who uses deep "scuttlebutt" research 
-10. Rakesh Jhunjhunwala Agent - The Big Bull of India
-11. Stanley Druckenmiller Agent - Macro legend who hunts for asymmetric opportunities with growth potential
-12. Warren Buffett Agent - The oracle of Omaha, seeks wonderful companies at a fair price
-13. Valuation Agent - Calculates the intrinsic value of a stock and generates trading signals
-14. Sentiment Agent - Analyzes market sentiment and generates trading signals
-15. Fundamentals Agent - Analyzes fundamental data and generates trading signals
-16. Technicals Agent - Analyzes technical indicators and generates trading signals
-17. Risk Manager - Calculates risk metrics and sets position limits
-18. Portfolio Manager - Makes final trading decisions and generates orders
+8. Nassim Taleb Agent - The Black Swan risk analyst, focuses on tail risk, antifragility, and asymmetric payoffs
+9. Peter Lynch Agent - Practical investor who seeks "ten-baggers" in everyday businesses
+10. Phil Fisher Agent - Meticulous growth investor who uses deep "scuttlebutt" research 
+11. Rakesh Jhunjhunwala Agent - The Big Bull of India
+12. Stanley Druckenmiller Agent - Macro legend who hunts for asymmetric opportunities with growth potential
+13. Warren Buffett Agent - The oracle of Omaha, seeks wonderful companies at a fair price
+14. Valuation Agent - Calculates the intrinsic value of a stock and generates trading signals
+15. Sentiment Agent - Analyzes market sentiment and generates trading signals
+16. Fundamentals Agent - Analyzes fundamental data and generates trading signals
+17. Technicals Agent - Analyzes technical indicators and generates trading signals
+18. Growth Analyst - Analyzes growth trends and valuation to identify growth opportunities
+19. News Sentiment Analyst - Analyzes company news sentiment to generate trading signals
+20. Risk Manager - Calculates risk metrics and sets position limits
+21. Portfolio Manager - Makes final trading decisions and generates orders
 
 <img width="1042" alt="Screenshot 2025-03-22 at 6 19 07 PM" src="https://github.com/user-attachments/assets/cbae3dcf-b571-490d-b0ad-3f0f035ac0d4" />
 


### PR DESCRIPTION
## Summary
The root and Docker READMEs still advertise the pre–Growth / pre–News-Sentiment agent roster. Both analysts have been registered in `src/utils/analysts.py` since `6570f74` (Growth) and `8a4d571` (News Sentiment), and `docker/README.md` was also still missing Nassim Taleb (present in the root README). This brings the published agent lists back in line with `ANALYST_CONFIG`.

## Problem
Newcomers reading either README miss two live analysts that the CLI/web graph already expose via `get_agents_list()` / `ANALYST_CONFIG`.

## Solution
- Add **Growth Analyst** and **News Sentiment Analyst** to `README.md` (entries 18–19; renumber Risk Manager / Portfolio Manager).
- Same two entries in `docker/README.md`, plus **Nassim Taleb Agent**, so the Docker copy matches the root list.

## Out of scope
- Did not rename existing README labels (e.g. "Technicals Agent" vs config's "Technical Analyst") — only filled the missing agents.
- Did not touch `VISION.md` / `ROADMAP.md` aspirational agent tables.
- Left open bugfix PRs (#572, #618, #686, etc.) alone.

## Test plan
- [x] Diffed README agent names against `display_name` values in `src/utils/analysts.py`.
- [x] Confirmed no open PR already syncing these two docs.
- [ ] Visual check of rendered README on GitHub.

## Related
- `6570f74` — Add growth agent
- `8a4d571` — Add news sentiment agent
- #556 / `84c2f9e` — later news-sentiment robustness fix (agent already shipped)

Made with [Cursor](https://cursor.com)