### PR TITLE
Add Eden AI as an LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ GIGACHAT_API_KEY=your-gigachat-api-key
 
 # For running LLMs hosted by OpenRouter
 OPENROUTER_API_KEY=your-openrouter-api-key
+# Eden AI routes to many providers behind one key; models are named "<provider>/<model>" (e.g. openai/gpt-5.5)
+EDENAI_API_KEY=your-edenai-api-key
 
 # For running LLMs hosted by Microsoft Azure OpenAI (gpt-4o, gpt-4o-mini, etc.)
 # Get your Azure OpenAI API settings from https://oai.azure.com/

--- a/app/frontend/src/components/settings/api-keys.tsx
+++ b/app/frontend/src/components/settings/api-keys.tsx
@@ -74,6 +74,13 @@ const LLM_API_KEYS: ApiKey[] = [
     placeholder: 'your-openrouter-api-key'
   },
   {
+    key: 'EDENAI_API_KEY',
+    label: 'Eden AI API',
+    description: 'For Eden AI models (openai/gpt-5.5, mistral/mistral-large-latest, etc.)',
+    url: 'https://www.edenai.co/',
+    placeholder: 'your-edenai-api-key'
+  },
+  {
     key: 'GIGACHAT_API_KEY',
     label: 'GigaChat API',
     description: 'For GigaChat models (GigaChat-2-Max, etc.)',

--- a/src/llm/api_models.json
+++ b/src/llm/api_models.json
@@ -33,5 +33,15 @@
     "display_name": "Gemini 3.1 Pro",
     "model_name": "gemini-3.1-pro-preview",
     "provider": "Google"
+  },
+  {
+    "display_name": "GPT-5.5 (Eden AI)",
+    "model_name": "openai/gpt-5.5",
+    "provider": "EdenAI"
+  },
+  {
+    "display_name": "Mistral Large (Eden AI)",
+    "model_name": "mistral/mistral-large-latest",
+    "provider": "EdenAI"
   }
 ]

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -20,6 +20,7 @@ class ModelProvider(str, Enum):
     ALIBABA = "Alibaba"
     ANTHROPIC = "Anthropic"
     DEEPSEEK = "DeepSeek"
+    EDENAI = "EdenAI"
     GOOGLE = "Google"
     GROQ = "Groq"
     KIMI = "Kimi"
@@ -213,6 +214,15 @@ def get_model(model_name: str, model_provider: ModelProvider, api_keys: dict = N
                 }
             }
         )
+    elif model_provider == ModelProvider.EDENAI:
+        api_key = (api_keys or {}).get("EDENAI_API_KEY") or os.getenv("EDENAI_API_KEY")
+        if not api_key:
+            print(f"API Key Error: Please make sure EDENAI_API_KEY is set in your .env file or provided via API keys.")
+            raise ValueError("Eden AI API key not found. Please make sure EDENAI_API_KEY is set in your .env file or provided via API keys.")
+        # Eden AI exposes an OpenAI-compatible endpoint that routes to many providers
+        # behind a single key. Models are addressed as "<provider>/<model>", e.g. "openai/gpt-5.5".
+        base_url = os.getenv("EDENAI_BASE_URL") or "https://api.edenai.run/v3"
+        return ChatOpenAI(model=model_name, api_key=api_key, base_url=base_url)
     elif model_provider == ModelProvider.KIMI:
         api_key = (api_keys or {}).get("MOONSHOT_API_KEY") or os.getenv("MOONSHOT_API_KEY") \
             or (api_keys or {}).get("KIMI_API_KEY") or os.getenv("KIMI_API_KEY")


### PR DESCRIPTION
## What

Adds [Eden AI](https://www.edenai.co/) as an LLM provider.

Eden AI exposes an OpenAI-compatible Chat Completions endpoint (`https://api.edenai.run/v3`) that
routes to many underlying providers behind a single API key, so it plugs in as a `ChatOpenAI`
`base_url` provider — the same pattern already used for OpenRouter and Kimi. Models are addressed
as `<provider>/<model>`, e.g. `openai/gpt-5.5` or `mistral/mistral-large-latest`.

## Changes

- `src/llm/models.py`: `ModelProvider.EDENAI` + a `get_model()` branch reading `EDENAI_API_KEY`
  (base url `https://api.edenai.run/v3`, overridable via `EDENAI_BASE_URL`).
- `src/llm/api_models.json`: two models — `openai/gpt-5.5` and `mistral/mistral-large-latest` —
  to show the cross-provider naming. The backend `/language-models` route derives providers from
  this list, so Eden AI shows up automatically.
- `.env.example` and the frontend API-keys settings: register `EDENAI_API_KEY`.

## Testing

Verified live against `https://api.edenai.run/v3` with the exact code path this branch adds
(`ChatOpenAI(model=..., api_key=..., base_url=...)`):

- Plain `.invoke(...)` returns as expected for both `openai/gpt-5.5` and `mistral/mistral-large-latest`.
- `.with_structured_output(...)` (used throughout the analyst/PM agents) returns valid Pydantic
  objects for both models — tool/function calling passes through Eden AI correctly.

Set a key with `export EDENAI_API_KEY=...` (from https://app.edenai.run/admin/api-settings/features-preferences)
and pick a `... (Eden AI)` model to try it.
