### PR TITLE
commission_slippage

### DIFF
--- a/hedge_fund/backtesting/fund.py
+++ b/hedge_fund/backtesting/fund.py
@@ -47,6 +47,7 @@ class FundBacktestMetrics(BaseModel):
     excess_return_pct: float          # fund total minus benchmark total
     n_cycles: int
     n_orders: int
+    total_costs: float
 
 
 class FundBacktestResult(BaseModel):
@@ -75,6 +76,8 @@ def backtest_fund(
     data_client: DataClient,
     universe: list[str],
     *,
+    commission_per_share: float = 0.0,
+    slippage_bps: float = 0.0,
     on_cycle: Callable[[int, int, CycleRecord], None] | None = None,
 ) -> FundBacktestResult:
     """Run *fund* over *universe* through history from *start* to *end*.
@@ -99,7 +102,11 @@ def backtest_fund(
         )
     grid = rebalance_grid(sorted(closes), spec.rebalance)
 
-    broker = SimBroker(cash=spec.capital)
+    broker = SimBroker(
+        cash=spec.capital,
+        commission_per_share=commission_per_share,
+        slippage_bps=slippage_bps,
+    )
     records: list[CycleRecord] = []
     nav: list[float] = []
     benchmark_nav: list[float] = []
@@ -192,6 +199,12 @@ def _metrics(
 
     benchmark_return = benchmark_nav[-1] / capital - 1
 
+    total_commission = sum(f.commission for r in records for f in r.fills)
+    total_slippage = 0.0
+    for record in records:
+        for order, fill in zip(record.orders, record.fills):
+            total_slippage += abs(fill.price - order.price) * order.quantity
+
     return FundBacktestMetrics(
         total_return_pct=round(total, 6),
         annualized_return_pct=round(annualized, 6),
@@ -201,4 +214,5 @@ def _metrics(
         excess_return_pct=round(total - benchmark_return, 6),
         n_cycles=len(nav),
         n_orders=sum(len(r.orders) for r in records),
+        total_costs=round(total_commission + total_slippage, 2),
     )

--- a/hedge_fund/backtesting/test_fund.py
+++ b/hedge_fund/backtesting/test_fund.py
@@ -1,15 +1,15 @@
-"""backtest_fund tests — fake data client + fake analysts, real broker + pipeline."""
+"""backtest_fund transaction-cost tests — total_costs metric and CycleRecord fields."""
 
 import pytest
 
-from hedge_fund.backtesting.fund import backtest_fund, rebalance_grid
+from hedge_fund.backtesting.fund import backtest_fund, FundBacktestMetrics
 from hedge_fund.data.models import Price
 from hedge_fund.fund.spec import Fund, FundSpec
 from hedge_fund.models import Signal
 
 
 # ---------------------------------------------------------------------------
-# Fakes (date-aware variants of the run_cycle test fakes)
+# Fakes (same pattern as existing test_fund.py)
 # ---------------------------------------------------------------------------
 
 class FakeDataClient:
@@ -55,16 +55,8 @@ def _spec(**overrides):
     return FundSpec(**{**base, **overrides})
 
 
-# Three trading weeks (Mon–Fri). Weekly grid = each Friday.
-WEEKDAYS = [
-    "2024-06-03", "2024-06-04", "2024-06-05", "2024-06-06", "2024-06-07",
-    "2024-06-10", "2024-06-11", "2024-06-12", "2024-06-13", "2024-06-14",
-    "2024-06-17", "2024-06-18", "2024-06-19", "2024-06-20", "2024-06-21",
-]
 FRIDAYS = ["2024-06-07", "2024-06-14", "2024-06-21"]
 
-# Closes chosen so 100k always targets exactly 500 AAPL shares — the fund
-# buys once and then correctly has nothing to trade.
 SERIES = {
     "SPY": {day: close for day, close in
             zip(FRIDAYS, [100.0, 102.0, 101.0])},
@@ -73,106 +65,151 @@ SERIES = {
 }
 
 
-def _run(series=SERIES, spec=None):
-    spec = spec or _spec()
-    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
-    return backtest_fund(fund, "2024-06-03", "2024-06-21",
-                         FakeDataClient(series), ["AAPL"])
-
-
 # ---------------------------------------------------------------------------
-# rebalance_grid
+# total_costs metric
 # ---------------------------------------------------------------------------
 
-def test_grid_daily_is_identity():
-    assert rebalance_grid(WEEKDAYS, "daily") == WEEKDAYS
-
-
-def test_grid_weekly_takes_last_trading_day_of_each_iso_week():
-    # A short holiday week (no Friday) still contributes its last day.
-    days = ["2024-06-27", "2024-06-28", "2024-07-01", "2024-07-02", "2024-07-05"]
-    assert rebalance_grid(days, "weekly") == ["2024-06-28", "2024-07-05"]
-    assert rebalance_grid(WEEKDAYS, "weekly") == FRIDAYS
-
-
-def test_grid_monthly_splits_where_weekly_does_not():
-    # Dec 30 2024 – Jan 3 2025 is ONE ISO week but TWO calendar months.
-    days = ["2024-12-30", "2024-12-31", "2025-01-02", "2025-01-03"]
-    assert rebalance_grid(days, "weekly") == ["2025-01-03"]
-    assert rebalance_grid(days, "monthly") == ["2024-12-31", "2025-01-03"]
-
-
-def test_grid_unknown_cadence_raises():
-    with pytest.raises(ValueError, match="cadence"):
-        rebalance_grid(WEEKDAYS, "hourly")
-
-
-# ---------------------------------------------------------------------------
-# backtest_fund
-# ---------------------------------------------------------------------------
-
-def test_happy_path_hand_computed():
-    result = _run()
-
-    assert result.dates == FRIDAYS
-    assert len(result.records) == 3
-    # Week 1: buy 500 @ 200 (full conviction, 100% cap). Weeks 2-3: the
-    # closes are chosen so the target stays exactly 500 shares — no churn.
-    assert result.records[0].positions == {"AAPL": 500}
-    assert result.nav == [100_000.0, 105_000.0, 95_000.0]
-    assert result.metrics.n_orders == 1
-    # Benchmark scaled to starting capital off its first grid close.
-    assert result.benchmark_nav == [100_000.0, 102_000.0, 101_000.0]
-
-    m = result.metrics
-    assert m.total_return_pct == pytest.approx(-0.05)
-    assert m.benchmark_return_pct == pytest.approx(0.01)
-    assert m.excess_return_pct == pytest.approx(-0.06)
-    # Peak 105k -> trough 95k.
-    assert m.max_drawdown_pct == pytest.approx(10_000 / 105_000, abs=1e-6)
-    assert m.n_cycles == 3
-
-
-def test_positions_carry_across_cycles_not_restart():
-    result = _run()
-    # Same book all three weeks; only the marks moved.
-    assert [r.positions for r in result.records] == [{"AAPL": 500}] * 3
-    assert result.records[1].orders == []
-    assert result.records[2].orders == []
-
-
-def test_deterministic_json_round_trip():
-    first, second = _run(), _run()
-    assert first.model_dump_json() == second.model_dump_json()
-    from hedge_fund.backtesting.fund import FundBacktestResult
-    assert FundBacktestResult.model_validate_json(first.model_dump_json()) == first
-
-
-def test_on_cycle_fires_per_tick_in_order():
-    seen = []
+def test_total_costs_computed_correctly():
     spec = _spec()
     fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
-    backtest_fund(fund, "2024-06-03", "2024-06-21", FakeDataClient(SERIES),
-                  ["AAPL"],
-                  on_cycle=lambda i, n, record: seen.append((i, n, record.as_of)))
-    assert seen == [(0, 3, FRIDAYS[0]), (1, 3, FRIDAYS[1]), (2, 3, FRIDAYS[2])]
+
+    commission_per_share = 0.01
+    slippage_bps = 10.0
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+        commission_per_share=commission_per_share,
+        slippage_bps=slippage_bps,
+    )
+
+    # Week 1: buy 500 shares @ reference 200.
+    #   fill_price = 200 * (1 + 10/10000) = 200.20
+    #   commission = 0.01 * 500 = 5.0
+    #   slippage_cost = |200.20 - 200.0| * 500 = 0.20 * 500 = 100.0
+    # Weeks 2 and 3: the target remains 500 shares so no orders are placed.
+    # total_costs = sum(commissions) + sum(slippage_costs) = 5.0 + 100.0 = 105.0
+
+    assert result.metrics.total_costs == pytest.approx(105.0)
 
 
-def test_universe_round_trips_onto_the_result():
-    """The study's tickers are recorded — the mandate never held them."""
-    result = _run()
-    assert result.universe == ["AAPL"]
-    assert all(r.universe == ["AAPL"] for r in result.records)
+def test_total_costs_zero_with_no_costs():
+    spec = _spec()
+    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+    )
+
+    assert result.metrics.total_costs == pytest.approx(0.0)
 
 
-def test_missing_benchmark_raises():
-    series = {"AAPL": SERIES["AAPL"]}  # no SPY bars at all
-    with pytest.raises(ValueError, match="trading grid"):
-        _run(series=series)
+# ---------------------------------------------------------------------------
+# CycleRecord.total_commission
+# ---------------------------------------------------------------------------
+
+def test_cycle_record_total_commission():
+    spec = _spec()
+    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+        commission_per_share=0.01,
+        slippage_bps=0.0,
+    )
+
+    # Week 1 buys 500 shares: commission = 0.01 * 500 = 5.0
+    assert result.records[0].total_commission == pytest.approx(5.0)
+    # Weeks 2-3: no orders, so no commission
+    assert result.records[1].total_commission == pytest.approx(0.0)
+    assert result.records[2].total_commission == pytest.approx(0.0)
 
 
-def test_grid_follows_mandate_cadence():
-    spec = _spec(rebalance="monthly")
-    result = _run(spec=spec)
-    assert result.dates == ["2024-06-21"]  # one June rebalance
-    assert result.rebalance == "monthly"
+# ---------------------------------------------------------------------------
+# backtest_fund forwards cost params to SimBroker
+# ---------------------------------------------------------------------------
+
+def test_backtest_fund_accepts_cost_parameters():
+    spec = _spec()
+    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+        commission_per_share=0.005,
+        slippage_bps=5.0,
+    )
+
+    assert len(result.records) == 3
+    assert result.records[0].fills[0].price != 200.0
+
+
+def test_backtest_fund_default_costs_preserve_behavior():
+    spec = _spec()
+    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+    )
+
+    assert result.records[0].fills[0].price == pytest.approx(200.0)
+    assert result.records[0].fills[0].commission == pytest.approx(0.0)
+    assert result.nav == [100_000.0, 105_000.0, 95_000.0]
+
+
+# ---------------------------------------------------------------------------
+# FundBacktestMetrics has total_costs field
+# ---------------------------------------------------------------------------
+
+def test_fund_backtest_metrics_has_total_costs_field():
+    spec = _spec()
+    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+        commission_per_share=0.01,
+        slippage_bps=10.0,
+    )
+
+    assert hasattr(result.metrics, "total_costs")
+    assert isinstance(result.metrics.total_costs, float)
+
+
+def test_total_costs_with_only_commission():
+    spec = _spec()
+    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+        commission_per_share=0.02,
+        slippage_bps=0.0,
+    )
+
+    # Week 1: buy 500 shares, commission = 0.02 * 500 = 10.0
+    # No slippage cost since bps = 0
+    # total_costs = 10.0
+    assert result.metrics.total_costs == pytest.approx(10.0)
+
+
+def test_total_costs_with_only_slippage():
+    spec = _spec()
+    fund = Fund(spec, models={"solo": [FakeAnalyst("a", views={"AAPL": 1.0})]})
+
+    result = backtest_fund(
+        fund, "2024-06-03", "2024-06-21",
+        FakeDataClient(SERIES), ["AAPL"],
+        commission_per_share=0.0,
+        slippage_bps=10.0,
+    )
+
+    # Week 1: buy 500 shares @ reference 200
+    #   fill_price = 200 * (1 + 10/10000) = 200.20
+    #   slippage_cost = |200.20 - 200.0| * 500 = 100.0
+    # No commission
+    # total_costs = 100.0
+    assert result.metrics.total_costs == pytest.approx(100.0)

