### PR TITLE
Use daily portfolio ledger for v2 backtest metrics

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -53,7 +53,7 @@ Data (point-in-time) → Alpha models → Portfolio → Risk → Execution → L
 | `signals/` | `AlphaModel`/`QuantModel` interface, PEAD, `LLMAgent`, Buffett | ✅ |
 | `llm/` | LLM provider protocol, Anthropic client, prompt cache | ✅ |
 | `features/` | Point-in-time fundamentals snapshot (more features planned) | ◐ |
-| `backtesting/` | Backtest engine over an alpha model's views | ✅ |
+| `backtesting/` | Cash-constrained backtester with a daily mark-to-market portfolio ledger | ✅ |
 | `event_study/` | Market-model abnormal returns (CARs) | ✅ |
 | `demo/` | Presentation showcases over the real engine | ✅ |
 | `validation/` | Combinatorial purged CV (CPCV), backtest-overfitting prob (PBO) | ⬜ |

--- a/v2/backtesting/__init__.py
+++ b/v2/backtesting/__init__.py
@@ -1,9 +1,12 @@
 """v2 backtesting — simulate trading an alpha model's signals over time."""
 
 from v2.backtesting.engine import BacktestEngine
+from v2.backtesting.ledger import PortfolioLedger
 from v2.backtesting.models import (
     BacktestResult,
     PerformanceMetrics,
+    PortfolioLedgerEntry,
+    PositionSnapshot,
     Trade,
 )
 
@@ -11,5 +14,8 @@ __all__ = [
     "BacktestEngine",
     "BacktestResult",
     "PerformanceMetrics",
+    "PortfolioLedger",
+    "PortfolioLedgerEntry",
+    "PositionSnapshot",
     "Trade",
 ]

--- a/v2/backtesting/__main__.py
+++ b/v2/backtesting/__main__.py
@@ -129,20 +129,16 @@ def main() -> None:
     engine = BacktestEngine(capital=CAPITAL, per_trade=PER_TRADE)
     model = PEADModel()
 
-    # Phase 1: Backtest the PEAD alpha model, ticker by ticker, with progress
+    # Phase 1: Backtest all tickers in one shared, cash-constrained portfolio.
     sys.stdout.write(f"  Backtesting PEAD alpha... [0/{n}]")
     sys.stdout.flush()
 
-    trades = []
     with FDClient() as fd:
-        for i, ticker in enumerate(TICKERS):
-            sys.stdout.write(f"\r  Backtesting PEAD alpha... [{i + 1}/{n}] {ticker:<6}")
-            sys.stdout.flush()
-            r = engine.run_alpha(
-                model, [ticker], fd, START_DATE, END_DATE, holding_days=HOLDING_DAYS,
-            )
-            trades.extend(r.trades)
+        result = engine.run_alpha(
+            model, TICKERS, fd, START_DATE, END_DATE, holding_days=HOLDING_DAYS,
+        )
 
+    trades = sorted(result.trades, key=lambda trade: (trade.exit_date, trade.ticker))
     sys.stdout.write(f"\r  Backtesting PEAD alpha... {len(trades)} trades" + " " * 20 + "\n")
     sys.stdout.flush()
     time.sleep(0.5)
@@ -151,25 +147,19 @@ def main() -> None:
         print("  No trades generated.")
         return
 
-    trades.sort(key=lambda t: t.entry_date)
-
-    # Phase 2: Replay trades one by one with running metrics
+    # Phase 2: Replay settlement dates against the daily marked-to-market NAV.
     clear()
-    equity = CAPITAL
-    displayed: list = []
+    for cutoff in sorted({trade.exit_date for trade in trades}):
+        displayed = [trade for trade in trades if trade.exit_date <= cutoff]
+        running_ledger = [entry for entry in result.ledger if entry.date <= cutoff]
 
-    for trade in trades:
-        equity += trade.pnl
-        displayed.append(trade)
-
-        # Rebuild display each trade (like v1's clear-and-reprint)
+        # Rebuild the display on each settlement date.
         clear()
 
-        # Compute running metrics over the trades shown so far
-        running_curve = engine._build_equity_curve(displayed)
-        running_metrics = engine._compute_metrics(displayed, running_curve)
+        # Compute risk metrics from the daily NAV path shown so far.
+        running_metrics = engine._compute_metrics(displayed, running_ledger)
 
-        print_header(running_metrics, equity)
+        print_header(running_metrics, running_ledger[-1].nav)
         print_table_header()
 
         # Print all trades so far (newest first)
@@ -179,8 +169,14 @@ def main() -> None:
         print()
         time.sleep(0.4)
 
-    # Final summary
+    # Final summary uses the complete requested backtest window.
     time.sleep(0.5)
+    clear()
+    print_header(result.metrics, result.equity_curve[-1])
+    print_table_header()
+    for trade in reversed(trades):
+        print_trade_row(trade)
+    print()
     print(f"  {BOLD}Done.{RESET} {len(trades)} trades executed.\n")
 
 

--- a/v2/backtesting/engine.py
+++ b/v2/backtesting/engine.py
@@ -1,27 +1,9 @@
-"""Backtesting engine — simulate trading an alpha model's views over time.
+"""Backtest alpha views through one cash-constrained, marked-to-market book.
 
