### PR TITLE
Add interactive analyze script and local Ollama model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repo.
+
+## What this is
+
+AI Hedge Fund — an educational proof-of-concept where multiple LLM "investor" agents
+(Buffett, Munger, Burry, etc.) plus valuation/sentiment/fundamentals/technicals agents
+feed a risk manager and portfolio manager to produce trading *signals*. It does **not**
+place real trades. Educational/research use only.
+
+The project is mid-rebuild: `src/` is the current v1 system; `v2/` is the in-progress
+redesign (fund-as-entity, pluggable "alpha models"). See `VISION.md` and `ROADMAP.md`.
+
+## Layout
+
+- `src/` — v1 hedge fund. Entry points:
+  - `src/main.py` — run the agents once for given tickers.
+  - `src/backtester.py` — backtest over a date range.
+  - `src/cli/input.py` — shared CLI arg parsing (`parse_cli_inputs`).
+  - `src/agents/` — one file per investor agent.
+  - `src/llm/models.py`, `src/llm/ollama_models.json` — model registry (cloud + local Ollama).
+  - `src/utils/ollama.py` — Ollama install/model checks.
+- `v2/` — next-gen redesign (signals, event studies, risk, data clients). Has its own tests.
+- `app/` — full-stack web application (`app/backend` FastAPI, `app/frontend` React).
+- `scripts/analyze.sh` — interactive launcher: prompts for tickers, offers local Ollama.
+
+## Running
+
+Uses Poetry (Python ^3.11).
+
+```bash
+poetry install
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA            # analyze
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA --ollama   # local LLM
+poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA      # backtest
+```
+
+Or the interactive wrapper (prompts for comma-separated tickers, then offers Ollama):
+
+```bash
+./scripts/analyze.sh
+TICKERS=AAPL,MSFT ./scripts/analyze.sh --ollama --model gpt-oss:20b   # non-interactive
+```
+
+`--tickers` / `--ticker` are aliases (comma-separated). `--model <name>` skips the
+interactive model picker; combine with `--ollama` to force a local model.
+
+## Local Ollama
+
+Local models must be registered in `src/llm/ollama_models.json` to appear in the picker
+(matched by `model_name`). Requires the model to be pulled in Ollama first.
+
+## Conventions
+
+- Match surrounding code style; the CLI standardizes flags via `add_common_args` in
+  `src/cli/input.py` — add new shared flags there rather than per-script.
+- Commit only when asked. `.env` holds API keys (copy from `.env.example`); never commit it.

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Interactive launcher for the AI hedge fund analysis.
+# Prompts for one or more stock tickers (comma-separated), then runs the
+# analysis via src/main.py. Any extra flags passed to this script are
+# forwarded to main.py (e.g. --show-reasoning, --ollama, --model gpt-4o).
+#
+# Usage:
+#   ./scripts/analyze.sh
+#   ./scripts/analyze.sh --show-reasoning
+#   TICKERS=AAPL,MSFT ./scripts/analyze.sh    # skip the prompt
+
+set -euo pipefail
+
+# Resolve project root (the directory containing this script's parent).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+# Accept tickers from the TICKERS env var, otherwise prompt interactively.
+tickers="${TICKERS:-}"
+while [[ -z "${tickers// /}" ]]; do
+    read -r -p "Which stocks do you want to analyse? (comma-separated, e.g. AAPL,MSFT,GOOGL): " tickers
+    if [[ -z "${tickers// /}" ]]; then
+        echo "Please enter at least one ticker." >&2
+    fi
+done
+
+# Normalise: strip spaces around commas and uppercase the symbols.
+tickers="$(echo "${tickers}" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')"
+
+# Collect extra args passed straight to main.py.
+extra_args=("$@")
+
+# If Ollama is installed and the caller hasn't already specified a model
+# source, offer to use a local model.
+already_specified=false
+for a in ${extra_args[@]+"${extra_args[@]}"}; do
+    case "$a" in
+        --ollama|--model) already_specified=true ;;
+    esac
+done
+
+if ! ${already_specified} && command -v ollama >/dev/null 2>&1; then
+    read -r -p "Use local Ollama model? [Y/n]: " use_ollama
+    case "${use_ollama:-Y}" in
+        [Nn]*) : ;;
+        *) extra_args+=(--ollama) ;;
+    esac
+fi
+
+echo "Analysing: ${tickers}"
+echo
+
+# Time the whole run. Capture the exit code so timing prints even on failure.
+SECONDS=0
+exit_code=0
+# Run through poetry if available, otherwise fall back to python directly.
+if command -v poetry >/dev/null 2>&1; then
+    poetry run python src/main.py --tickers "${tickers}" ${extra_args[@]+"${extra_args[@]}"} || exit_code=$?
+else
+    python src/main.py --tickers "${tickers}" ${extra_args[@]+"${extra_args[@]}"} || exit_code=$?
+fi
+
+echo
+echo "Total execution time: $((SECONDS / 60))m $((SECONDS % 60))s (${SECONDS}s)"
+exit "${exit_code}"

--- a/src/cli/input.py
+++ b/src/cli/input.py
@@ -111,10 +111,11 @@ def select_model(use_ollama: bool, model_flag: str | None = None) -> tuple[str, 
     if model_flag:
         model = find_model_by_name(model_flag)
         if model:
+            provider = ModelProvider.OLLAMA.value if use_ollama else model.provider.value
             print(
-                f"\nUsing specified model: {Fore.CYAN}{model.provider.value}{Style.RESET_ALL} - {Fore.GREEN + Style.BRIGHT}{model.model_name}{Style.RESET_ALL}\n"
+                f"\nUsing specified model: {Fore.CYAN}{provider}{Style.RESET_ALL} - {Fore.GREEN + Style.BRIGHT}{model.model_name}{Style.RESET_ALL}\n"
             )
-            return model.model_name, model.provider.value
+            return model.model_name, provider
         else:
             print(f"{Fore.RED}Model '{model_flag}' not found. Please select a model.{Style.RESET_ALL}")
 

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -25,6 +25,7 @@ class ModelProvider(str, Enum):
     KIMI = "Kimi"
     META = "Meta"
     MISTRAL = "Mistral"
+    NVIDIA = "NVIDIA"
     OPENAI = "OpenAI"
     OLLAMA = "Ollama"
     OPENROUTER = "OpenRouter"

--- a/src/llm/ollama_models.json
+++ b/src/llm/ollama_models.json
@@ -53,5 +53,15 @@
     "display_name": "Llama 3.3 (70B)",
     "model_name": "llama3.3:70b-instruct-q4_0",
     "provider": "Meta"
+  },
+  {
+    "display_name": "Gemma 4",
+    "model_name": "gemma4:latest",
+    "provider": "Google"
+  },
+  {
+    "display_name": "Nemotron 3 Nano (4B)",
+    "model_name": "nemotron-3-nano:4b",
+    "provider": "NVIDIA"
   }
 ] 


### PR DESCRIPTION
- scripts/analyze.sh: interactive launcher that prompts for comma-separated tickers, offers local Ollama, forwards flags to main.py, and logs total execution time.
- Allow `--model` with `--ollama` to use the OLLAMA provider directly.
- Add NVIDIA provider and register gemma4 and nemotron-3-nano local models.
- Add CLAUDE.md with project layout and run instructions.