### PR TITLE
Add DPXMacroStabilityModel — macro regime overlay alpha model

### DIFF
--- a/hedge_fund/signals/__init__.py
+++ b/hedge_fund/signals/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from hedge_fund.signals.base import AlphaModel, QuantModel
 from hedge_fund.signals.buffett import BuffettAgent
+from hedge_fund.signals.dpx_macro import DPXMacroStabilityModel
 from hedge_fund.signals.druckenmiller import DruckenmillerAgent
 from hedge_fund.signals.graham import GrahamAgent
 from hedge_fund.signals.llm_agent import LLMAgent
@@ -20,6 +21,7 @@ from hedge_fund.signals.pead import PEADModel
 ALPHA_MODEL_REGISTRY: dict[str, type[AlphaModel]] = {
     # Quant models
     "pead": PEADModel,
+    "dpx_macro": DPXMacroStabilityModel,
     # LLM investor agents
     "buffett": BuffettAgent,
     "munger": MungerAgent,
@@ -38,5 +40,6 @@ __all__ = [
     "LynchAgent",
     "DruckenmillerAgent",
     "PEADModel",
+    "DPXMacroStabilityModel",
     "ALPHA_MODEL_REGISTRY",
 ]

--- a/hedge_fund/signals/dpx_macro.py
+++ b/hedge_fund/signals/dpx_macro.py
@@ -1,0 +1,117 @@
+"""DPX macro stability alpha model — a market-wide regime overlay.
+
+Forms a view from DPX's Stability Oracle (https://untitledfinancial.com), a
+live macro/climate/FX/geopolitical signal pipeline that gates institutional
+stablecoin settlement. The oracle produces one global stability score, not a
+per-ticker one — so this is a *regime overlay*: the same conviction is
+returned for every ticker on a given day, meant to be combined with
+ticker-specific alpha models (PEAD, Buffett, etc.) rather than used alone.
+
+No API key required — the endpoint used here is free and unauthenticated.
+
+Live-only caveat: the Stability Oracle exposes current conditions, not a
+queryable history. `predict()` can only form a real view for the current
+day; for any other `date` it abstains (conviction 0.0) rather than silently
+reusing today's score as a stand-in for a past date, which would violate
+the point-in-time contract this interface requires.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_cls, datetime
+
+import requests
+
+from hedge_fund.data.protocol import DataClient
+from hedge_fund.models import Signal
+from hedge_fund.signals.base import QuantModel
+
+_RELIABILITY_URL = "https://stability.untitledfinancial.com/reliability"
+_TIMEOUT_SECONDS = 10.0
+
+
+class DPXMacroStabilityModel(QuantModel):
+    """Market-wide macro regime overlay from DPX's live Stability Oracle.
+
+    `predict(ticker, date)` ignores `ticker` (the signal is market-wide) and
+    returns the same conviction for every symbol on a given call. Conviction
+    is derived from the oracle's 0-100 stability score: STABLE conditions
+    (score >= 90) map toward a mildly bullish risk-on overlay, UNSTABLE
+    conditions (score < 75) map toward bearish, CAUTION sits in between.
+    """
+
+    def __init__(self, *, timeout_seconds: float = _TIMEOUT_SECONDS) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._cache: dict[str, dict] = {}  # keyed by date string, one lookup per day
+
+    @property
+    def name(self) -> str:
+        return "dpx_macro"
+
+    def predict(self, ticker: str, date: str, data_client: DataClient) -> Signal:
+        if not _is_today(date):
+            return Signal(
+                model_name=self.name,
+                ticker=ticker,
+                date=date,
+                value=0.0,
+                reasoning=(
+                    "DPX Stability Oracle is live-only (no historical query) — "
+                    "abstaining rather than reusing today's score for a past date."
+                ),
+            )
+
+        try:
+            reliability = self._fetch_reliability(date)
+        except (requests.RequestException, KeyError, ValueError) as exc:
+            # Infrastructure failure — abstain with the error visible in
+            # reasoning rather than silently returning a false neutral.
+            return Signal(
+                model_name=self.name,
+                ticker=ticker,
+                date=date,
+                value=0.0,
+                reasoning=f"DPX Stability Oracle unavailable: {exc}",
+            )
+
+        score = self._safe_float(reliability["stability"]["currentScore"])
+        status = reliability["stability"]["latestStatus"]
+        caution_threshold = self._safe_float(reliability["stability"]["threshold"]["caution"])
+        stable_threshold = self._safe_float(reliability["stability"]["threshold"]["stable"])
+
+        # Center the sigmoid on the caution/stable midpoint so STABLE trends
+        # toward +1, UNSTABLE toward -1, with CAUTION near zero.
+        midpoint = (caution_threshold + stable_threshold) / 2
+        conviction = self._sigmoid((score - midpoint) / 10, scale=1.0)
+
+        peg_bps = self._safe_float(reliability.get("peg", {}).get("deviationBps"))
+
+        return Signal(
+            model_name=self.name,
+            ticker=ticker,
+            date=date,
+            value=self._normalize_to_signal(conviction),
+            reasoning=(
+                f"DPX Stability Oracle: {status} (score {score:.0f}/100), "
+                f"peg deviation {peg_bps:.0f}bps"
+            ),
+            components={"stability_score": score, "peg_deviation_bps": peg_bps},
+            metadata={"source": _RELIABILITY_URL, "status": status},
+        )
+
+    def _fetch_reliability(self, date: str) -> dict:
+        if date in self._cache:
+            return self._cache[date]
+        resp = requests.get(_RELIABILITY_URL, timeout=self._timeout_seconds)
+        resp.raise_for_status()
+        data = resp.json()
+        self._cache[date] = data
+        return data
+
+
+def _is_today(date_str: str) -> bool:
+    try:
+        requested = datetime.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError:
+        return False
+    return requested == date_cls.today()

--- a/hedge_fund/signals/test_dpx_macro.py
+++ b/hedge_fund/signals/test_dpx_macro.py
@@ -1,0 +1,103 @@
+"""Tests for DPXMacroStabilityModel."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import Mock, patch
+
+import requests
+
+from hedge_fund.models import Signal
+from hedge_fund.signals import QuantModel
+from hedge_fund.signals.base import AlphaModel
+from hedge_fund.signals.dpx_macro import DPXMacroStabilityModel
+
+_TODAY = date.today().strftime("%Y-%m-%d")
+_YESTERDAY = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def _reliability(score: float, status: str, peg_bps: float = 0.0) -> dict:
+    return {
+        "stability": {
+            "currentScore": score,
+            "latestStatus": status,
+            "threshold": {"stable": 90, "caution": 75, "unstable": 0},
+        },
+        "peg": {"deviationBps": peg_bps},
+    }
+
+
+class TestInterface:
+    def test_is_quant_model_is_alpha_model(self):
+        assert issubclass(QuantModel, AlphaModel)
+        assert issubclass(DPXMacroStabilityModel, QuantModel)
+
+    def test_name(self):
+        assert DPXMacroStabilityModel().name == "dpx_macro"
+
+    def test_returns_signal_type(self):
+        with patch("hedge_fund.signals.dpx_macro.requests.get") as mock_get:
+            mock_get.return_value = Mock(
+                json=lambda: _reliability(95, "STABLE"),
+                raise_for_status=lambda: None,
+            )
+            sig = DPXMacroStabilityModel().predict("AAPL", _TODAY, None)
+        assert isinstance(sig, Signal)
+
+
+class TestConviction:
+    def test_stable_conditions_are_bullish(self):
+        with patch("hedge_fund.signals.dpx_macro.requests.get") as mock_get:
+            mock_get.return_value = Mock(
+                json=lambda: _reliability(100, "STABLE"),
+                raise_for_status=lambda: None,
+            )
+            sig = DPXMacroStabilityModel().predict("AAPL", _TODAY, None)
+        assert sig.value > 0
+
+    def test_unstable_conditions_are_bearish(self):
+        with patch("hedge_fund.signals.dpx_macro.requests.get") as mock_get:
+            mock_get.return_value = Mock(
+                json=lambda: _reliability(20, "UNSTABLE"),
+                raise_for_status=lambda: None,
+            )
+            sig = DPXMacroStabilityModel().predict("AAPL", _TODAY, None)
+        assert sig.value < 0
+
+    def test_signal_is_ticker_agnostic(self):
+        # Same macro conditions -> same conviction regardless of ticker
+        with patch("hedge_fund.signals.dpx_macro.requests.get") as mock_get:
+            mock_get.return_value = Mock(
+                json=lambda: _reliability(80, "CAUTION"),
+                raise_for_status=lambda: None,
+            )
+            model = DPXMacroStabilityModel()
+            sig_a = model.predict("AAPL", _TODAY, None)
+            sig_b = model.predict("MSFT", _TODAY, None)
+        assert sig_a.value == sig_b.value
+
+
+class TestPointInTime:
+    def test_abstains_for_non_today_date(self):
+        # No historical query available -- must not fabricate a past view
+        sig = DPXMacroStabilityModel().predict("AAPL", _YESTERDAY, None)
+        assert sig.value == 0.0
+        assert "live-only" in sig.reasoning.lower()
+
+    def test_abstains_on_infrastructure_failure(self):
+        with patch("hedge_fund.signals.dpx_macro.requests.get") as mock_get:
+            mock_get.side_effect = requests.ConnectionError("boom")
+            sig = DPXMacroStabilityModel().predict("AAPL", _TODAY, None)
+        assert sig.value == 0.0
+        assert "unavailable" in sig.reasoning.lower()
+
+    def test_caches_within_same_predict_call_date(self):
+        with patch("hedge_fund.signals.dpx_macro.requests.get") as mock_get:
+            mock_get.return_value = Mock(
+                json=lambda: _reliability(80, "CAUTION"),
+                raise_for_status=lambda: None,
+            )
+            model = DPXMacroStabilityModel()
+            model.predict("AAPL", _TODAY, None)
+            model.predict("MSFT", _TODAY, None)
+        assert mock_get.call_count == 1


### PR DESCRIPTION
Adds a new `QuantModel` alpha model that forms a market-wide macro regime view from [DPX](https://untitledfinancial.com)'s live Stability Oracle — a real-time macro/climate/FX/geopolitical signal pipeline that gates institutional stablecoin settlement.

**What it does:** unlike PEAD/Buffett/etc which form ticker-specific views, this is a regime overlay — same conviction for every ticker on a given day, meant to be combined with ticker-specific models rather than used alone. Score-to-conviction mapping is centered on the oracle's own STABLE/CAUTION/UNSTABLE thresholds.

**No setup required:** the endpoint used (`stability.untitledfinancial.com/reliability`) is free and unauthenticated — no API key, no account, nothing to configure.

**Live-only caveat, handled explicitly:** the oracle exposes current conditions only, not a queryable history. Per the point-in-time contract in `base.py`, `predict()` abstains (conviction 0.0, with reasoning explaining why) for any date other than today, rather than silently reusing today's score as a stand-in for a historical date.

**Testing:** 9 new tests (interface, conviction direction, point-in-time abstention, caching, infrastructure-failure handling) — all passing, plus the full existing `hedge_fund/signals/` suite (40 tests) still passes. Also verified with a real, non-mocked call against the live endpoint before opening this.

Registered in `ALPHA_MODEL_REGISTRY` as `dpx_macro`, following the existing pattern.