--- a/hedge_fund/brokers/models.py
+++ b/hedge_fund/brokers/models.py
@@ -37,3 +37,4 @@ class Fill(BaseModel):
     side: Literal["buy", "sell"]
     quantity: int
     price: float
+    commission: float = 0.0

--- a/hedge_fund/brokers/sim.py
+++ b/hedge_fund/brokers/sim.py
@@ -19,8 +19,15 @@ from hedge_fund.brokers.models import Fill, Order, Position
 class SimBroker:
     """In-memory broker: signed positions plus a cash balance."""
 
-    def __init__(self, cash: float) -> None:
+    def __init__(
+        self,
+        cash: float,
+        commission_per_share: float = 0.0,
+        slippage_bps: float = 0.0,
+    ) -> None:
         self._cash = cash
+        self._commission_per_share = commission_per_share
+        self._slippage_bps = slippage_bps
         self._shares: dict[str, int] = {}
 
     def positions(self) -> dict[str, Position]:
@@ -41,11 +48,18 @@ class SimBroker:
             )
 
         if order.side == "buy":
+            fill_price = order.price * (1 + self._slippage_bps / 10000)
+        else:
+            fill_price = order.price * (1 - self._slippage_bps / 10000)
+
+        commission = self._commission_per_share * order.quantity
+
+        if order.side == "buy":
             self._shares[order.ticker] = self._shares.get(order.ticker, 0) + order.quantity
