### PR TITLE
fix(storage): prevent path traversal in /storage/save-json

### DIFF
--- a/app/backend/routes/storage.py
+++ b/app/backend/routes/storage.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from pydantic import BaseModel
 
 from app.backend.models.schemas import ErrorResponse
@@ -10,6 +10,37 @@ router = APIRouter(prefix="/storage")
 class SaveJsonRequest(BaseModel):
     filename: str
     data: dict
+
+
+def _safe_output_path(outputs_dir: Path, filename: str) -> Path:
+    """Resolve `filename` inside `outputs_dir`, rejecting path traversal.
+
+    Rejects absolute paths, drive letters, and any component like ``..`` so the
+    resulting file is guaranteed to live directly under ``outputs_dir``.
+    """
+    if not filename or not filename.strip():
+        raise HTTPException(status_code=400, detail="filename must not be empty")
+
+    # Reject path separators / parent references / absolute paths outright.
+    # We require a plain filename (no directory components).
+    if (
+        "/" in filename
+        or "\\" in filename
+        or filename in (".", "..")
+        or PurePosixPath(filename).is_absolute()
+        or PureWindowsPath(filename).is_absolute()
+    ):
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    outputs_dir_resolved = outputs_dir.resolve()
+    file_path = (outputs_dir_resolved / filename).resolve()
+
+    # Belt-and-suspenders: ensure the resolved path is directly inside outputs_dir.
+    if file_path.parent != outputs_dir_resolved:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    return file_path
+
 
 @router.post(
     path="/save-json",
@@ -26,10 +57,10 @@ async def save_json_file(request: SaveJsonRequest):
         project_root = Path(__file__).parent.parent.parent.parent  # Navigate to project root
         outputs_dir = project_root / "outputs"
         outputs_dir.mkdir(exist_ok=True)
-        
-        # Construct file path
-        file_path = outputs_dir / request.filename
-        
+
+        # Construct and validate file path (prevents path traversal - CWE-22)
+        file_path = _safe_output_path(outputs_dir, request.filename)
+
         # Save JSON data to file
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(request.data, f, indent=2, ensure_ascii=False)
@@ -40,5 +71,7 @@ async def save_json_file(request: SaveJsonRequest):
             "filename": request.filename
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save file: {str(e)}") 


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability (CWE-22) in the `POST /storage/save-json` backend endpoint. The `filename` field from the JSON body was concatenated directly to the `outputs/` directory with no validation, allowing a caller to write JSON files to arbitrary locations reachable by the backend process.

## Affected code

`app/backend/routes/storage.py`, `save_json_file` (route `POST /storage/save-json`, mounted via `app/backend/routes/__init__.py`).

Before the fix:

```python
file_path = outputs_dir / request.filename
with open(file_path, 'w', encoding='utf-8') as f:
    json.dump(request.data, f, indent=2, ensure_ascii=False)
```

`request.filename` is user-controlled and unvalidated. `Path("outputs") / "../../foo.json"` resolves outside `outputs/`, and absolute paths (`/tmp/x.json`, `C:\Windows\...`) replace the base entirely per `pathlib` semantics.

## Data flow

1. Client sends `POST /storage/save-json` with JSON body `{"filename": "...", "data": {...}}`.
2. FastAPI binds it to `SaveJsonRequest` (no filename validation on the model).
3. `filename` is joined to `outputs_dir` and passed to `open(..., 'w')`.

No auth or CSRF protection sits in front of the route (the app is a local dev tool). CORS is limited to `localhost:5173`, but that does not block:
- CSRF-shaped requests from a malicious page to `127.0.0.1` using `Content-Type: text/plain` (no preflight; FastAPI still parses the JSON body).
- Same-LAN attackers when the backend is bound to `0.0.0.0` (e.g. Docker deployments).
- Any local process on the machine.

## Fix

Introduces `_safe_output_path()` that:

1. Rejects empty/whitespace filenames.
2. Rejects any filename containing `/` or `\`, equal to `.`/`..`, or that parses as absolute under POSIX or Windows semantics (`PurePosixPath.is_absolute()` / `PureWindowsPath.is_absolute()`).
3. Resolves both `outputs_dir` and the candidate path with `Path.resolve()`.
4. Verifies the resolved parent is exactly the resolved `outputs_dir` (belt-and-suspenders against symlinks or edge cases).

Invalid input returns `HTTP 400 Invalid filename` instead of writing the file. `HTTPException` is re-raised so the generic `except Exception` handler doesn't downgrade a 400 into a 500.

Diff is 39 additions / 6 deletions, scoped to `app/backend/routes/storage.py`.

## Proof of concept

With the backend running (default `uvicorn app.backend.main:app`):

```bash
# Pre-fix: writes /tmp/pwned.json outside the outputs/ directory
curl -s -X POST http://127.0.0.1:8000/storage/save-json \
  -H 'Content-Type: application/json' \
  -d '{"filename": "../../../../../../tmp/pwned.json", "data": {"x": 1}}'
# => {"success": true, ...} and /tmp/pwned.json exists

# Post-fix: rejected
# => {"detail": "Invalid filename"} with HTTP 400, no file written

# Absolute-path variant, also blocked post-fix:
curl -s -X POST http://127.0.0.1:8000/storage/save-json \
  -H 'Content-Type: application/json' \
  -d '{"filename": "/tmp/pwned.json", "data": {"x": 1}}'
```

## Testing

- Manually exercised the endpoint with: a normal filename (`result.json` — succeeds, file lands under `outputs/`), traversal (`../evil.json` — 400), absolute POSIX (`/tmp/x.json` — 400), Windows absolute (`C:\\x.json` — 400), `..` and `.` (400), empty string (400), nested (`sub/x.json` — 400).
- No other call sites use `SaveJsonRequest.filename`, so the stricter validation does not break internal callers. Frontend usage in `app/frontend` passes plain filenames like `flow-export.json`, which continue to work.

## Adversarial review

Before submitting we tried to argue this away. The project README describes the app as an educational/local tool, and CORS is pinned to `localhost:5173`, which blocks browser-origin cross-site fetches from arbitrary websites. However: (a) CORS does not block simple CSRF-shaped POSTs where the attacker doesn't need to read the response — the write still happens; (b) `Content-Type: text/plain` requests avoid preflight and FastAPI still parses them if a JSON body is provided; (c) users running the backend on `0.0.0.0` (documented in the Docker setup) expose it to the LAN with no auth. The write primitive is constrained to JSON-serialisable content, but that is more than enough to clobber config or state files the process can reach. The fix is small, defensive, and behaviour-preserving for legitimate callers, so we think it's worth landing regardless of threat-model debate.