### PR TITLE
fix: prevent infinite pagination loop when all items share the same date

### DIFF
--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -203,6 +203,7 @@ def get_insider_trades(
 
     all_trades = []
     current_end_date = end_date
+    previous_end_date = None
 
     while True:
         url = f"https://api.financialdatasets.ai/insider-trades/?ticker={ticker}&filing_date_lte={current_end_date}"
@@ -238,6 +239,11 @@ def get_insider_trades(
         if current_end_date <= start_date:
             break
 
+        # Prevent infinite loop when all items share the same date
+        if current_end_date == previous_end_date:
+            break
+        previous_end_date = current_end_date
+
     if not all_trades:
         return []
 
@@ -269,6 +275,7 @@ def get_company_news(
 
     all_news = []
     current_end_date = end_date
+    previous_end_date = None
 
     while True:
         url = f"https://api.financialdatasets.ai/news/?ticker={ticker}&end_date={current_end_date}"
@@ -303,6 +310,11 @@ def get_company_news(
         # If we've reached or passed the start_date, we can stop
         if current_end_date <= start_date:
             break
+
+        # Prevent infinite loop when all items share the same date
+        if current_end_date == previous_end_date:
+            break
+        previous_end_date = current_end_date
 
     if not all_news:
         return []


### PR DESCRIPTION
## Description

`get_insider_trades` and `get_company_news` can get stuck in an infinite loop during pagination. When the API returns a full page of results that all share the same filing/publication date, `current_end_date` doesn't advance between iterations, causing the same page to be fetched repeatedly.

## Fix

Tracks the previous end date between pagination iterations and breaks out of the loop when no date progress is detected, preventing the infinite hang while still processing data normally on the happy path.

## Related Issues

Fixes #537
Also addresses hangs reported in #395 and #400

## Testing

- Verified the fix works for the normal case (dates advance normally)
- Infinite loop is prevented when all items share the same date