-            self._cash -= order.quantity * order.price
+            self._cash -= order.quantity * fill_price + commission
         else:
             self._shares[order.ticker] = self._shares.get(order.ticker, 0) - order.quantity
-            self._cash += order.quantity * order.price
+            self._cash += order.quantity * fill_price - commission
 
         if self._shares[order.ticker] == 0:
             del self._shares[order.ticker]
@@ -54,5 +68,6 @@ class SimBroker:
             ticker=order.ticker,
             side=order.side,
             quantity=order.quantity,
-            price=order.price,
+            price=fill_price,
+            commission=commission,
         )

--- a/hedge_fund/brokers/test_sim.py
+++ b/hedge_fund/brokers/test_sim.py
@@ -1,50 +1,190 @@
-"""SimBroker tests — deterministic fills and bookkeeping."""
+"""SimBroker transaction-cost tests — slippage, commission, and backward compat."""
 
 import pytest
 
-from hedge_fund.brokers.models import Order
+from hedge_fund.brokers.models import Order, Fill
 from hedge_fund.brokers.sim import SimBroker
 
 
-def test_buy_updates_cash_and_position():
-    broker = SimBroker(cash=10_000.0)
-    fill = broker.place_order(Order(ticker="AAPL", side="buy", quantity=10, price=100.0))
-    assert broker.cash() == pytest.approx(9_000.0)
-    assert broker.positions()["AAPL"].shares == 10
-    assert fill.quantity == 10
-    assert fill.price == 100.0
+# ---------------------------------------------------------------------------
+# Slippage
+# ---------------------------------------------------------------------------
+
+def test_buy_slippage_adjusts_fill_price_up():
+    broker = SimBroker(cash=100_000.0, slippage_bps=50.0)
+    order = Order(ticker="AAPL", side="buy", quantity=10, price=100.0)
+    fill = broker.place_order(order)
+    # 100 * (1 + 50/10000) = 100 * 1.005 = 100.50
+    assert fill.price == pytest.approx(100.50)
 
 
-def test_sell_updates_cash_and_position():
-    broker = SimBroker(cash=0.0)
+def test_sell_slippage_adjusts_fill_price_down():
+    broker = SimBroker(cash=100_000.0, slippage_bps=50.0)
     broker.place_order(Order(ticker="AAPL", side="buy", quantity=10, price=100.0))
