### PR TITLE
Add Newsflash as an optional corroboration-scored news source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 # Get your Financial Datasets API key from https://financialdatasets.ai/
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 
+# Optional: deduplicated, corroboration-scored news events from https://newsflash.sh
+# (get_newsflash_news). Works without a key (50 requests/day); a key raises rate
+# limits and unlocks deeper history for backtests.
+NEWSFLASH_API_KEY=your-newsflash-api-key
+
 # For running LLMs hosted by openai (GPT 5, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-openai-api-key

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -107,10 +107,38 @@ class CompanyNews(BaseModel):
     date: str
     url: str
     sentiment: str | None = None
+    # Set when the item comes from Newsflash (see get_newsflash_news); None for other providers.
+    corroboration: int | None = None  # number of independent sources reporting the same event
+    confidence: float | None = None  # min(1, corroboration / 3): 0.33 = single-outlet rumor, 1.0 = wire-wide story
 
 
 class CompanyNewsResponse(BaseModel):
     news: list[CompanyNews]
+
+
+class NewsflashEvent(BaseModel):
+    """A deduplicated news event from Newsflash (https://newsflash.sh).
+
+    One event represents one real-world happening, with the outlets that
+    corroborate it collapsed into `sources` / `corroboration` / `confidence`.
+    """
+
+    id: int
+    canonical_title: str
+    summary: str | None = None
+    category: str | None = None
+    first_seen_at: str
+    last_seen_at: str | None = None
+    sources: list[str] = []
+    corroboration: int = 1
+    confidence: float = 0.0
+
+    # The API may add fields (e.g. `relevance` on semantic search); don't fail on them
+    model_config = {"extra": "allow"}
+
+
+class NewsflashEventsResponse(BaseModel):
+    events: list[NewsflashEvent]
 
 
 class CompanyFacts(BaseModel):

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -4,6 +4,7 @@ import os
 import pandas as pd
 import requests
 import time
+import urllib.parse
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ from src.data.models import (
     InsiderTrade,
     InsiderTradeResponse,
     CompanyFactsResponse,
+    NewsflashEventsResponse,
 )
 
 # Global cache instance