-The engine queries an AlphaModel across a date grid, turns its convictions
-into trades, and computes performance (return, Sharpe, drawdown).
-
-IMPORTANT — separation of concerns (the "unify" decision):
-  - The AlphaModel forms *views* (conviction in [-1, +1]).
-  - This engine owns *mechanics* (entry timing, holding period, sizing).
-These mechanics are intentionally simple for now (threshold + fixed holding
-period + equal-dollar sizing). Week 8 portfolio construction will replace
-this harness with real position sizing and risk-aware weighting.
-
-Usage:
-    from datetime import date
-    from v2.data import FDClient
-    from v2.backtesting import BacktestEngine
-    from v2.signals import PEADModel
-
-    with FDClient() as fd:
-        engine = BacktestEngine(capital=100_000, per_trade=10_000)
-        result = engine.run_alpha(
-            PEADModel(), ["AAPL", "MSFT"], fd,
-            "2024-06-01", date.today().isoformat(), holding_days=5,
-        )
+The AlphaModel only forms views. This harness owns the intentionally simple
+mechanics: threshold entries, equal-dollar targets, fixed holding periods, and
+fully collateralized shorts. All tickers share one PortfolioLedger, so capital
+cannot be allocated independently more than once.
 """
 
 from __future__ import annotations
@@ -31,7 +13,8 @@ from datetime import date, datetime, timedelta
 
 import numpy as np
 
-from v2.backtesting.models import BacktestResult, PerformanceMetrics, Trade
+from v2.backtesting.ledger import PortfolioLedger, TradeIntent
+from v2.backtesting.models import BacktestResult, PerformanceMetrics, PortfolioLedgerEntry, Trade
 from v2.data.protocol import DataClient
 from v2.signals.base import AlphaModel
 
@@ -39,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class BacktestEngine:
-    """Simulates trading an alpha model's signals with equal-dollar sizing."""
+    """Simulate an alpha model against one shared portfolio."""
 
     def __init__(
         self,
@@ -47,8 +30,12 @@ class BacktestEngine:
         capital: float = 100_000.0,
         per_trade: float = 10_000.0,
     ) -> None:
-        self._capital = capital
-        self._per_trade = per_trade
+        if capital <= 0:
+            raise ValueError("capital must be positive")
+        if per_trade <= 0:
+            raise ValueError("per_trade must be positive")
+        self._capital = float(capital)
+        self._per_trade = float(per_trade)
 
     def run_alpha(
         self,
@@ -61,239 +48,236 @@ class BacktestEngine:
         threshold: float = 0.0,
         holding_days: int = 5,
     ) -> BacktestResult:
-        """Backtest an alpha model over [start_date, end_date].
+        """Backtest an alpha model over ``[start_date, end_date]``.
 
-        For each ticker we walk the trading-day grid, ask the model for its
-        view, and open a position whenever conviction clears `threshold`.
-        Positions are held for `holding_days` trading days.
-
-        Args:
-            model:        AlphaModel to backtest (e.g. PEADModel()).
-            tickers:      Universe to trade.
-            data_client:    Data client.
-            start_date:   First date to evaluate signals (YYYY-MM-DD).
-            end_date:     Last date to evaluate signals (YYYY-MM-DD).
-            threshold:    Minimum |conviction| to act on (0.0 = any nonzero view).
-            holding_days: Trading days to hold each position.
+        Candidate entries are generated per ticker, then executed together in
+        chronological order against a shared pool of cash. Same-day signals
+        split available cash equally up to ``per_trade`` each. The returned
+        ledger is marked to market at every available close through the later
+        of ``end_date`` and the final accepted exit.
         """
-        trades: list[Trade] = []
-        for ticker in tickers:
-            trades.extend(self._trade_ticker(
-                model, ticker, data_client, start_date, end_date,
-                threshold=threshold, holding_days=holding_days,
-            ))
+        if holding_days <= 0:
+            raise ValueError("holding_days must be positive")
+        if threshold < 0:
+            raise ValueError("threshold must be non-negative")
 
-        if not trades:
+        price_maps = self._load_price_maps(
+            tickers, data_client, start_date, end_date, holding_days,
+        )
+        if not price_maps:
             return BacktestResult()
 
-        trades.sort(key=lambda t: t.entry_date)
-        equity_curve = self._build_equity_curve(trades)
-        metrics = self._compute_metrics(trades, equity_curve)
-        return BacktestResult(trades=trades, metrics=metrics, equity_curve=equity_curve)
+        intents: list[TradeIntent] = []
+        for ticker in tickers:
+            price_map = price_maps.get(ticker)
+            if not price_map:
+                continue
+            intents.extend(
+                self._trade_ticker(
+                    model,
+                    ticker,
+                    data_client,
+                    price_map,
+                    start_date,
+                    end_date,
+                    threshold=threshold,
+                    holding_days=holding_days,
+                )
+            )
+
+        # Include padded dates while simulating so positions opened near the
+        # requested end can close mechanically.
+        padded_calendar = sorted(
+            {
+                day
+                for price_map in price_maps.values()
+                for day in price_map
+                if day >= start_date
+            }
+        )
+        ledger = PortfolioLedger(capital=self._capital, per_trade=self._per_trade)
+        trades, snapshots = ledger.run(intents, price_maps, padded_calendar)
+
+        final_date = max(
+            [end_date, *(trade.exit_date for trade in trades)],
+        )
+        snapshots = [snapshot for snapshot in snapshots if snapshot.date <= final_date]
+        equity_curve = self._build_equity_curve(snapshots)
+        metrics = self._compute_metrics(trades, snapshots) if trades else None
+        return BacktestResult(
+            trades=trades,
+            metrics=metrics,
+            equity_curve=equity_curve,
+            ledger=snapshots,
+        )
 
     # ------------------------------------------------------------------
-    # Per-ticker simulation
+    # Data and candidate generation
     # ------------------------------------------------------------------
+
+    def _load_price_maps(
+        self,
+        tickers: list[str],
+        data_client: DataClient,
+        start_date: str,
+        end_date: str,
+        holding_days: int,
+    ) -> dict[str, dict[str, float]]:
+        end_padded = (_parse_date(end_date) + timedelta(days=holding_days * 2 + 10)).isoformat()
+        end_padded = min(end_padded, date.today().isoformat())
+
+        price_maps: dict[str, dict[str, float]] = {}
+        for ticker in tickers:
+            prices = data_client.get_prices(ticker, start_date, end_padded)
+            if not prices:
+                continue
+            price_map = {
+                price.time[:10]: float(price.close)
+                for price in prices
+                if price.close is not None and float(price.close) > 0
+            }
+            if price_map:
+                price_maps[ticker] = price_map
+        return price_maps
 
     def _trade_ticker(
         self,
         model: AlphaModel,
         ticker: str,
         data_client: DataClient,
+        price_map: dict[str, float],
         start_date: str,
         end_date: str,
         *,
         threshold: float,
         holding_days: int,
-    ) -> list[Trade]:
-        """Walk one ticker's trading-day grid and open/close positions."""
-        # Fetch the price series once. Pad the end so exits beyond end_date
-        # still have a closing price to fill against.
-        end_padded = (_parse_date(end_date) + timedelta(days=holding_days * 2 + 10)).isoformat()
-        today = date.today().isoformat()
-        if end_padded > today:
-            end_padded = today
-
-        prices = data_client.get_prices(ticker, start_date, end_padded)
-        if not prices:
-            return []
-
-        price_map = {p.time[:10]: p.close for p in prices}
+    ) -> list[TradeIntent]:
+        """Walk one ticker's signal grid and emit unallocated trade intents."""
         all_days = sorted(price_map)