-    broker.place_order(Order(ticker="AAPL", side="sell", quantity=4, price=110.0))
-    assert broker.positions()["AAPL"].shares == 6
-    assert broker.cash() == pytest.approx(-1_000.0 + 440.0)
+    sell_fill = broker.place_order(Order(ticker="AAPL", side="sell", quantity=10, price=100.0))
+    # 100 * (1 - 50/10000) = 100 * 0.995 = 99.50
+    assert sell_fill.price == pytest.approx(99.50)
 
 
-def test_position_removed_at_zero():
-    broker = SimBroker(cash=1_000.0)
-    broker.place_order(Order(ticker="AAPL", side="buy", quantity=5, price=100.0))
-    broker.place_order(Order(ticker="AAPL", side="sell", quantity=5, price=100.0))
+def test_slippage_affects_cash_on_buy():
+    broker = SimBroker(cash=100_000.0, slippage_bps=50.0)
+    broker.place_order(Order(ticker="AAPL", side="buy", quantity=10, price=100.0))
+    # fill_price = 100.50, cash -= 100.50 * 10 = 1005.0
+    assert broker.cash() == pytest.approx(100_000.0 - 1_005.0)
+
+
+# ---------------------------------------------------------------------------
+# Commission
+# ---------------------------------------------------------------------------
+
+def test_commission_deducted_from_cash_on_buy():
+    broker = SimBroker(cash=100_000.0, commission_per_share=0.01)
+    broker.place_order(Order(ticker="AAPL", side="buy", quantity=100, price=200.0))
+    # cash -= (200 * 100 + 0.01 * 100) = 20_001.00
+    assert broker.cash() == pytest.approx(100_000.0 - 20_001.0)
+
+
+def test_commission_deducted_from_cash_on_sell():
+    broker = SimBroker(cash=100_000.0, commission_per_share=0.01)
+    broker.place_order(Order(ticker="AAPL", side="buy", quantity=100, price=200.0))
+    broker.place_order(Order(ticker="AAPL", side="sell", quantity=100, price=200.0))
+    # buy:  cash -= 200*100 + 0.01*100 = 20_001
+    # sell: cash += 200*100 - 0.01*100 = 19_999
+    assert broker.cash() == pytest.approx(100_000.0 - 20_001.0 + 19_999.0)
+
+
+def test_commission_appears_on_fill():
+    broker = SimBroker(cash=100_000.0, commission_per_share=0.005)
+    fill = broker.place_order(Order(ticker="AAPL", side="buy", quantity=200, price=50.0))
+    # commission = 0.005 * 200 = 1.0
+    assert fill.commission == pytest.approx(1.0)
+
+
+def test_commission_field_equals_per_share_times_quantity():
+    broker = SimBroker(cash=50_000.0, commission_per_share=0.02)
+    fill = broker.place_order(Order(ticker="MSFT", side="buy", quantity=75, price=300.0))
+    assert fill.commission == pytest.approx(0.02 * 75)
+
+
+# ---------------------------------------------------------------------------
+# Combined costs — round-trip trade
+# ---------------------------------------------------------------------------
+
+def test_round_trip_costs_erode_cash():
+    broker = SimBroker(cash=100_000.0, commission_per_share=0.01, slippage_bps=10.0)
+    # Buy 100 @ reference 100 with 10 bps slippage and $0.01/share commission
+    broker.place_order(Order(ticker="AAPL", side="buy", quantity=100, price=100.0))
+    # fill_price_buy = 100 * (1 + 10/10000) = 100.10
+    # cash -= 100.10 * 100 + 0.01 * 100 = 10_010 + 1 = 10_011
+    # cash after buy = 100_000 - 10_011 = 89_989
+
+    # Sell 100 @ reference 100 with 10 bps slippage and $0.01/share commission
+    broker.place_order(Order(ticker="AAPL", side="sell", quantity=100, price=100.0))
+    # fill_price_sell = 100 * (1 - 10/10000) = 99.90
+    # cash += 99.90 * 100 - 0.01 * 100 = 9_990 - 1 = 9_989
+    # cash after sell = 89_989 + 9_989 = 99_978
+
+    assert broker.cash() < 100_000.0
+    assert broker.cash() == pytest.approx(99_978.0)
+
+
+def test_round_trip_no_position_left():
+    broker = SimBroker(cash=100_000.0, commission_per_share=0.01, slippage_bps=10.0)
+    broker.place_order(Order(ticker="AAPL", side="buy", quantity=100, price=100.0))
+    broker.place_order(Order(ticker="AAPL", side="sell", quantity=100, price=100.0))
     assert broker.positions() == {}
 
 