@@ -310,6 +312,93 @@ def get_company_news(
     # Cache the results using the comprehensive cache key
     _cache.set_company_news(cache_key, [news.model_dump() for news in all_news])
     return all_news
+
+
+def get_newsflash_news(
+    query: str,
+    end_date: str | None = None,
+    start_date: str | None = None,
+    limit: int = 100,
+    semantic: bool = False,
+    min_confidence: float = 0.0,
+    api_key: str = None,
+) -> list[CompanyNews]:
+    """Fetch corroborated news events from Newsflash (https://newsflash.sh).
+
+    Additive alternative to `get_company_news` — financialdatasets.ai remains the
+    default news provider. Newsflash crawls many outlets and dedupes coverage into
+    *events*: one real-world happening carrying a `corroboration` count (how many
+    independent sources reported it) and a `confidence` score in [0, 1]
+    (min(1, corroboration / 3)). Use these as a signal-quality gate: a story from a
+    single outlet is a 0.33-confidence rumor, while one on every wire scores 1.0.
+    Pass `min_confidence` (e.g. 0.66) to drop weakly-corroborated events before
+    they reach sentiment/LLM analysis.
+
+    Works keyless out of the box (50 requests/day). Set NEWSFLASH_API_KEY (or pass
+    `api_key`) for higher rate limits and deeper history — the archive spans ~5
+    years for backtests, with lookback depth gated by tier. `semantic=True`
+    switches from keyword to meaning-based search (useful for topics like
+    "chip export controls" rather than a ticker).
+
+    `query` can be a company name, ticker, or topic; it is echoed back as the
+    `ticker` field on the returned CompanyNews items. Each event maps to one item
+    whose `url` points at the event detail endpoint (/api/events/{id}), which
+    lists the underlying articles with their original URLs.
+    """
+    # Create a cache key that includes all parameters to ensure exact matches
+    cache_key = f"newsflash_{query}_{start_date or 'none'}_{end_date or 'none'}_{limit}_{int(semantic)}"
+
+    # Check cache first - simple exact match (min_confidence is applied after, so the unfiltered result is reusable)
+    if cached_data := _cache.get_company_news(cache_key):
+        return [news for news in (CompanyNews(**item) for item in cached_data) if (news.confidence or 0.0) >= min_confidence]
+
+    # If not in cache, fetch from API
+    headers = {}
+    newsflash_api_key = api_key or os.environ.get("NEWSFLASH_API_KEY")
+    if newsflash_api_key:
+        headers["Authorization"] = f"Bearer {newsflash_api_key}"
+
+    url = f"https://newsflash.sh/api/events?q={urllib.parse.quote(query)}&limit={limit}"
+    if start_date:
+        url += f"&from={start_date}"
+    if end_date:
+        url += f"&to={end_date}"
+    if semantic:
+        url += "&semantic=1"
+
+    response = _make_api_request(url, headers)
+    if response.status_code != 200:
+        return []
+
+    # Parse response with Pydantic model
+    try:
+        events_response = NewsflashEventsResponse(**response.json())
+        events = events_response.events
+    except Exception as e:
+        logger.warning("Failed to parse Newsflash events response for %s: %s", query, e)
+        return []
+
+    if not events:
+        return []
+
+    all_news = [
+        CompanyNews(
+            ticker=query,
+            title=event.canonical_title,
+            author=None,
+            source=", ".join(event.sources) if event.sources else "newsflash",
+            date=event.first_seen_at,
+            url=f"https://newsflash.sh/api/events/{event.id}",
+            sentiment=None,
+            corroboration=event.corroboration,
+            confidence=event.confidence,
+        )
+        for event in events
+    ]
+
+    # Cache the unfiltered results using the comprehensive cache key
+    _cache.set_company_news(cache_key, [news.model_dump() for news in all_news])
+    return [news for news in all_news if (news.confidence or 0.0) >= min_confidence]
 
 
 def get_market_cap(

--- a/tests/test_newsflash.py
+++ b/tests/test_newsflash.py
@@ -1,0 +1,155 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from src.tools.api import get_newsflash_news
+
+SAMPLE_RESPONSE = {
+    "count": 2,
+    "events": [
+        {
+            "id": 101,
+            "canonical_title": "Nvidia announces new data center GPU",
+            "summary": "Nvidia unveiled its next-generation accelerator.",
+            "category": "tech",
+            "first_seen_at": "2026-07-23T15:00:00.000Z",
+            "last_seen_at": "2026-07-23T18:00:00.000Z",
+            "article_count": 4,
+            "source_count": 3,
+            "sources": ["reuters", "techcrunch", "theverge"],
+            "corroboration": 3,
+            "confidence": 1.0,
+        },
+        {
+            "id": 102,
+            "canonical_title": "Rumor: Nvidia eyeing acquisition",
+            "summary": "A single outlet reports acquisition talks.",
+            "category": "tech",
+            "first_seen_at": "2026-07-23T16:00:00.000Z",
+            "last_seen_at": "2026-07-23T16:00:00.000Z",
+            "article_count": 1,
+            "source_count": 1,
+            "sources": ["someblog"],
+            "corroboration": 1,
+            "confidence": 0.3333333333333333,
+        },
+    ],
+}
+
+
+class TestGetNewsflashNews:
+    """Test suite for the Newsflash news provider."""
+
+    @patch('src.tools.api._cache')
+    @patch('src.tools.api.requests.get')
+    def test_maps_events_to_company_news(self, mock_get, mock_cache):
+        """Events are mapped into CompanyNews with corroboration/confidence attached."""
+        mock_cache.get_company_news.return_value = None
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_RESPONSE
+        mock_get.return_value = mock_response
+
+        result = get_newsflash_news("NVDA", end_date="2026-07-24")
+
+        assert len(result) == 2
+        assert result[0].ticker == "NVDA"
+        assert result[0].title == "Nvidia announces new data center GPU"
+        assert result[0].source == "reuters, techcrunch, theverge"
+        assert result[0].date == "2026-07-23T15:00:00.000Z"
+        assert result[0].url == "https://newsflash.sh/api/events/101"
+        assert result[0].sentiment is None
+        assert result[0].corroboration == 3
+        assert result[0].confidence == 1.0
+
+        # Request went to the Newsflash events endpoint with the expected params
+        url = mock_get.call_args[0][0]
+        assert url.startswith("https://newsflash.sh/api/events?q=NVDA")
+        assert "&to=2026-07-24" in url
+        assert "semantic" not in url
+
+        # Unfiltered results were cached
+        mock_cache.set_company_news.assert_called_once()
+
+    @patch('src.tools.api._cache')
+    @patch('src.tools.api.requests.get')
+    def test_min_confidence_filters_rumors(self, mock_get, mock_cache):
+        """min_confidence drops weakly-corroborated events."""
+        mock_cache.get_company_news.return_value = None
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_RESPONSE
+        mock_get.return_value = mock_response
+
+        result = get_newsflash_news("NVDA", min_confidence=0.66)
+
+        assert len(result) == 1
+        assert result[0].corroboration == 3
+
+        # The cache still receives the unfiltered list so other thresholds can reuse it
+        cached = mock_cache.set_company_news.call_args[0][1]
+        assert len(cached) == 2
+
+    @patch('src.tools.api._cache')
+    @patch('src.tools.api.requests.get')
+    def test_cache_hit_skips_api(self, mock_get, mock_cache):
+        """A cache hit returns mapped models without an HTTP call."""
+        mock_cache.get_company_news.return_value = [
+            {
+                "ticker": "NVDA",
+                "title": "Cached event",
+                "author": None,
+                "source": "reuters",
+                "date": "2026-07-23T15:00:00.000Z",
+                "url": "https://newsflash.sh/api/events/101",
+                "sentiment": None,
+                "corroboration": 3,
+                "confidence": 1.0,
+            }
+        ]
+
+        result = get_newsflash_news("NVDA")
+
+        assert len(result) == 1
+        assert result[0].title == "Cached event"
+        mock_get.assert_not_called()
+
+    @patch('src.tools.api._cache')
+    @patch('src.tools.api.requests.get')
+    def test_semantic_and_dates_in_url(self, mock_get, mock_cache):
+        """semantic=1 and from/to are forwarded, and the query is URL-encoded."""
+        mock_cache.get_company_news.return_value = None
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"count": 0, "events": []}
+        mock_get.return_value = mock_response
+
+        result = get_newsflash_news("chip export controls", start_date="2026-07-01", end_date="2026-07-24", semantic=True)
+
+        assert result == []
+        url = mock_get.call_args[0][0]
+        assert "q=chip%20export%20controls" in url
+        assert "&from=2026-07-01" in url
+        assert "&to=2026-07-24" in url
+        assert "&semantic=1" in url
+
+    @patch('src.tools.api._cache')
+    @patch('src.tools.api.requests.get')
+    def test_api_error_returns_empty_list(self, mock_get, mock_cache):
+        """Non-200 responses degrade to an empty list, matching other providers."""
+        mock_cache.get_company_news.return_value = None
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_get.return_value = mock_response
+
+        result = get_newsflash_news("NVDA")
+
+        assert result == []
+        mock_cache.set_company_news.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This adds `get_newsflash_news()` in `src/tools/api.py` as an **additive** news option — financialdatasets.ai remains the default and nothing existing changes behavior.

[Newsflash](https://newsflash.sh) crawls many outlets and dedupes coverage into *events*: one happening with a `corroboration` count (independent sources) and a `confidence` score in [0,1] (`min(1, sources/3)`). That gives agents a signal-quality gate the current news feed doesn't have: a single-outlet rumor scores 0.33, a wire-wide story 1.0. The function exposes this via `min_confidence` (e.g. `0.66` drops uncorroborated events before they burn LLM sentiment calls).

**Design — follows existing conventions:**
- Returns `list[CompanyNews]`, so it drops into any agent that consumes `get_company_news` output. Two optional fields (`corroboration`, `confidence`, default `None`) were added to `CompanyNews`; existing providers are unaffected.
- Reuses the in-memory cache (namespaced key) and `_make_api_request`'s 429 backoff; parses with a Pydantic response model; degrades to `[]` on errors like the other fetchers.
- `url` points at the event detail endpoint (`/api/events/{id}`), which lists the underlying articles with their original URLs.

**No key required:** works instantly at 50 req/day; optional `NEWSFLASH_API_KEY` (added to `.env.example`) raises limits and unlocks deeper history (~5-year archive, useful for the backtester). `semantic=True` enables meaning-based search for topic queries ("chip export controls") rather than tickers.

**Testing:** `tests/test_newsflash.py` (5 tests, mocked like `test_api_rate_limiting.py`) covers mapping, the confidence gate, caching, URL building, and the error path. Full suite passes (70/70). Also verified against the live API keyless.

Disclosure: I built Newsflash — happy to adjust anything (naming, defaults, or wiring it as an opt-in fallback inside `get_company_news`) to fit the project's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTSt4BDWJCsGjUyLCnbuj5