-        # Scan grid = trading days within [start_date, end_date]
-        grid = [d for d in all_days if start_date <= d <= end_date]
+        all_day_index = {day: index for index, day in enumerate(all_days)}
+        grid = [day for day in all_days if start_date <= day <= end_date]
+        grid_index = {day: index for index, day in enumerate(grid)}
 
-        trades: list[Trade] = []
-        armed = True  # edge-trigger: only open when re-armed (signal returned to flat)
+        intents: list[TradeIntent] = []
+        armed = True
         i = 0
         while i < len(grid):
-            d = grid[i]
-            signal = model.predict(ticker, d, data_client)
+            current_date = grid[i]
+            signal = model.predict(ticker, current_date, data_client)
 
             if armed and abs(signal.value) > threshold:
-                direction = "long" if signal.value > 0 else "short"
-                entry_idx = all_days.index(d)
+                entry_idx = all_day_index[current_date]
                 exit_idx = entry_idx + holding_days
                 if exit_idx >= len(all_days):
-                    break  # not enough future data to close the position
-                trade = self._build_trade(
-                    ticker, direction, d, all_days[exit_idx],
-                    price_map, holding_days, signal.reasoning, dict(signal.metadata),
+                    break
+                exit_date = all_days[exit_idx]
+                direction = "long" if signal.value > 0 else "short"
+                intents.append(
+                    TradeIntent(
+                        ticker=ticker,
+                        direction=direction,
+                        entry_date=current_date,
+                        exit_date=exit_date,
+                        entry_price=price_map[current_date],
+                        exit_price=price_map[exit_date],
+                        holding_days=holding_days,
+                        reasoning=signal.reasoning,
+                        metadata=dict(signal.metadata),
+                    )
                 )
-                if trade is not None:
-                    trades.append(trade)
                 armed = False
-                # Skip ahead past the holding period — no overlapping positions
-                i = grid.index(all_days[exit_idx]) if all_days[exit_idx] in grid else len(grid)
+                if exit_date not in grid_index:
+                    break
+                i = grid_index[exit_date]
                 continue
 
-            # Re-arm once the model goes back to "no view"
             if abs(signal.value) <= threshold:
                 armed = True
             i += 1
 
-        return trades
+        return intents
 
     # ------------------------------------------------------------------
-    # Signal -> Trade
+    # NAV curve and performance metrics
     # ------------------------------------------------------------------
 
-    def _build_trade(
-        self,
-        ticker: str,
-        direction: str,
-        entry_date: str,
-        exit_date: str,
-        price_map: dict[str, float],
-        holding_days: int,
-        reasoning: str | None,
-        metadata: dict,
-    ) -> Trade | None:
-        """Fill a position at entry/exit closes with equal-dollar sizing."""
-        entry_price = price_map.get(entry_date)
-        exit_price = price_map.get(exit_date)
-        if entry_price is None or exit_price is None or entry_price <= 0:
-            return None
-
-        shares = self._per_trade / entry_price
-
-        if direction == "long":
-            pnl = shares * (exit_price - entry_price)
-            return_pct = (exit_price - entry_price) / entry_price
-        else:
-            pnl = shares * (entry_price - exit_price)
-            return_pct = (entry_price - exit_price) / entry_price
-
-        return Trade(
-            ticker=ticker,
-            direction=direction,
-            entry_date=entry_date,
-            exit_date=exit_date,
-            entry_price=entry_price,
-            exit_price=exit_price,
-            shares=round(shares, 4),
-            pnl=round(pnl, 2),
-            return_pct=round(return_pct, 6),
-            holding_days=holding_days,
-            reasoning=reasoning,
-            metadata=metadata,
-        )
-
-    # ------------------------------------------------------------------
-    # Equity curve
-    # ------------------------------------------------------------------
-
-    def _build_equity_curve(self, trades: list[Trade]) -> list[float]:
-        """Track portfolio value after each trade settles.
-
-        Starts at initial capital (e.g. $100,000) and adds each trade's
-        dollar P&L in chronological order. The result is a list like:
-        [100000, 100500, 99800, 100200, ...] — one entry per trade plus
-        the starting value. This is what you'd plot to visualize the
-        strategy's performance and see drawdowns.
-        """
-        equity = self._capital
-        curve = [equity]
-        for t in trades:
-            equity += t.pnl
-            curve.append(round(equity, 2))
-        return curve
-
-    # ------------------------------------------------------------------
-    # Performance metrics
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _build_equity_curve(ledger: list[PortfolioLedgerEntry]) -> list[float]:
+        """Return the end-of-day NAV series from portfolio ledger entries."""
+        return [snapshot.nav for snapshot in ledger]
 
     def _compute_metrics(
         self,
         trades: list[Trade],
-        equity_curve: list[float],
+        ledger: list[PortfolioLedgerEntry],
     ) -> PerformanceMetrics:
-        """Compute the three numbers that tell you if a strategy works.
+        """Compute performance from daily portfolio NAV, not per-trade returns."""
+        if not ledger:
+            raise ValueError("cannot compute metrics without portfolio ledger entries")
 
-        1. Total/annualized return — did it make money?
-        2. Sharpe ratio — is the return worth the risk? (return per unit
-           of volatility, annualized). Above 1.0 is decent, above 2.0
-           is strong. Our PEAD strategy hit 0.33 — not tradable yet.
-        3. Max drawdown — how bad did it get at the worst point?
-           (largest peak-to-trough drop in the equity curve)
+        nav = np.asarray([snapshot.nav for snapshot in ledger], dtype=float)
+        final_nav = float(nav[-1])
+        total_return_pct = (final_nav - self._capital) / self._capital
 
-        Also computes win rate and trade counts for context.
-        """
-        returns = [t.return_pct for t in trades]
-        n = len(returns)
+        first_date = _parse_date(ledger[0].date)
+        last_date = _parse_date(ledger[-1].date)
+        calendar_days = max((last_date - first_date).days, 1)
+        years = calendar_days / 365.25
+        if final_nav <= 0:
+            annualized_return = -1.0
+        else:
+            annualized_return = (final_nav / self._capital) ** (1 / years) - 1
 
-        # Total return: how much the portfolio gained or lost overall
-        final_equity = equity_curve[-1]
-        total_return_pct = (final_equity - self._capital) / self._capital
+        daily_returns = np.asarray(
+            [
+                nav[index] / nav[index - 1] - 1
+                for index in range(1, len(nav))
+                if nav[index - 1] > 0
+            ],
+            dtype=float,
+        )
+        if len(daily_returns) >= 2:
+            daily_std = float(daily_returns.std(ddof=1))
+            annualized_volatility = daily_std * np.sqrt(252)
+            sharpe = (
+                float(daily_returns.mean()) / daily_std * np.sqrt(252)
+                if daily_std > 1e-12
+                else 0.0
+            )
+        else:
+            annualized_volatility = 0.0
+            sharpe = 0.0
 
-        # Annualized return: what the total return would be per year
-        # if the strategy ran at the same rate continuously
-        first_entry = _parse_date(trades[0].entry_date)
-        last_exit = _parse_date(trades[-1].exit_date)
-        calendar_days = (last_exit - first_entry).days
-        years = max(calendar_days / 365.25, 0.01)
-        annualized = (1 + total_return_pct) ** (1 / years) - 1
+        running_peak = np.maximum.accumulate(nav)
+        drawdowns = np.divide(
+            running_peak - nav,
+            running_peak,
+            out=np.zeros_like(nav),
+            where=running_peak != 0,
+        )
+        max_drawdown = float(drawdowns.max()) if len(drawdowns) else 0.0
 
-        # Sharpe ratio: average return divided by volatility, scaled to
-        # annual terms. Higher = better risk-adjusted performance.
-        arr = np.array(returns)
-        avg = float(arr.mean())
-        std = float(arr.std(ddof=1)) if n > 1 else 1.0
-        trades_per_year = n / years if years > 0 else n
-        sharpe = (avg / std) * np.sqrt(trades_per_year) if std > 0 else 0.0
-
-        # Max drawdown: walk the equity curve tracking the peak. Whenever
-        # the value drops below the peak, measure how far it fell. The
-        # largest such drop is the max drawdown.
-        peak = equity_curve[0]
-        max_dd = 0.0
-        for val in equity_curve:
-            if val > peak:
-                peak = val
-            dd = (peak - val) / peak
-            if dd > max_dd:
-                max_dd = dd
-
-        # Win rate: fraction of trades that made money
-        wins = sum(1 for r in returns if r > 0)
+        trade_returns = [trade.return_pct for trade in trades]
+        n_trades = len(trades)
+        wins = sum(1 for value in trade_returns if value > 0)
+        average_trade_return = float(np.mean(trade_returns)) if trade_returns else 0.0
 
         return PerformanceMetrics(
             total_return_pct=round(total_return_pct, 6),
-            annualized_return_pct=round(annualized, 6),
+            annualized_return_pct=round(annualized_return, 6),
+            annualized_volatility=round(annualized_volatility, 6),
             sharpe_ratio=round(sharpe, 4),
-            max_drawdown_pct=round(max_dd, 6),
-            win_rate=round(wins / n, 4) if n > 0 else 0.0,
-            n_trades=n,
-            n_long=sum(1 for t in trades if t.direction == "long"),
-            n_short=sum(1 for t in trades if t.direction == "short"),
-            avg_return_pct=round(avg, 6),
-            avg_holding_days=round(sum(t.holding_days for t in trades) / n, 1),
+            max_drawdown_pct=round(max_drawdown, 6),
+            win_rate=round(wins / n_trades, 4) if n_trades else 0.0,
+            n_trades=n_trades,
+            n_long=sum(1 for trade in trades if trade.direction == "long"),
+            n_short=sum(1 for trade in trades if trade.direction == "short"),
+            avg_return_pct=round(average_trade_return, 6),
+            avg_holding_days=round(
+                sum(trade.holding_days for trade in trades) / n_trades, 1,
+            ) if n_trades else 0.0,
         )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _parse_date(s: str) -> date:
-    return datetime.strptime(s[:10], "%Y-%m-%d").date()
+def _parse_date(value: str) -> date:
+    return datetime.strptime(value[:10], "%Y-%m-%d").date()

--- a/v2/backtesting/ledger.py
+++ b/v2/backtesting/ledger.py
@@ -1,0 +1,223 @@
+"""Cash-constrained, daily mark-to-market portfolio ledger for backtests."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from math import floor
+from typing import Any, Literal
+
+from v2.backtesting.models import PortfolioLedgerEntry, PositionSnapshot, Trade
+
+
+Direction = Literal["long", "short"]
+
+
+@dataclass(frozen=True)
+class TradeIntent:
+    """An alpha-triggered entry with a known mechanical exit date."""
+
+    ticker: str
+    direction: Direction
+    entry_date: str
+    exit_date: str
+    entry_price: float
+    exit_price: float
+    holding_days: int
+    reasoning: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _OpenPosition:
+    ticker: str
+    direction: Direction
+    entry_date: str
+    exit_date: str
+    entry_price: float
+    exit_price: float
+    shares: float
+    initial_notional: float
+    holding_days: int
+    reasoning: str | None
+    metadata: dict[str, Any]
+
+    def unrealized_pnl(self, market_price: float) -> float:
+        price_change = market_price - self.entry_price
+        sign = 1.0 if self.direction == "long" else -1.0
+        return round(sign * self.shares * price_change, 2)
+
+    def equity_value(self, market_price: float) -> float:
+        if self.direction == "long":
+            return round(self.shares * market_price, 2)
+        # Shorts are fully collateralized in this harness. Their capital value
+        # is the reserved entry notional plus mark-to-market P&L.
+        return round(self.initial_notional + self.unrealized_pnl(market_price), 2)
+
+
+class PortfolioLedger:
+    """Execute trade intents against one shared pool of capital.
+
+    Entries and exits fill at the supplied daily closes. Long positions spend
+    their notional; shorts reserve the same notional as full collateral. When
+    several signals arrive on the same day, available cash is split equally so
+    ticker ordering cannot decide which signals receive capital.
+    """
+
+    def __init__(self, *, capital: float, per_trade: float) -> None:
+        if capital <= 0:
+            raise ValueError("capital must be positive")
+        if per_trade <= 0:
+            raise ValueError("per_trade must be positive")
+        self._capital = float(capital)
+        self._per_trade = float(per_trade)
+
+    def run(
+        self,
+        intents: list[TradeIntent],
+        price_maps: dict[str, dict[str, float]],
+        calendar: list[str],
+    ) -> tuple[list[Trade], list[PortfolioLedgerEntry]]:
+        intents_by_date: dict[str, list[TradeIntent]] = defaultdict(list)
+        for intent in intents:
+            intents_by_date[intent.entry_date].append(intent)
+
+        cash = self._capital
+        realized_pnl = 0.0
+        latest_prices: dict[str, float] = {}
+        open_positions: dict[str, _OpenPosition] = {}
+        completed_trades: list[Trade] = []
+        snapshots: list[PortfolioLedgerEntry] = []
+
+        for current_date in calendar:
+            for ticker, price_map in price_maps.items():
+                if current_date in price_map:
+                    latest_prices[ticker] = price_map[current_date]
+
+            # Close first so capital settled at today's close can fund entries
+            # filled at the same close.
+            for ticker in sorted(list(open_positions)):
+                position = open_positions[ticker]
+                if position.exit_date != current_date:
+                    continue
+
+                pnl = position.unrealized_pnl(position.exit_price)
+                cash = round(cash + position.initial_notional + pnl, 2)
+                realized_pnl = round(realized_pnl + pnl, 2)
+                completed_trades.append(
+                    Trade(
+                        ticker=position.ticker,
+                        direction=position.direction,
+                        entry_date=position.entry_date,
+                        exit_date=position.exit_date,
+                        entry_price=position.entry_price,
+                        exit_price=position.exit_price,
+                        shares=position.shares,
+                        pnl=pnl,
+                        return_pct=round(pnl / position.initial_notional, 6),
+                        holding_days=position.holding_days,
+                        reasoning=position.reasoning,
+                        metadata=position.metadata,
+                    )
+                )
+                del open_positions[ticker]
+
+            new_intents = [
+                intent
+                for intent in sorted(intents_by_date.get(current_date, []), key=lambda x: x.ticker)
+                if intent.ticker not in open_positions and intent.entry_price > 0
+            ]
+            if new_intents and cash > 0:
+                allocation = min(self._per_trade, cash / len(new_intents))
+                for intent in new_intents:
+                    # Four decimal places preserve the harness's fractional-share
+                    # behavior without ever rounding above available cash.
+                    shares = floor((allocation / intent.entry_price) * 10_000) / 10_000
+                    notional = round(shares * intent.entry_price, 2)
+                    if shares <= 0 or notional <= 0 or notional > cash:
+                        continue
+                    cash = round(cash - notional, 2)
+                    open_positions[intent.ticker] = _OpenPosition(
+                        ticker=intent.ticker,
+                        direction=intent.direction,
+                        entry_date=intent.entry_date,
+                        exit_date=intent.exit_date,
+                        entry_price=intent.entry_price,
+                        exit_price=intent.exit_price,
+                        shares=shares,
+                        initial_notional=notional,
+                        holding_days=intent.holding_days,
+                        reasoning=intent.reasoning,
+                        metadata=dict(intent.metadata),
+                    )
+
+            snapshots.append(
+                self._snapshot(
+                    current_date=current_date,
+                    cash=cash,
+                    realized_pnl=realized_pnl,
+                    open_positions=open_positions,
+                    latest_prices=latest_prices,
+                )
+            )
+
+        completed_trades.sort(key=lambda trade: (trade.entry_date, trade.ticker))
+        return completed_trades, snapshots
+
+    def _snapshot(
+        self,
+        *,
+        current_date: str,
+        cash: float,
+        realized_pnl: float,
+        open_positions: dict[str, _OpenPosition],
+        latest_prices: dict[str, float],
+    ) -> PortfolioLedgerEntry:
+        positions: dict[str, PositionSnapshot] = {}
+        long_market_value = 0.0
+        short_market_value = 0.0
+        margin_used = 0.0
+        unrealized_pnl = 0.0
+        positions_equity = 0.0
+
+        for ticker, position in sorted(open_positions.items()):
+            market_price = latest_prices.get(ticker, position.entry_price)
+            market_value = round(position.shares * market_price, 2)
+            position_pnl = position.unrealized_pnl(market_price)
+            equity_value = position.equity_value(market_price)
+            if position.direction == "long":
+                long_market_value += market_value
+            else:
+                short_market_value += market_value
+                margin_used += position.initial_notional
+            unrealized_pnl += position_pnl
+            positions_equity += equity_value
+            positions[ticker] = PositionSnapshot(
+                direction=position.direction,
+                shares=position.shares,
+                entry_price=position.entry_price,
+                market_price=market_price,
+                market_value=market_value,
+                equity_value=equity_value,
+                unrealized_pnl=position_pnl,
+                exit_date=position.exit_date,
+            )
+
+        long_market_value = round(long_market_value, 2)
+        short_market_value = round(short_market_value, 2)
+        unrealized_pnl = round(unrealized_pnl, 2)
+        nav = round(cash + positions_equity, 2)
+
+        return PortfolioLedgerEntry(
+            date=current_date,
+            cash=round(cash, 2),
+            positions=positions,
+            long_market_value=long_market_value,
+            short_market_value=short_market_value,
+            margin_used=round(margin_used, 2),
+            gross_exposure=round(long_market_value + short_market_value, 2),
+            net_exposure=round(long_market_value - short_market_value, 2),
+            realized_pnl=round(realized_pnl, 2),
+            unrealized_pnl=unrealized_pnl,
+            nav=nav,
+        )

--- a/v2/backtesting/models.py
+++ b/v2/backtesting/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -11,7 +11,7 @@ class Trade(BaseModel):
     """A single completed trade — one entry and one exit."""
 
     ticker: str
-    direction: str                    # "long" or "short"
+    direction: Literal["long", "short"]
     entry_date: str                   # YYYY-MM-DD
     exit_date: str                    # YYYY-MM-DD
     entry_price: float
@@ -24,11 +24,41 @@ class Trade(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)  # alpha-model context
 
 
+class PositionSnapshot(BaseModel):
+    """End-of-day mark for one open position."""
+
+    direction: Literal["long", "short"]
+    shares: float
+    entry_price: float
+    market_price: float
+    market_value: float               # gross exposure at the current close
+    equity_value: float               # capital attributed to the position
+    unrealized_pnl: float
+    exit_date: str
+
+
+class PortfolioLedgerEntry(BaseModel):
+    """One end-of-day portfolio snapshot used to derive NAV-based metrics."""
+
+    date: str
+    cash: float
+    positions: dict[str, PositionSnapshot] = Field(default_factory=dict)
+    long_market_value: float = 0.0
+    short_market_value: float = 0.0
+    margin_used: float = 0.0
+    gross_exposure: float = 0.0
+    net_exposure: float = 0.0
+    realized_pnl: float = 0.0
+    unrealized_pnl: float = 0.0
+    nav: float
+
+
 class PerformanceMetrics(BaseModel):
-    """Summary stats for a set of trades."""
+    """Portfolio NAV risk metrics plus completed-trade statistics."""
 
     total_return_pct: float
     annualized_return_pct: float
+    annualized_volatility: float
     sharpe_ratio: float
     max_drawdown_pct: float
     win_rate: float                   # fraction of trades with positive return
@@ -45,3 +75,4 @@ class BacktestResult(BaseModel):
     trades: list[Trade] = Field(default_factory=list)
     metrics: PerformanceMetrics | None = None
     equity_curve: list[float] = Field(default_factory=list)
+    ledger: list[PortfolioLedgerEntry] = Field(default_factory=list)

--- a/v2/backtesting/test_backtest.py
+++ b/v2/backtesting/test_backtest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from datetime import date, timedelta
 
+import numpy as np
 import pytest
 
 from v2.backtesting import BacktestEngine
@@ -65,6 +66,21 @@ def _make_prices(start_price: float, days: int, daily_change: float = 0.01) -> l
     return prices
 
 
+def _make_prices_from_closes(closes: list[float]) -> list[Price]:
+    """Generate business-day bars from an explicit close series."""
+    prices = []
+    d = date(2025, 8, 4)
+    for close in closes:
+        while d.weekday() >= 5:
+            d += timedelta(days=1)
+        prices.append(Price(
+            open=close, close=close, high=close, low=close,
+            volume=1_000_000, time=d.isoformat(),
+        ))
+        d += timedelta(days=1)
+    return prices
+
+
 # ---------------------------------------------------------------------------
 # run_alpha — fills, sizing, P&L
 # ---------------------------------------------------------------------------
@@ -121,6 +137,116 @@ class TestRunAlpha:
         )
         assert result.equity_curve[0] == 50_000
         assert result.equity_curve[-1] == 50_000 + result.trades[0].pnl
+
+    def test_same_day_signals_share_one_cash_pool(self):
+        prices = _make_prices(100.0, 12, daily_change=0.01)
+        fire = prices[0].time[:10]
+
+        class PerTickerMock:
+            def get_prices(self, ticker, start_date, end_date, **kwargs):
+                return prices
+
+        result = BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
+            FixedAlpha(1.0, {fire}), ["AAA", "BBB"], PerTickerMock(),
+            prices[0].time[:10], prices[6].time[:10], holding_days=5,
+        )
+
+        assert len(result.trades) == 2
+        assert sum(t.shares * t.entry_price for t in result.trades) <= 10_000
+        assert result.trades[0].shares == pytest.approx(50.0)
+        assert result.trades[1].shares == pytest.approx(50.0)
+        assert result.ledger[0].cash == 0.0
+        assert set(result.ledger[0].positions) == {"AAA", "BBB"}
+        assert result.ledger[0].gross_exposure == 10_000.0
+
+    def test_open_position_prevents_overallocating_later_signal(self):
+        prices = _make_prices(100.0, 14, daily_change=0.01)
+
+        class PerTickerAlpha(AlphaModel):
+            @property
+            def name(self):
+                return "per-ticker"
+
+            def predict(self, ticker, date, data_client):
+                fire = {
+                    "AAA": prices[0].time[:10],
+                    "BBB": prices[1].time[:10],
+                }
+                return Signal(
+                    model_name=self.name, ticker=ticker, date=date,
+                    value=1.0 if fire[ticker] == date else 0.0,
+                )
+
+        class PerTickerMock:
+            def get_prices(self, ticker, start_date, end_date, **kwargs):
+                return prices
+
+        result = BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
+            PerTickerAlpha(), ["AAA", "BBB"], PerTickerMock(),
+            prices[0].time[:10], prices[8].time[:10], holding_days=5,
+        )
+
+        assert [trade.ticker for trade in result.trades] == ["AAA"]
+
+    def test_ledger_marks_unrealized_pnl_each_day(self):
+        prices = _make_prices_from_closes([100.0, 105.0, 110.0, 110.0])
+        fire = prices[0].time[:10]
+        result = BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
+            FixedAlpha(1.0, {fire}), ["TEST"], MockFDClient(prices),
+            prices[0].time[:10], prices[2].time[:10], holding_days=2,
+        )
+
+        assert result.equity_curve[:3] == [10_000.0, 10_500.0, 11_000.0]
+        assert result.ledger[1].unrealized_pnl == 500.0
+        assert result.ledger[1].positions["TEST"].market_value == 10_500.0
+        assert result.ledger[2].positions == {}
+        assert result.ledger[2].realized_pnl == 1_000.0
+        for entry in result.ledger:
+            assert entry.nav == pytest.approx(
+                10_000 + entry.realized_pnl + entry.unrealized_pnl,
+            )
+
+    def test_short_reserves_margin_and_reports_exposure(self):
+        prices = _make_prices_from_closes([100.0, 90.0, 90.0])
+        fire = prices[0].time[:10]
+        result = BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
+            FixedAlpha(-1.0, {fire}), ["TEST"], MockFDClient(prices),
+            prices[0].time[:10], prices[1].time[:10], holding_days=1,
+        )
+
+        opening = result.ledger[0]
+        assert opening.cash == 0.0
+        assert opening.margin_used == 10_000.0
+        assert opening.short_market_value == 10_000.0
+        assert opening.net_exposure == -10_000.0
+
+    def test_drawdown_includes_intratrade_mark_to_market_loss(self):
+        prices = _make_prices_from_closes([100.0, 50.0, 100.0, 100.0])
+        fire = prices[0].time[:10]
+        result = BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
+            FixedAlpha(1.0, {fire}), ["TEST"], MockFDClient(prices),
+            prices[0].time[:10], prices[2].time[:10], holding_days=2,
+        )
+
+        assert result.trades[0].pnl == 0.0
+        assert result.metrics.total_return_pct == 0.0
+        assert result.metrics.max_drawdown_pct == 0.5
+
+    def test_sharpe_and_volatility_use_daily_nav_returns(self):
+        prices = _make_prices_from_closes([100.0, 110.0, 99.0, 108.9, 108.9])
+        fire = prices[0].time[:10]
+        result = BacktestEngine(capital=10_000, per_trade=10_000).run_alpha(
+            FixedAlpha(1.0, {fire}), ["TEST"], MockFDClient(prices),
+            prices[0].time[:10], prices[3].time[:10], holding_days=3,
+        )
+
+        daily_returns = np.array([0.10, -0.10, 0.10])
+        expected_volatility = daily_returns.std(ddof=1) * np.sqrt(252)
+        expected_sharpe = daily_returns.mean() / daily_returns.std(ddof=1) * np.sqrt(252)
+        assert result.metrics.annualized_volatility == pytest.approx(
+            expected_volatility, abs=1e-6,
+        )
+        assert result.metrics.sharpe_ratio == pytest.approx(expected_sharpe, abs=1e-4)
 
     def test_no_signal_no_trades(self):
         prices = _make_prices(100.0, 20)

--- a/v2/demo/backtest.py
+++ b/v2/demo/backtest.py
@@ -202,9 +202,9 @@ def _tape_panel(trades: list, limit: int = 20) -> Panel:
                  title_align="left")
 
 
-def _frame(engine, trades_shown, n_total, width, footer: Text | None = None) -> Group:
-    curve = engine._build_equity_curve(trades_shown)
-    metrics = engine._compute_metrics(trades_shown, curve)
+def _frame(engine, ledger_shown, trades_shown, n_total, width, footer: Text | None = None) -> Group:
+    curve = engine._build_equity_curve(ledger_shown)
+    metrics = engine._compute_metrics(trades_shown, ledger_shown)
     parts = [
         _banner(),
         _stats_panel(metrics, curve[-1], n_total, len(trades_shown)),
@@ -245,16 +245,17 @@ def main() -> None:
                 model, TICKERS, fd, START_DATE, END_DATE, holding_days=HOLDING_DAYS,
             )
 
-        trades = sorted(result.trades, key=lambda t: (t.entry_date, t.ticker))
+        trades = sorted(result.trades, key=lambda t: (t.exit_date, t.ticker))
         if not trades:
             live.update(Text("  No trades generated.", style="red"))
             return
 
-        delay = max(0.02, min(0.35, REPLAY_SECONDS / len(trades)))
-        shown: list = []
-        for trade in trades:
-            shown.append(trade)
-            live.update(_frame(engine, shown, len(trades), curve_width))
+        exit_dates = sorted({trade.exit_date for trade in trades})
+        delay = max(0.02, min(0.35, REPLAY_SECONDS / len(exit_dates)))
+        for cutoff in exit_dates:
+            shown = [trade for trade in trades if trade.exit_date <= cutoff]
+            ledger_shown = [entry for entry in result.ledger if entry.date <= cutoff]
+            live.update(_frame(engine, ledger_shown, shown, len(trades), curve_width))
             time.sleep(delay)
 
         # Phase C — freeze on the final frame
@@ -266,7 +267,16 @@ def main() -> None:
             style="dim",
         )
         footer.append(f" · Sharpe {m.sharpe_ratio:.2f}", style="bold white")
-        live.update(_frame(engine, shown, len(trades), curve_width, footer=footer))
+        live.update(
+            _frame(
+                engine,
+                result.ledger,
+                trades,
+                len(trades),
+                curve_width,
+                footer=footer,
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- execute all v2 backtest signals against one shared, cash-constrained portfolio instead of allocating capital independently per ticker
- add an end-of-day `PortfolioLedger` with cash, open positions, long/short exposure, short margin, realized and unrealized P&L, and NAV
- derive the equity curve, annualized volatility, Sharpe ratio, and maximum drawdown from daily marked-to-market NAV returns
- update the v2 CLI and demo replay to consume ledger snapshots, and add coverage for allocation, margin, mark-to-market accounting, drawdown, and daily risk metrics

## Portfolio mechanics

- exits settle before same-close entries
- simultaneous signals split available cash equally, capped by `per_trade`
- short positions are fully collateralized and report both margin usage and gross/net exposure
- accepted positions are marked at each available daily close through the requested window or their final exit

## Testing

- `python -m pytest v2 -q` (`76 passed`)
- `python -m compileall -q v2`
- `git diff --check`