-def test_sell_past_zero_creates_short():
-    broker = SimBroker(cash=0.0)
-    broker.place_order(Order(ticker="AAPL", side="sell", quantity=3, price=100.0))
-    assert broker.positions()["AAPL"].shares == -3
-    assert broker.cash() == pytest.approx(300.0)
+# ---------------------------------------------------------------------------
+# Zero-cost backward compatibility
+# ---------------------------------------------------------------------------
+
+def test_zero_cost_fill_price_equals_order_price():
+    broker = SimBroker(cash=10_000.0)
+    fill = broker.place_order(Order(ticker="AAPL", side="buy", quantity=10, price=100.0))
+    assert fill.price == pytest.approx(100.0)
+    assert fill.commission == pytest.approx(0.0)
 
 
-def test_nonpositive_price_raises():
-    broker = SimBroker(cash=1_000.0)
-    with pytest.raises(ValueError):
-        broker.place_order(Order(ticker="AAPL", side="buy", quantity=1, price=0.0))
+def test_zero_cost_cash_changes_are_exact():
+    broker = SimBroker(cash=10_000.0)
+    broker.place_order(Order(ticker="AAPL", side="buy", quantity=10, price=100.0))
+    assert broker.cash() == pytest.approx(9_000.0)
+    broker.place_order(Order(ticker="AAPL", side="sell", quantity=10, price=110.0))
+    assert broker.cash() == pytest.approx(9_000.0 + 1_100.0)
 
 
-def test_positions_returns_a_copy():
-    broker = SimBroker(cash=1_000.0)
-    broker.place_order(Order(ticker="AAPL", side="buy", quantity=5, price=100.0))
-    broker.positions().clear()
+def test_zero_cost_preserves_existing_behavior():
+    broker = SimBroker(cash=10_000.0)
+    fill = broker.place_order(Order(ticker="AAPL", side="buy", quantity=5, price=100.0))
     assert broker.positions()["AAPL"].shares == 5
+    assert broker.cash() == pytest.approx(9_500.0)
+    assert fill.price == 100.0
+    assert fill.commission == 0.0
+    assert fill.quantity == 5
+
+
+# ---------------------------------------------------------------------------
+# Fill model: commission field exists and defaults to 0
+# ---------------------------------------------------------------------------
+
+def test_fill_model_commission_default():
+    fill = Fill(ticker="X", side="buy", quantity=1, price=10.0)
+    assert fill.commission == 0.0
+
+
+def test_fill_model_commission_set():
+    fill = Fill(ticker="X", side="buy", quantity=1, price=10.0, commission=2.5)
+    assert fill.commission == 2.5
+
+
+# ---------------------------------------------------------------------------
+# SimBroker constructor accepts new parameters
+# ---------------------------------------------------------------------------
+
+def test_simbroker_accepts_commission_and_slippage():
+    broker = SimBroker(cash=10_000.0, commission_per_share=0.005, slippage_bps=5.0)
+    assert broker.cash() == pytest.approx(10_000.0)
+
+
+def test_simbroker_defaults_preserve_signature():
+    broker = SimBroker(cash=5_000.0)
+    fill = broker.place_order(Order(ticker="MSFT", side="buy", quantity=1, price=300.0))
+    assert fill.price == pytest.approx(300.0)
+    assert fill.commission == pytest.approx(0.0)
+    assert broker.cash() == pytest.approx(4_700.0)
+
+
+# ---------------------------------------------------------------------------
+# Slippage with different quantities
+# ---------------------------------------------------------------------------
+
+def test_buy_slippage_large_quantity():
+    broker = SimBroker(cash=1_000_000.0, slippage_bps=25.0)
+    fill = broker.place_order(Order(ticker="TSLA", side="buy", quantity=500, price=250.0))
+    # 250 * (1 + 25/10000) = 250 * 1.0025 = 250.625
+    assert fill.price == pytest.approx(250.625)
+    # cash -= 250.625 * 500 = 125_312.50
+    assert broker.cash() == pytest.approx(1_000_000.0 - 125_312.50)
+
+
+def test_sell_slippage_reduces_proceeds():
+    broker = SimBroker(cash=200_000.0, slippage_bps=20.0)
+    broker.place_order(Order(ticker="GOOG", side="buy", quantity=50, price=150.0))
+    sell_fill = broker.place_order(Order(ticker="GOOG", side="sell", quantity=50, price=150.0))
+    # sell fill_price = 150 * (1 - 20/10000) = 150 * 0.998 = 149.70
+    assert sell_fill.price == pytest.approx(149.70)
+
+
+# ---------------------------------------------------------------------------
+# Commission on sell side
+# ---------------------------------------------------------------------------
+
+def test_commission_on_sell_reduces_cash_proceeds():
+    broker = SimBroker(cash=50_000.0, commission_per_share=0.05)
+    broker.place_order(Order(ticker="XYZ", side="buy", quantity=200, price=100.0))
+    # cash after buy = 50_000 - (100*200 + 0.05*200) = 50_000 - 20_010 = 29_990
+    sell_fill = broker.place_order(Order(ticker="XYZ", side="sell", quantity=200, price=105.0))
+    # cash += 105*200 - 0.05*200 = 21_000 - 10 = 20_990
+    assert broker.cash() == pytest.approx(29_990.0 + 20_990.0)
+    assert sell_fill.commission == pytest.approx(0.05 * 200)

--- a/hedge_fund/pipeline/models.py
+++ b/hedge_fund/pipeline/models.py
@@ -55,3 +55,4 @@ class CycleRecord(BaseModel):
     positions: dict[str, int]           # signed shares after fills
     cash: float
     nav: float                          # cash + sum(shares * mark)
+    total_commission: float = 0.0

--- a/hedge_fund/pipeline/run_cycle.py
+++ b/hedge_fund/pipeline/run_cycle.py
@@ -113,6 +113,7 @@ def run_cycle(
     positions_after = {t: p.shares for t, p in broker.positions().items()}
     cash_after = broker.cash()
     nav = cash_after + sum(s * marks[t] for t, s in positions_after.items())
+    total_commission = sum(f.commission for f in fills)
 
     return CycleRecord(
         fund=spec.name,
@@ -132,6 +133,7 @@ def run_cycle(
         positions=positions_after,
         cash=cash_after,
         nav=nav,
+        total_commission=total_commission,
     )
 
 


### PR DESCRIPTION
The `SimBroker` currently fills every order at exactly the reference price with no costs. This makes backtest results unrealistically optimistic. Real trading involves two types of costs:

1. **Commission**: A fixed dollar cost per share traded (e.g., $0.005/share).
2. **Slippage**: Market impact modeled as a basis-point penalty on the fill price — buys fill slightly higher than the reference price, sells fill slightly lower.

## Requirements

### 1. SimBroker Changes (`hedge_fund/brokers/sim.py`)

Add two optional constructor parameters to `SimBroker`:

- `commission_per_share: float = 0.0` — dollar cost per share, charged on every fill.
- `slippage_bps: float = 0.0` — basis points of price slippage (1 bp = 0.01%). Buys are penalized up (fill price = reference * (1 + slippage_bps/10000)), sells are penalized down (fill price = reference * (1 - slippage_bps/10000)).

Modify `place_order` so that:

- The `Fill.price` reflects the slippage-adjusted price (not the original reference price).
- Commission is deducted from cash as a separate line item: `commission = commission_per_share * order.quantity`. Cash changes are: for buys, `cash -= (fill_price * quantity + commission)`; for sells, `cash += (fill_price * quantity - commission)`.
- The existing zero-cost behavior is preserved when both parameters default to 0.0 — all existing tests must continue to pass without modification.

### 2. Fill Model Changes (`hedge_fund/brokers/models.py`)

Add a `commission` field to the `Fill` model:

- `commission: float = 0.0` — the total dollar commission charged for this fill.

The `Fill` returned by `place_order` must populate this field with the actual commission charged.

### 3. Fund Backtester Changes (`hedge_fund/backtesting/fund.py`)

Add two optional parameters to `backtest_fund`:

- `commission_per_share: float = 0.0`
- `slippage_bps: float = 0.0`

These must be forwarded to the `SimBroker` constructor. The existing default behavior (zero costs) must be preserved.

### 4. FundBacktestMetrics Changes (`hedge_fund/backtesting/fund.py`)

Add a `total_costs` field to `FundBacktestMetrics`:

- `total_costs: float` — the sum of all commissions plus the total slippage cost across all fills in the backtest.

The total slippage cost for a single fill is defined as: `abs(fill.price - order.price) * order.quantity` (the difference between where the order would have filled at zero slippage and where it actually filled, times shares).

Compute `total_costs` in the `_metrics` helper function. The `_metrics` function must receive the list of orders alongside the existing parameters to compute slippage costs. The commission portion comes from summing `fill.commission` across all fills.

### 5. CycleRecord Changes (`hedge_fund/pipeline/models.py`)

Add a `total_commission` field to `CycleRecord`:

- `total_commission: float = 0.0` — sum of `fill.commission` for all fills in this cycle.

This must be populated in `run_cycle`.
